### PR TITLE
Remove residue left over from temp folder optimization.

### DIFF
--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -4,13 +4,11 @@ namespace Kudu.Core
     public interface IEnvironment
     {
         string RepositoryPath { get; }
-        string DeploymentRepositoryTargetPath { get; }
         string DeploymentRepositoryPath { get; }
         string DeploymentTargetPath { get; }
         string DeploymentCachePath { get; }
         string ApplicationRootPath { get; }
         string TempPath { get; }
         string AppName { get; }
-        RepositoryType RepositoryType { get; }
     }
 }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -303,9 +303,6 @@ namespace Kudu.Core.Deployment
 
                            // Run post deployment steps
                            RunPostDeploymentSteps(id, profiler, deployStep);
-
-                           // Copy repository (if this is the first push)
-                           CopyRepository(id, profiler);
                        })
                        .Catch(ex =>
                        {
@@ -355,55 +352,9 @@ namespace Kudu.Core.Deployment
         }
 
         /// <summary>
-        /// Copy the repository from the temp repository path to the repository path.
-        /// Only happens on first deployment.
-        /// </summary>
-        private void CopyRepository(string id, IProfiler profiler)
-        {
-            ILogger logger = null;
-            DeploymentStatusFile trackingFile = null;
-
-            try
-            {
-                logger = GetLogger(id);
-                trackingFile = OpenTrackingFile(id);
-
-                // The repository has already been copied
-                if (_environment.RepositoryType != RepositoryType.None)
-                {
-                    return;
-                }
-
-                using (profiler.Step("Copying files to repository"))
-                {
-                    // Copy the repository from the temporary path to the repository target path
-                    FileSystemHelpers.Copy(_environment.DeploymentRepositoryPath,
-                                           _environment.DeploymentRepositoryTargetPath,
-                                           skipScmFolder: false);
-                }
-            }
-            catch (Exception ex)
-            {
-                if (logger != null)
-                {
-                    logger.Log(ex);
-                }
-            }
-            finally
-            {
-                if (trackingFile != null)
-                {
-                    trackingFile.Complete = true;
-                    trackingFile.Save(_fileSystem);
-                }
-
-                ReportStatus(id);
-            }
-        }
-
-        /// <summary>
         /// Runs post deployment steps.
         /// - Marks the active deployment
+        /// - Sets the complete flag
         /// </summary>
         private void RunPostDeploymentSteps(string id, IProfiler profiler, IDisposable deployStep)
         {
@@ -430,13 +381,17 @@ namespace Kudu.Core.Deployment
             }
             catch (Exception ex)
             {
-                if (logger != null && trackingFile != null)
+                if (logger != null)
                 {
                     NotifyError(logger, trackingFile, ex);
                 }
             }
             finally
             {
+                // Set the deployment as complete
+                trackingFile.Complete = true;
+                trackingFile.Save(_fileSystem);
+
                 ReportStatus(id);
 
                 // End the deployment step

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -8,23 +8,20 @@ namespace Kudu.Core
     {
         private readonly string _deployPath;
         private readonly string _deployCachePath;
-        private readonly string _stableDeploymentRepositoryPath;
         private readonly string _tempPath;
         private readonly Func<string> _deploymentRepositoryPathResolver;
         private readonly Func<string> _repositoryPathResolver;
 
-        public Environment(string appName,
-                           string applicationRootPath,
-                           string stableDeploymentRepositoryPath,
-                           string tempPath,
-                           Func<string> deploymentRepositoryPathResolver,
-                           Func<string> repositoryPathResolver,
-                           string deployPath,
+        public Environment(string appName, 
+                           string applicationRootPath, 
+                           string tempPath, 
+                           Func<string> deploymentRepositoryPathResolver, 
+                           Func<string> repositoryPathResolver, 
+                           string deployPath, 
                            string deployCachePath)
         {
             AppName = appName;
             ApplicationRootPath = applicationRootPath;
-            _stableDeploymentRepositoryPath = stableDeploymentRepositoryPath;
             _tempPath = tempPath;
             _deploymentRepositoryPathResolver = deploymentRepositoryPathResolver;
             _repositoryPathResolver = repositoryPathResolver;
@@ -75,15 +72,6 @@ namespace Kudu.Core
             }
         }
 
-        public string DeploymentRepositoryTargetPath
-        {
-            get
-            {
-                FileSystemHelpers.EnsureDirectory(_stableDeploymentRepositoryPath);
-                return _stableDeploymentRepositoryPath;
-            }
-        }
-
         public string ApplicationRootPath
         {
             get;
@@ -102,14 +90,6 @@ namespace Kudu.Core
         {
             get;
             private set;
-        }
-
-        public RepositoryType RepositoryType
-        {
-            get
-            {
-                return RepositoryManager.GetRepositoryType(DeploymentRepositoryTargetPath);
-            }
         }
     }
 }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -249,13 +249,12 @@ namespace Kudu.Services.Web.App_Start
             string tempPath = Path.Combine(Path.GetTempPath(), "kudu", System.Guid.NewGuid().ToString());
             string deploymentTempPath = Path.Combine(tempPath, Constants.RepositoryPath);
 
-            return new Environment(site,
-                                   root,
-                                   deploymentRepositoryPath,
-                                   tempPath,
-                                   () => deploymentRepositoryPath,
-                                   () => ResolveRepositoryPath(site),
-                                   deployPath,
+            return new Environment(site, 
+                                   root, 
+                                   tempPath, 
+                                   () => deploymentRepositoryPath, 
+                                   () => ResolveRepositoryPath(site), 
+                                   deployPath, 
                                    deployCachePath);
         }
 


### PR DESCRIPTION
We used to copy from the temp folder on first push.
This change removes that logic.
