### PR TITLE
Remove lock from clone operation

### DIFF
--- a/Kudu.Contracts/Infrastructure/IOperationLock.cs
+++ b/Kudu.Contracts/Infrastructure/IOperationLock.cs
@@ -1,8 +1,12 @@
-﻿namespace Kudu.Contracts.Infrastructure
+﻿using System;
+
+namespace Kudu.Contracts.Infrastructure
 {
     public interface IOperationLock
     {
+        bool IsHeld { get; }
         bool Lock();
         bool Release();
+        bool Wait(TimeSpan timeOut);
     }
 }

--- a/Kudu.Contracts/Infrastructure/LockExtensions.cs
+++ b/Kudu.Contracts/Infrastructure/LockExtensions.cs
@@ -4,6 +4,14 @@ namespace Kudu.Contracts.Infrastructure
 {
     public static class LockExtensions
     {
+
+        public static void LockOrWait(this IOperationLock lockObj,
+                                      Action operation,
+                                      TimeSpan timeOut)
+        {
+            LockOperation(lockObj, operation, () => lockObj.Wait(timeOut));
+        }
+
         public static void LockOperation(this IOperationLock lockObj,
                                          Action operation,
                                          Action onBusy)

--- a/Kudu.Core/Infrastructure/LockFile.cs
+++ b/Kudu.Core/Infrastructure/LockFile.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Kudu.Contracts.Infrastructure;
@@ -15,11 +16,40 @@ namespace Kudu.Core.Infrastructure
         private readonly string _path;
         private Stream _lockStream;
         private readonly ITraceFactory _traceFactory;
+        private event Action _lockReleased;
 
         public LockFile(ITraceFactory traceFactory, string path)
         {
             _traceFactory = traceFactory;
-            _path = path;
+            _path = Path.GetFullPath(path);
+        }
+
+
+        public bool IsHeld
+        {
+            get
+            {
+                try
+                {
+                    // If there's no file then there's no process holding onto it
+                    if (!File.Exists(_path))
+                    {
+                        return false;
+                    }
+
+                    // If there is a file, lets see if someone has an open handle to it, or if it's
+                    // just hanging there for no reason
+                    using (new FileStream(_path, FileMode.Open, FileAccess.Write, FileShare.None))
+                    {
+                        // Nobody is here
+                        return false;
+                    }
+                }
+                catch
+                {
+                    return true;
+                }
+            }
         }
 
         public bool Lock()
@@ -50,9 +80,13 @@ namespace Kudu.Core.Infrastructure
 
             try
             {
-
                 _lockStream.Close();
                 File.Delete(_path);
+
+                if (_lockReleased != null)
+                {
+                    _lockReleased();
+                }
 
                 TraceLock("Lock released");
                 return true;
@@ -65,6 +99,61 @@ namespace Kudu.Core.Infrastructure
             finally
             {
                 Interlocked.Exchange(ref _lockStream, null);
+            }
+        }
+
+        public bool Wait(TimeSpan timeout)
+        {
+            if (_lockStream == null)
+            {
+                TraceLock("Waiting on lock");
+
+                // Poll the file system every second
+                var interval = TimeSpan.FromSeconds(1);
+                var elapsed = TimeSpan.Zero;
+
+                bool timedout = false;
+
+                // This is less efficient than a file change nofitication but more reliable
+                // as there's a race condition when setting up the notification
+                while (IsHeld)
+                {
+                    Thread.Sleep(interval);
+                    elapsed += interval;
+
+                    if (elapsed > timeout)
+                    {
+                        timedout = true;
+                        break;
+                    }
+                }
+
+                TraceLock("Waiting complete");
+
+                return timedout;
+            }
+            else
+            {
+                // Same instance of the lock, so we can shortcut to an event handler
+                var wh = new ManualResetEventSlim();
+                Action handler = null;
+
+                handler = () =>
+                {
+                    wh.Set();
+
+                    _lockReleased -= handler;
+                };
+
+                _lockReleased += handler;
+
+                TraceLock("Waiting on lock");
+
+                bool timedout = wh.Wait(timeout);
+
+                TraceLock("Waiting complete");
+
+                return timedout;
             }
         }
 

--- a/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
+++ b/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Kudu.Core.Deployment;
 using Kudu.FunctionalTests.Infrastructure;
 using Kudu.TestHarness;
@@ -450,6 +451,28 @@ namespace Kudu.FunctionalTests
                     Assert.True(repo.FileExists("index.html"));
                 }
             });
+        }
+
+        [Fact]
+        public void ClonesInParallel()
+        {
+            string appName = KuduUtils.GetRandomWebsiteName("ClonesInParallel");
+
+            ApplicationManager.Run(appName, appManager =>
+            {
+                var t1 = Task.Factory.StartNew(() => DoClone("PClone1", appManager));
+                var t2 = Task.Factory.StartNew(() => DoClone("PClone2", appManager));
+                var t3 = Task.Factory.StartNew(() => DoClone("PClone3", appManager));
+                Task.WaitAll(t1, t2, t3);
+            });
+        }
+
+        private static void DoClone(string repositoryName, ApplicationManager appManager)
+        {
+            using (var repo = Git.Clone(repositoryName, appManager.GitUrl, createDirectory: true))
+            {
+                Assert.True(repo.FileExists("index.html"));
+            }
         }
 
         [Fact]

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -137,7 +137,7 @@ namespace Kudu.Services.Web.App_Start
             kernel.Bind<ISiteBuilderFactory>().To<SiteBuilderFactory>()
                                              .InRequestScope();
 
-            kernel.Bind<IServerRepository>().ToMethod(context => new GitExeServer(environment.DeploymentRepositoryPath, context.Kernel.Get<ITraceFactory>()))
+            kernel.Bind<IServerRepository>().ToMethod(context => new GitExeServer(environment.DeploymentRepositoryPath, environment.ApplicationRootPath, context.Kernel.Get<ITraceFactory>()))
                                             .InRequestScope();
 
             kernel.Bind<IDeploymentManager>().To<DeploymentManager>()
@@ -147,7 +147,7 @@ namespace Kudu.Services.Web.App_Start
             // Git server
             kernel.Bind<IDeploymentManagerFactory>().ToMethod(context => GetDeploymentManagerFactory(environment, propertyProvider, context.Kernel.Get<ITraceFactory>()));
 
-            kernel.Bind<IGitServer>().ToMethod(context => new GitExeServer(environment.DeploymentRepositoryPath, context.Kernel.Get<ITraceFactory>()))
+            kernel.Bind<IGitServer>().ToMethod(context => new GitExeServer(environment.DeploymentRepositoryPath, environment.ApplicationRootPath, context.Kernel.Get<ITraceFactory>()))
                                      .InRequestScope();
 
             // Hg Server
@@ -173,7 +173,7 @@ namespace Kudu.Services.Web.App_Start
         {
             return new DeploymentManagerFactory(() =>
             {
-                var serverRepository = new GitExeServer(environment.DeploymentRepositoryPath, traceFactory);
+                var serverRepository = new GitExeServer(environment.DeploymentRepositoryPath, environment.ApplicationRootPath, traceFactory);
                 var fileSystem = new FileSystem();
                 var siteBuilderFactory = new SiteBuilderFactory(propertyProvider, environment);
 

--- a/Kudu.Services/GitServer/RpcService.cs
+++ b/Kudu.Services/GitServer/RpcService.cs
@@ -64,13 +64,9 @@ namespace Kudu.Services.GitServer
             {
                 var memoryStream = new MemoryStream();
 
-                _deploymentLock.LockHttpOperation(() =>
-                {
-                    _gitServer.Upload(GetInputStream(request), memoryStream);
-                });
+                _gitServer.Upload(GetInputStream(request), memoryStream);
 
                 return CreateResponse(memoryStream, "application/x-git-{0}-result".With("upload-pack"));
-
             }
         }
 


### PR DESCRIPTION
- Only lock repository init operation.
- If repository is being initialized then wait on that operation to complete.
- Added Wait and IsHeld to IOperationLock.
- Added functional test to test clones in parallel.
