### PR TITLE
[node.js] package install improvements

### DIFF
--- a/Kudu.Core/Deployment/BasicBuilder.cs
+++ b/Kudu.Core/Deployment/BasicBuilder.cs
@@ -148,6 +148,8 @@ namespace Kudu.Core.Deployment
                         writer.Start();
                         // Run install on the output directory
                         log = npm.Install(context.Tracer, writer);
+                        // Run rebuild in case any binary packages are included in the git repository
+                        log = npm.Rebuild(context.Tracer, writer);
                     }
 
                     if (String.IsNullOrWhiteSpace(log))

--- a/Kudu.Core/Deployment/NpmExecutable.cs
+++ b/Kudu.Core/Deployment/NpmExecutable.cs
@@ -14,6 +14,16 @@ namespace Kudu.Core.Deployment
 
         public string Install(ITracer tracer, ProgressWriter writer)
         {
+            return RunCommandWithProgress(tracer, writer, "install --production");
+        }
+
+        internal string Rebuild(ITracer tracer, ProgressWriter writer)
+        {
+            return RunCommandWithProgress(tracer, writer, "rebuild");
+        }
+
+        private string RunCommandWithProgress(ITracer tracer, ProgressWriter writer, string command)
+        {
             return Execute(tracer,
                            output =>
                            {
@@ -26,7 +36,7 @@ namespace Kudu.Core.Deployment
                                return true;
                            },
                            Console.OutputEncoding,
-                           "install").Item1;
+                           command).Item1;
         }
     }
 }


### PR DESCRIPTION
- Add `--production` flag to `npm install`. This will make npm disregard packages that are listed under devDependencies.
- Add `npm rebuild` after install. This will rebuild all native modules that
  might have been committed into the repository.
