### PR TITLE
Fix for IIS not accepting http verb PUT for Kudu Service

### DIFF
--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -17,7 +17,9 @@
     <httpRuntime maxRequestLength="104857600" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" />
   </system.web>
   <system.webServer>
-    <modules runAllManagedModulesForAllRequests="true"></modules>
+    <modules runAllManagedModulesForAllRequests="true">
+      <remove name="WebDAVModule" />
+    </modules>
     <security>
       <requestFiltering>
         <requestLimits maxAllowedContentLength="104857600" />


### PR DESCRIPTION
When trying to deploy a previous commit from the Kudu Web UI, Kudu Service returns "405 Method Not Allowed". By removing the WebDAVModule in the web.config of Kudu service this issue was resolved and "Deploy" now works as expected.

This issue was discussed with @davidfowl and @davidebbo on twitter.
