### PR TITLE
Improved error handling in Kudu management site

### DIFF
--- a/Kudu.Core/Infrastructure/PathUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtility.cs
@@ -10,7 +10,6 @@ namespace Kudu.Core.Infrastructure
         {
             string programFiles = SystemEnvironment.GetFolderPath(SystemEnvironment.SpecialFolder.ProgramFilesX86);
             string path = Path.Combine(programFiles, "Git", "bin", "git.exe");
-            // throw new InvalidOperationException(Resources.Error_FailedToLocateGit);
 
             if (!File.Exists(path))
             {


### PR DESCRIPTION
Fix for issue #180, when getting an error, outputting the failure instead of simply failing with 500.
