### PR TITLE
Final fixes to get functional tests running

### DIFF
--- a/Kudu.Client/Editor/RemoteProjectSystem.cs
+++ b/Kudu.Client/Editor/RemoteProjectSystem.cs
@@ -18,7 +18,7 @@ namespace Kudu.Client.Editor
             // REVIEW: this goes through the same client that set the Accept header to application/json, but we receive text/plain
             return _client.GetAsync(path)
                           .Result
-                          .EnsureSuccessStatusCode()
+                          .EnsureSuccessful()
                           .Content
                           .ReadAsStringAsync()
                           .Result;
@@ -33,14 +33,14 @@ namespace Kudu.Client.Editor
         {
             _client.PutAsync(path, HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("content", content)))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
 
         public void Delete(string path)
         {
             _client.DeleteAsync(path)
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
     }
 }

--- a/Kudu.Client/Infrastructure/HttpClientExtensions.cs
+++ b/Kudu.Client/Infrastructure/HttpClientExtensions.cs
@@ -15,7 +15,7 @@ namespace Kudu.Client.Infrastructure
         public static T GetJson<T>(this HttpClient client, string url)
         {
             var response = client.GetAsync(url);
-            var content = response.Result.EnsureSuccessStatusCode().Content.ReadAsStringAsync().Result;
+            var content = response.Result.EnsureSuccessful().Content.ReadAsStringAsync().Result;
 
             return JsonConvert.DeserializeObject<T>(content);
         }
@@ -47,7 +47,7 @@ namespace Kudu.Client.Infrastructure
         {
             return client.PostAsync(String.Empty, new StringContent(String.Empty)).Then(result =>
             {
-                return result.EnsureSuccessStatusCode();
+                return result.EnsureSuccessful();
             });
         }
 
@@ -55,7 +55,7 @@ namespace Kudu.Client.Infrastructure
         {
             return client.PostAsync(requestUri, new StringContent(String.Empty)).Then(result =>
             {
-                return result.EnsureSuccessStatusCode();
+                return result.EnsureSuccessful();
             });
         }
 
@@ -63,7 +63,7 @@ namespace Kudu.Client.Infrastructure
         {
             return client.PutAsync(requestUri, new StringContent(String.Empty)).Then(result =>
             {
-                return result.EnsureSuccessStatusCode();
+                return result.EnsureSuccessful();
             });
         }
 
@@ -71,7 +71,7 @@ namespace Kudu.Client.Infrastructure
         {
             return client.PutAsync(requestUri, HttpClientHelper.CreateJsonContent(items)).Then(result =>
             {
-                return result.EnsureSuccessStatusCode();
+                return result.EnsureSuccessful();
             });
         }
 
@@ -79,7 +79,7 @@ namespace Kudu.Client.Infrastructure
         {
             return client.DeleteAsync(requestUri).Then(result =>
             {
-                return result.EnsureSuccessStatusCode();
+                return result.EnsureSuccessful();
             });
         }
 
@@ -87,7 +87,7 @@ namespace Kudu.Client.Infrastructure
         {
             return client.PostAsync(url, HttpClientHelper.CreateJsonContent(param)).Then(result =>
             {
-                return result.EnsureSuccessStatusCode();
+                return result.EnsureSuccessful();
             });
         }
     }

--- a/Kudu.Client/Infrastructure/HttpResponseMessageExtensions.cs
+++ b/Kudu.Client/Infrastructure/HttpResponseMessageExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace Kudu.Client
+{
+    public static class HttpResponseMessageExtensions
+    {
+        /// <summary>
+        /// Determines if the HttpResponse is successful, throws otherwise.
+        /// </summary>
+        public static HttpResponseMessage EnsureSuccessful(this HttpResponseMessage httpResponseMessage)
+        {
+            if (httpResponseMessage.StatusCode == HttpStatusCode.InternalServerError)
+            {
+                // For 500, we serialize the exception message on the server. 
+                var exceptionMessage = httpResponseMessage.Content.ReadAsAsync<HttpExceptionMessage>().Result;
+                exceptionMessage.StatusCode = httpResponseMessage.StatusCode;
+                exceptionMessage.ReasonPhrase = httpResponseMessage.ReasonPhrase;
+
+                throw new HttpUnsuccessfulRequestException { ResponseMessage = exceptionMessage };
+            }
+            return httpResponseMessage.EnsureSuccessStatusCode();
+        }
+    }
+
+    public class HttpExceptionMessage
+    {
+        public HttpStatusCode StatusCode { get; set; }
+
+        public string ReasonPhrase { get; set; }
+
+        public string ExceptionMessage { get; set; }
+
+        public string ExceptionType { get; set; }
+    }
+
+    public class HttpUnsuccessfulRequestException : HttpRequestException
+    {
+        public HttpExceptionMessage ResponseMessage { get; set; }
+    }
+}

--- a/Kudu.Client/Kudu.Client.csproj
+++ b/Kudu.Client/Kudu.Client.csproj
@@ -68,6 +68,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Infrastructure\BasicAuthCredentialProvider.cs" />
+    <Compile Include="Infrastructure\HttpResponseMessageExtensions.cs" />
     <Compile Include="Infrastructure\HttpClientExtensions.cs" />
     <Compile Include="Infrastructure\HttpClientHelper.cs" />
     <Compile Include="Infrastructure\ICredentialProvider.cs" />

--- a/Kudu.Client/SSHKey/RemoteSSHKeyManager.cs
+++ b/Kudu.Client/SSHKey/RemoteSSHKeyManager.cs
@@ -29,7 +29,7 @@ namespace Kudu.Client.SSHKey
 
             return _client.PutAsync(String.Empty, param).Then(response =>
             {
-                response.EnsureSuccessStatusCode();
+                response.EnsureSuccessful();
                 return;
             });
         }

--- a/Kudu.Client/Settings/RemoteDeploymentSettingsManager.cs
+++ b/Kudu.Client/Settings/RemoteDeploymentSettingsManager.cs
@@ -24,7 +24,7 @@ namespace Kudu.Client.Deployment
         public Task SetValue(string key, string value)
         {
             var values = HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("key", key), new KeyValuePair<string, string>("value", value));
-            return _client.PostAsync(String.Empty, values).Then(response => response.EnsureSuccessStatusCode());
+            return _client.PostAsync(String.Empty, values).Then(response => response.EnsureSuccessful());
         }
 
         public Task<NameValueCollection> GetValues()

--- a/Kudu.Client/SourceControl/RemoteRepository.cs
+++ b/Kudu.Client/SourceControl/RemoteRepository.cs
@@ -20,7 +20,7 @@ namespace Kudu.Client.SourceControl
             {
                 return _client.GetAsync("id")
                               .Result
-                              .EnsureSuccessStatusCode()
+                              .EnsureSuccessful()
                               .Content
                               .ReadAsStringAsync()
                               .Result;
@@ -31,7 +31,7 @@ namespace Kudu.Client.SourceControl
         {
             _client.PostAsync("init", new StringContent(String.Empty))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
 
         public IEnumerable<Branch> GetBranches()
@@ -74,21 +74,21 @@ namespace Kudu.Client.SourceControl
         {
             _client.PostAsync("add", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("path", path)))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
 
         public void RevertFile(string path)
         {
             _client.PostAsync("remove", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("path", path)))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
 
         public ChangeSet Commit(string message, string authorName)
         {
             string json = _client.PostAsync("commit", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("name", authorName), new KeyValuePair<string, string>("message", message)))
                                  .Result
-                                 .EnsureSuccessStatusCode()
+                                 .EnsureSuccessful()
                                  .Content.ReadAsStringAsync()
                                  .Result;
 
@@ -99,21 +99,21 @@ namespace Kudu.Client.SourceControl
         {
             _client.PostAsync("push", new StringContent(String.Empty))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
 
         public void Update(string id)
         {
             _client.PostAsync("update", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("id", id)))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
 
         public void Update()
         {
             _client.PostAsync("update", new StringContent(String.Empty))
                    .Result
-                   .EnsureSuccessStatusCode();
+                   .EnsureSuccessful();
         }
     }
 }

--- a/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
+++ b/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
@@ -371,19 +371,20 @@ command = deploy.cmd");
             {
                 ApplicationManager.Run(appName, appManager =>
                 {
-                    string url = appManager.SiteUrl + @"/Content/Site.css";
+                    string path = @"Content/Site.css";
+                    string url = appManager.SiteUrl + path;
 
                     // Act
                     appManager.GitDeploy(repo.PhysicalPath);
 
                     KuduAssert.VerifyUrl(url, verificationText);
 
-                    appManager.ProjectSystem.WriteAllText(url, "Hello world!");
+                    appManager.ProjectSystem.WriteAllText(path, "Hello world!");
 
                     // Sleep a little since it's a remote call
                     Thread.Sleep(500);
 
-                    KuduAssert.VerifyUrl(appManager.SiteUrl, "Hello world!");
+                    KuduAssert.VerifyUrl(url, "Hello world!");
 
                     // Make an unrelated change (newline to the end of web.config)
                     repo.AppendFile(@"Mvc3Application\Web.config", "\n");

--- a/Kudu.FunctionalTests/Infrastructure/KuduAssert.cs
+++ b/Kudu.FunctionalTests/Infrastructure/KuduAssert.cs
@@ -15,7 +15,7 @@ namespace Kudu.FunctionalTests.Infrastructure
         {
             var ex = Assert.Throws<AggregateException>(() => action());
             var baseEx = ex.GetBaseException();
-            Assert.IsType<T>(baseEx);
+            Assert.IsAssignableFrom<T>(baseEx);
             return (T)baseEx;
         }
 
@@ -34,7 +34,10 @@ namespace Kudu.FunctionalTests.Infrastructure
             if (contents.Length > 0)
             {
                 var responseBody = response.Content.ReadAsStringAsync().Result;
-                Assert.True(contents.All(responseBody.Contains));
+                foreach (var content in contents)
+                {
+                    Assert.Contains(content, responseBody, StringComparison.Ordinal);
+                }
             }
         }
 
@@ -47,7 +50,7 @@ namespace Kudu.FunctionalTests.Infrastructure
             if (content != null)
             {
                 var responseBody = response.Content.ReadAsStringAsync().Result;
-                Assert.True(responseBody.Contains(content));
+                Assert.Contains(content, responseBody, StringComparison.Ordinal);
             }
         }
 

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -251,7 +251,7 @@ namespace Kudu.Services.Web.App_Start
 
         private static IProjectSystem GetEditorProjectSystem(IEnvironment environment, IContext context)
         {
-            return new ProjectSystem(environment.RootPath);
+            return new ProjectSystem(environment.WebRootPath);
         }
 
         private static ICommandExecutor GetCommandExecutor(IEnvironment environment, IContext context)

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -93,6 +93,12 @@ namespace Kudu.TestHarness
                 KuduUtils.DownloadDump(appManager.ServiceUrl, dumpPath);
 
                 Debug.WriteLine(ex.Message);
+
+                var httpResponseEx = ex as HttpUnsuccessfulRequestException;
+                if (httpResponseEx != null)
+                {
+                    Debug.WriteLine(httpResponseEx.ResponseMessage);
+                }
                 throw;
             }
             finally


### PR DESCRIPTION
- Modifying the editor project root to point to web root
- Ensure we read the response body when dealing with unsuccessful status
  codes.
- Fixing functional test that was broken due to path changes
- Tweaking KuduAssert to use XUnit.Assert
