### PR TITLE
Several test updates:

### DIFF
--- a/Kudu.Client/Deployment/RemoteDeploymentManager.cs
+++ b/Kudu.Client/Deployment/RemoteDeploymentManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Kudu.Client.Infrastructure;
@@ -9,13 +10,8 @@ namespace Kudu.Client.Deployment
 {
     public class RemoteDeploymentManager : KuduRemoteClientBase
     {
-        public RemoteDeploymentManager(string serviceUrl)
-            : base(serviceUrl)
-        {
-        }
-
-        public RemoteDeploymentManager(string serviceUrl, HttpMessageHandler handler)
-            : base(serviceUrl, handler)
+        public RemoteDeploymentManager(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials, handler)
         {
         }
 
@@ -31,38 +27,38 @@ namespace Kudu.Client.Deployment
                 url += "&$filter=LastSuccessEndTime ne null";
             }
 
-            return _client.GetJsonAsync<IEnumerable<DeployResult>>(url);
+            return Client.GetJsonAsync<IEnumerable<DeployResult>>(url);
         }
 
         public Task<DeployResult> GetResultAsync(string id)
         {
-            return _client.GetJsonAsync<DeployResult>(id);
+            return Client.GetJsonAsync<DeployResult>(id);
         }
 
         public Task<IEnumerable<LogEntry>> GetLogEntriesAsync(string id)
         {
-            return _client.GetJsonAsync<IEnumerable<LogEntry>>(id + "/log");
+            return Client.GetJsonAsync<IEnumerable<LogEntry>>(id + "/log");
         }
 
         public Task<IEnumerable<LogEntry>> GetLogEntryDetailsAsync(string id, string logId)
         {
-            return _client.GetJsonAsync<IEnumerable<LogEntry>>(id + "/log/" + logId);
+            return Client.GetJsonAsync<IEnumerable<LogEntry>>(id + "/log/" + logId);
         }
 
         public Task DeleteAsync(string id)
         {
-            return _client.DeleteSafeAsync(id);
+            return Client.DeleteSafeAsync(id);
         }
 
         public Task DeployAsync(string id)
         {
-            return _client.PutAsync(id);
+            return Client.PutAsync(id);
         }
 
         public Task DeployAsync(string id, bool clean)
         {
             var param = new KeyValuePair<string, string>("clean", clean.ToString());
-            return _client.PutAsync(id, param);
+            return Client.PutAsync(id, param);
         }
     }
 }

--- a/Kudu.Client/Editor/RemoteProjectSystem.cs
+++ b/Kudu.Client/Editor/RemoteProjectSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using Kudu.Client.Infrastructure;
 using Kudu.Core.Editor;
 
@@ -7,8 +8,8 @@ namespace Kudu.Client.Editor
 {
     public class RemoteProjectSystem : KuduRemoteClientBase, IProjectSystem
     {
-        public RemoteProjectSystem(string serviceUrl)
-            :base(serviceUrl)
+        public RemoteProjectSystem(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
         }
 
@@ -16,7 +17,7 @@ namespace Kudu.Client.Editor
         {
             // REVIEW: Do we need to url encode?
             // REVIEW: this goes through the same client that set the Accept header to application/json, but we receive text/plain
-            return _client.GetAsync(path)
+            return Client.GetAsync(path)
                           .Result
                           .EnsureSuccessful()
                           .Content
@@ -26,21 +27,21 @@ namespace Kudu.Client.Editor
 
         public Project GetProject()
         {
-            return _client.GetJson<Project>(String.Empty);
+            return Client.GetJson<Project>(String.Empty);
         }
 
         public void WriteAllText(string path, string content)
         {
-            _client.PutAsync(path, HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("content", content)))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PutAsync(path, HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("content", content)))
+                  .Result
+                  .EnsureSuccessful();
         }
 
         public void Delete(string path)
         {
-            _client.DeleteAsync(path)
-                   .Result
-                   .EnsureSuccessful();
+            Client.DeleteAsync(path)
+                  .Result
+                  .EnsureSuccessful();
         }
     }
 }

--- a/Kudu.Client/Editor/RemoteVfsManager.cs
+++ b/Kudu.Client/Editor/RemoteVfsManager.cs
@@ -1,0 +1,14 @@
+﻿using System.Net;
+using System.Net.Http;
+using Kudu.Client.Infrastructure;
+
+namespace Kudu.Client.Editor
+{
+    public class RemoteVfsManager : KuduRemoteClientBase
+    {
+        public RemoteVfsManager(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
+            : base(serviceUrl, credentials, handler)
+        {
+        }
+    }
+}

--- a/Kudu.Client/Infrastructure/HttpClientExtensions.cs
+++ b/Kudu.Client/Infrastructure/HttpClientExtensions.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Threading.Tasks;
-using Kudu.Contracts.Infrastructure;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Kudu.Client.Infrastructure
 {
@@ -19,18 +14,6 @@ namespace Kudu.Client.Infrastructure
             var content = response.Result.EnsureSuccessful().Content.ReadAsStringAsync().Result;
 
             return JsonConvert.DeserializeObject<T>(content);
-        }
-
-        public static void SetClientCredentials(this HttpClient client, ICredentials credentials)
-        {
-            if (credentials == null)
-            {
-                return;
-            }
-
-            NetworkCredential networkCred = credentials.GetCredential(client.BaseAddress, "Basic");
-            string credParameter = Convert.ToBase64String(Encoding.ASCII.GetBytes(networkCred.UserName + ":" + networkCred.Password));
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credParameter);
         }
 
         public static Task<T> GetJsonAsync<T>(this HttpClient client, string url)

--- a/Kudu.Client/Infrastructure/KuduRemoteClientBase.cs
+++ b/Kudu.Client/Infrastructure/KuduRemoteClientBase.cs
@@ -1,47 +1,27 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 
 namespace Kudu.Client.Infrastructure
 {
     public abstract class KuduRemoteClientBase
     {
-        protected readonly HttpClient _client;
-        private ICredentials _credentials;
-
-        public KuduRemoteClientBase(string serviceUrl)
-            : this(serviceUrl, null)
+        protected KuduRemoteClientBase(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
         {
+            if (serviceUrl == null)
+            {
+                throw new ArgumentNullException("serviceUrl");
+            }
 
-        }
-
-        public KuduRemoteClientBase(string serviceUrl, HttpMessageHandler handler)
-        {
-            ServiceUrl = UrlUtility.EnsureTrailingSlash(serviceUrl);
-            _client = HttpClientHelper.Create(ServiceUrl, handler);
+            ServiceUrl = serviceUrl;
+            Credentials = credentials;
+            Client = HttpClientHelper.CreateClient(ServiceUrl, credentials, handler);
         }
 
         public string ServiceUrl { get; private set; }
 
-        public HttpRequestHeaders Headers
-        {
-            get
-            {
-                return _client.DefaultRequestHeaders;
-            }
-        }
+        public ICredentials Credentials { get; private set; }
 
-        public ICredentials Credentials
-        {
-            get
-            {
-                return _credentials;
-            }
-            set
-            {
-                _credentials = value;
-                _client.SetClientCredentials(_credentials);
-            }
-        }
+        public HttpClient Client { get; private set; }
     }
 }

--- a/Kudu.Client/Infrastructure/UrlUtility.cs
+++ b/Kudu.Client/Infrastructure/UrlUtility.cs
@@ -1,14 +1,17 @@
-﻿namespace Kudu.Client.Infrastructure
+﻿using System;
+
+namespace Kudu.Client.Infrastructure
 {
-    internal static class UrlUtility
+    public static class UrlUtility
     {
-        internal static string EnsureTrailingSlash(string url)
+        public static string EnsureTrailingSlash(string url)
         {
-            if (url.EndsWith("/"))
+            UriBuilder address = new UriBuilder(url);
+            if (!address.Path.EndsWith("/"))
             {
-                return url;
+                address.Path += "/";
             }
-            return url + "/";
+            return address.Uri.AbsoluteUri;
         }
     }
 }

--- a/Kudu.Client/Kudu.Client.csproj
+++ b/Kudu.Client/Kudu.Client.csproj
@@ -68,6 +68,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Diagnostics\RemoteLogStreamManager.cs" />
+    <Compile Include="Editor\RemoteVfsManager.cs" />
     <Compile Include="Infrastructure\BasicAuthCredentialProvider.cs" />
     <Compile Include="Infrastructure\HttpResponseMessageExtensions.cs" />
     <Compile Include="Infrastructure\HttpClientExtensions.cs" />

--- a/Kudu.Client/RemoteEnvironmentManager.cs
+++ b/Kudu.Client/RemoteEnvironmentManager.cs
@@ -1,19 +1,12 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Net;
 using Kudu.Client.Infrastructure;
 
 namespace Kudu.Client
 {
     public class RemoteEnvironmentManager : KuduRemoteClientBase
     {
-        public RemoteEnvironmentManager(string serviceUrl)
-            : base(serviceUrl)
-        {
-        }
-
-        public RemoteEnvironmentManager(string serviceUrl, HttpMessageHandler handler)
-            : base(serviceUrl, handler)
+        public RemoteEnvironmentManager(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
         }
     }

--- a/Kudu.Client/SSHKey/RemoteSSHKeyManager.cs
+++ b/Kudu.Client/SSHKey/RemoteSSHKeyManager.cs
@@ -1,22 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net.Http;
+using System.Net;
 using System.Threading.Tasks;
 using Kudu.Client.Infrastructure;
-using Kudu.Contracts.Infrastructure;
-using Newtonsoft.Json;
 
 namespace Kudu.Client.SSHKey
 {
     public class RemoteSSHKeyManager : KuduRemoteClientBase
     {
-        public RemoteSSHKeyManager(string serviceUrl)
-            : base(serviceUrl)
-        {
-        }
-
-        public RemoteSSHKeyManager(string serviceUrl, HttpMessageHandler handler)
-            : base(serviceUrl, handler)
+        public RemoteSSHKeyManager(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
         }
 
@@ -27,7 +20,7 @@ namespace Kudu.Client.SSHKey
                 new KeyValuePair<string, string>("key", key)
             };
 
-            return _client.PutAsync(String.Empty, param).Then(response =>
+            return Client.PutAsync(String.Empty, param).Then(response =>
             {
                 response.EnsureSuccessful();
                 return;

--- a/Kudu.Client/Settings/RemoteDeploymentSettingsManager.cs
+++ b/Kudu.Client/Settings/RemoteDeploymentSettingsManager.cs
@@ -1,47 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Net.Http;
+using System.Net;
 using System.Threading.Tasks;
 using Kudu.Client.Infrastructure;
-using Kudu.Contracts.Infrastructure;
 using Newtonsoft.Json.Linq;
 
 namespace Kudu.Client.Deployment
 {
     public class RemoteDeploymentSettingsManager : KuduRemoteClientBase
     {
-        public RemoteDeploymentSettingsManager(string serviceUrl)
-            : base(serviceUrl)
-        {
-        }
-
-        public RemoteDeploymentSettingsManager(string serviceUrl, HttpClientHandler handler)
-            : base(serviceUrl, handler)
+        public RemoteDeploymentSettingsManager(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
         }
 
         public Task SetValueLegacy(string key, string value)
         {
             var values = HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("key", key), new KeyValuePair<string, string>("value", value));
-            return _client.PostAsync(String.Empty, values).Then(response => response.EnsureSuccessful());
+            return Client.PostAsync(String.Empty, values).Then(response => response.EnsureSuccessful());
         }
 
         public Task SetValue(string key, string value)
         {
             var values = HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>(key, value));
-            return _client.PostAsync(String.Empty, values).Then(response => response.EnsureSuccessful());
+            return Client.PostAsync(String.Empty, values).Then(response => response.EnsureSuccessful());
         }
 
         public Task SetValues(params KeyValuePair<string, string>[] values)
         {
             var jsonvalues = HttpClientHelper.CreateJsonContent(values);
-            return _client.PostAsync(String.Empty, jsonvalues).Then(response => response.EnsureSuccessful());
+            return Client.PostAsync(String.Empty, jsonvalues).Then(response => response.EnsureSuccessful());
         }
 
         public Task<NameValueCollection> GetValuesLegacy()
         {
-            return _client.GetJsonAsync<JArray>(String.Empty).Then(obj =>
+            return Client.GetJsonAsync<JArray>(String.Empty).Then(obj =>
             {
                 var nvc = new NameValueCollection();
                 foreach (JObject value in obj)
@@ -55,7 +49,7 @@ namespace Kudu.Client.Deployment
 
         public Task<NameValueCollection> GetValues()
         {
-            return _client.GetJsonAsync<JObject>("?version=2").Then(obj =>
+            return Client.GetJsonAsync<JObject>("?version=2").Then(obj =>
             {
                 var nvc = new NameValueCollection();
                 foreach (var pair in obj)
@@ -69,12 +63,12 @@ namespace Kudu.Client.Deployment
 
         public Task<string> GetValue(string key)
         {
-            return _client.GetJsonAsync<string>(key);
+            return Client.GetJsonAsync<string>(key);
         }
 
         public Task Delete(string key)
         {
-            return _client.DeleteSafeAsync(key);
+            return Client.DeleteSafeAsync(key);
         }
     }
 }

--- a/Kudu.Client/SourceControl/RemoteRepository.cs
+++ b/Kudu.Client/SourceControl/RemoteRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using Kudu.Client.Infrastructure;
 using Kudu.Core.SourceControl;
@@ -9,8 +10,8 @@ namespace Kudu.Client.SourceControl
 {
     public class RemoteRepository : KuduRemoteClientBase
     {
-        public RemoteRepository(string serviceUrl)
-            :base(serviceUrl)
+        public RemoteRepository(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
         }
 
@@ -18,7 +19,7 @@ namespace Kudu.Client.SourceControl
         {
             get
             {
-                return _client.GetAsync("id")
+                return Client.GetAsync("id")
                               .Result
                               .EnsureSuccessful()
                               .Content
@@ -29,36 +30,36 @@ namespace Kudu.Client.SourceControl
 
         public void Initialize()
         {
-            _client.PostAsync("init", new StringContent(String.Empty))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PostAsync("init", new StringContent(String.Empty))
+                  .Result
+                  .EnsureSuccessful();
         }
 
         public IEnumerable<Branch> GetBranches()
         {
-            return _client.GetJson<IEnumerable<Branch>>("branches");
+            return Client.GetJson<IEnumerable<Branch>>("branches");
         }
 
         public IEnumerable<FileStatus> GetStatus()
         {
-            return _client.GetJson<IEnumerable<FileStatus>>("status");
+            return Client.GetJson<IEnumerable<FileStatus>>("status");
         }
 
         public IEnumerable<ChangeSet> GetChanges()
         {
-            return _client.GetJson<IEnumerable<ChangeSet>>("log");
+            return Client.GetJson<IEnumerable<ChangeSet>>("log");
         }
 
         public IEnumerable<ChangeSet> GetChanges(int index, int limit)
         {
-            return _client.GetJson<IEnumerable<ChangeSet>>("log?index=" + index + "&limit=" + limit);
+            return Client.GetJson<IEnumerable<ChangeSet>>("log?index=" + index + "&limit=" + limit);
         }
 
         public ChangeSetDetail GetDetails(string id)
         {
-            return _client.GetJson<ChangeSetDetail>("details/" + id);
+            return Client.GetJson<ChangeSetDetail>("details/" + id);
         }
-        
+
         public ChangeSet GetChangeSet(string id)
         {
             // Not used by client apis as yet
@@ -67,53 +68,53 @@ namespace Kudu.Client.SourceControl
 
         public ChangeSetDetail GetWorkingChanges()
         {
-            return _client.GetJson<ChangeSetDetail>("working");
+            return Client.GetJson<ChangeSetDetail>("working");
         }
 
         public void AddFile(string path)
         {
-            _client.PostAsync("add", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("path", path)))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PostAsync("add", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("path", path)))
+                  .Result
+                  .EnsureSuccessful();
         }
 
         public void RevertFile(string path)
         {
-            _client.PostAsync("remove", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("path", path)))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PostAsync("remove", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("path", path)))
+                  .Result
+                  .EnsureSuccessful();
         }
 
         public ChangeSet Commit(string message, string authorName)
         {
-            string json = _client.PostAsync("commit", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("name", authorName), new KeyValuePair<string, string>("message", message)))
-                                 .Result
-                                 .EnsureSuccessful()
-                                 .Content.ReadAsStringAsync()
-                                 .Result;
+            string json = Client.PostAsync("commit", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("name", authorName), new KeyValuePair<string, string>("message", message)))
+                                .Result
+                                .EnsureSuccessful()
+                                .Content.ReadAsStringAsync()
+                                .Result;
 
             return JsonConvert.DeserializeObject<ChangeSet>(json);
         }
 
         public void Push()
         {
-            _client.PostAsync("push", new StringContent(String.Empty))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PostAsync("push", new StringContent(String.Empty))
+                  .Result
+                  .EnsureSuccessful();
         }
 
         public void Update(string id)
         {
-            _client.PostAsync("update", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("id", id)))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PostAsync("update", HttpClientHelper.CreateJsonContent(new KeyValuePair<string, string>("id", id)))
+                  .Result
+                  .EnsureSuccessful();
         }
 
         public void Update()
         {
-            _client.PostAsync("update", new StringContent(String.Empty))
-                   .Result
-                   .EnsureSuccessful();
+            Client.PostAsync("update", new StringContent(String.Empty))
+                  .Result
+                  .EnsureSuccessful();
         }
     }
 }

--- a/Kudu.Client/SourceControl/RemoteRepositoryManager.cs
+++ b/Kudu.Client/SourceControl/RemoteRepositoryManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Kudu.Client.Infrastructure;
@@ -8,26 +9,19 @@ namespace Kudu.Client.SourceControl
 {
     public class RemoteRepositoryManager : KuduRemoteClientBase
     {
-        public RemoteRepositoryManager(string serviceUrl)
-            :base(serviceUrl)
+        public RemoteRepositoryManager(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
-
-        }
-
-        public RemoteRepositoryManager(string serviceUrl, HttpMessageHandler handler)
-            : base(serviceUrl, handler)
-        {
-
         }
 
         public Task<RepositoryInfo> GetRepositoryInfo()
         {
-            return _client.GetJsonAsync<RepositoryInfo>("info");
+            return Client.GetJsonAsync<RepositoryInfo>("info");
         }
 
         public Task Delete()
         {
-            return _client.DeleteSafeAsync(String.Empty);
+            return Client.DeleteSafeAsync(String.Empty);
         }
     }
 }

--- a/Kudu.FunctionalTests/DropboxTests.cs
+++ b/Kudu.FunctionalTests/DropboxTests.cs
@@ -44,13 +44,8 @@ namespace Kudu.FunctionalTests
                     new KeyValuePair<string, string>("dropbox_email", account.email)
                     ).Wait();
 
-                HttpClient client = new HttpClient();
-                client.BaseAddress = new Uri(appManager.ServiceUrl);
+                HttpClient client = HttpClientHelper.CreateClient(appManager.ServiceUrl, appManager.DeploymentManager.Credentials);
                 client.DefaultRequestHeaders.Add("user-agent", "dropbox");
-                if (appManager.DeploymentManager.Credentials != null)
-                {
-                    client.SetClientCredentials(appManager.DeploymentManager.Credentials);
-                }
                 client.PostAsJsonAsync("deploy", deploy).Result.EnsureSuccessStatusCode();
 
                 KuduAssert.VerifyUrl(appManager.SiteUrl + "/default.html", "Hello Default!");

--- a/Kudu.FunctionalTests/Infrastructure/KuduAssert.cs
+++ b/Kudu.FunctionalTests/Infrastructure/KuduAssert.cs
@@ -27,9 +27,8 @@ namespace Kudu.FunctionalTests.Infrastructure
 
         public static void VerifyUrl(string url, ICredentials cred, params string[] contents)
         {
-            var client = new HttpClient();
+            HttpClient client = HttpClientHelper.CreateClient(url, cred);
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Kudu-Test", "1.0"));
-            client.SetClientCredentials(cred);
             var response = client.GetAsync(url).Result.EnsureSuccessful();
 
             if (contents.Length > 0)
@@ -48,10 +47,10 @@ namespace Kudu.FunctionalTests.Infrastructure
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Kudu-Test", "1.0"));
             var response = client.GetAsync(url).Result;
             string responseBody = response.Content.ReadAsStringAsync().Result;
-            
-            Assert.True(statusCode == response.StatusCode, 
+
+            Assert.True(statusCode == response.StatusCode,
                 String.Format("For {0}, Expected Status Code: {1} Actual Status Code: {2}. \r\n Response: {3}", url, statusCode, response.StatusCode, responseBody));
-            
+
             if (content != null)
             {
                 Assert.Contains(content, responseBody, StringComparison.Ordinal);

--- a/Kudu.FunctionalTests/Vfs/LiveScmEditorControllerTest.cs
+++ b/Kudu.FunctionalTests/Vfs/LiveScmEditorControllerTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Kudu.TestHarness;
+﻿using Kudu.TestHarness;
 using Xunit;
 
 namespace Kudu.FunctionalTests
@@ -14,8 +13,7 @@ namespace Kudu.FunctionalTests
 
             ApplicationManager.Run(appName, appManager =>
             {
-                string vfsController = String.Format("{0}scmvfs", appManager.ServiceUrl);
-                VfsControllerBaseTest suite = new VfsControllerBaseTest(vfsController, testConflictingUpdates: true);
+                VfsControllerBaseTest suite = new VfsControllerBaseTest(appManager.LiveScmVfsManager, testConflictingUpdates: true);
 
                 // Act + Assert
                 suite.RunIntegrationTest();

--- a/Kudu.FunctionalTests/Vfs/VfsControllerTest.cs
+++ b/Kudu.FunctionalTests/Vfs/VfsControllerTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Kudu.TestHarness;
+﻿using Kudu.TestHarness;
 using Xunit;
 
 namespace Kudu.FunctionalTests
@@ -14,8 +13,7 @@ namespace Kudu.FunctionalTests
 
             ApplicationManager.Run(appName, appManager =>
             {
-                string vfsController = String.Format("{0}vfs", appManager.ServiceUrl);
-                VfsControllerBaseTest suite = new VfsControllerBaseTest(vfsController, testConflictingUpdates: false);
+                VfsControllerBaseTest suite = new VfsControllerBaseTest(appManager.VfsManager, testConflictingUpdates: false);
 
                 // Act + Assert
                 suite.RunIntegrationTest();

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -74,6 +74,18 @@ namespace Kudu.TestHarness
             private set;
         }
 
+        public RemoteVfsManager VfsManager
+        {
+            get;
+            private set;
+        }
+
+        public RemoteVfsManager LiveScmVfsManager
+        {
+            get;
+            private set;
+        }
+
         public string GitUrl
         {
             get;
@@ -145,7 +157,7 @@ namespace Kudu.TestHarness
             var siteManager = GetSiteManager(pathResolver, settingsResolver);
 
             Site site;
-            
+
             if (KuduUtils.ReuseSameSiteForAllTests)
             {
                 // In site reuse mode, try to get the existing site, and create it if needed
@@ -182,7 +194,9 @@ namespace Kudu.TestHarness
                 SettingsManager = new RemoteDeploymentSettingsManager(site.ServiceUrl + "settings"),
                 LogStreamManager = new RemoteLogStreamManager(site.ServiceUrl + "logstream"),
                 SSHKeyManager = new RemoteSSHKeyManager(site.ServiceUrl + "sshkey"),
-                RepositoryManager = repositoryManager
+                VfsManager = new RemoteVfsManager(site.ServiceUrl + "vfs"),
+                LiveScmVfsManager = new RemoteVfsManager(site.ServiceUrl + "scmvfs"),
+                RepositoryManager = repositoryManager,
             };
         }
 

--- a/Kudu.TestHarness/DeploymentManagerExtensions.cs
+++ b/Kudu.TestHarness/DeploymentManagerExtensions.cs
@@ -1,31 +1,26 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Kudu.Client.Deployment;
-using Kudu.Core.Deployment;
 
 namespace Kudu.TestHarness
 {
     public static class DeploymentManagerExtensions
     {
         public static XDocument GetServerProfile(this ApplicationManager appManager, string applicationName)
-        {            
+        {
             var zippedLogsPath = Path.Combine(PathHelper.TestResultsPath, applicationName + ".zip");
             var unzippedLogsPath = Path.Combine(PathHelper.TestResultsPath, applicationName);
             var profileLogPath = Path.Combine(unzippedLogsPath, "profiles", "profile.xml");
 
-            return KuduUtils.GetServerProfile(appManager.ServiceUrl, zippedLogsPath, applicationName);            
+            return KuduUtils.GetServerProfile(appManager.ServiceUrl, zippedLogsPath, applicationName);
         }
 
         private static void WaitForRepositorySite(ApplicationManager appManager)
         {
-            HttpUtils.WaitForSite(appManager.ServiceUrl);
+            HttpUtils.WaitForSite(appManager.ServiceUrl, appManager.DeploymentManager.Credentials);
         }
 
-        
         private static void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
         {
             Debug.WriteLine(e.Exception.GetBaseException().ToString());

--- a/Kudu.TestHarness/Git.cs
+++ b/Kudu.TestHarness/Git.cs
@@ -135,8 +135,7 @@ namespace Kudu.TestHarness
 
         public static GitDeploymentResult GitDeploy(string kuduServiceUrl, string localRepoPath, string remoteRepoUrl, string localBranchName, string remoteBranchName)
         {
-            var deploymentManager = new RemoteDeploymentManager(kuduServiceUrl);
-
+            var deploymentManager = new RemoteDeploymentManager(kuduServiceUrl + "deployments"); 
             return GitDeploy(deploymentManager, kuduServiceUrl, localRepoPath, remoteRepoUrl, localBranchName, remoteBranchName);
         }
 

--- a/Kudu.TestHarness/HttpUtils.cs
+++ b/Kudu.TestHarness/HttpUtils.cs
@@ -1,14 +1,16 @@
 ﻿using System.Net;
 using System.Net.Http;
 using System.Threading;
+using Kudu.Client.Infrastructure;
 
 namespace Kudu.TestHarness
 {
     public class HttpUtils
     {
-        public static void WaitForSite(string siteUrl, int retries = 3, int delayBeforeRetry = 250)
+        public static void WaitForSite(string siteUrl, ICredentials credentials = null, int retries = 3, int delayBeforeRetry = 250)
         {
-            var client = new HttpClient();
+            var handler = HttpClientHelper.CreateClientHandler(siteUrl, credentials);
+            var client = new HttpClient(handler);
 
             while (retries > 0)
             {
@@ -30,6 +32,6 @@ namespace Kudu.TestHarness
                 retries--;
                 Thread.Sleep(delayBeforeRetry);
             }
-        }        
+        }
     }
 }

--- a/Kudu.TestHarness/KuduUtils.cs
+++ b/Kudu.TestHarness/KuduUtils.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Xml.Linq;
+using Kudu.Client.Infrastructure;
 
 namespace Kudu.TestHarness
 {
@@ -16,12 +17,8 @@ namespace Kudu.TestHarness
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(zippedLogsPath));
 
-                var client = new HttpClient(new HttpClientHandler()
-                {
-                    Credentials = credentials
-                });
-
-
+                var clientHandler = HttpClientHelper.CreateClientHandler(serviceUrl, credentials);
+                var client = new HttpClient(clientHandler);
                 var result = client.GetAsync(serviceUrl + "dump").Result;
                 if (result.IsSuccessStatusCode)
                 {

--- a/Kudu.TestHarness/RemoteLogStreamManager.cs
+++ b/Kudu.TestHarness/RemoteLogStreamManager.cs
@@ -9,8 +9,8 @@ namespace Kudu.TestHarness
     // This is a test class current workaround Stream.Close hangs.
     public class RemoteLogStreamManager : KuduRemoteClientBase
     {
-        public RemoteLogStreamManager(string serviceUrl)
-            : base(serviceUrl)
+        public RemoteLogStreamManager(string serviceUrl, ICredentials credentials = null)
+            : base(UrlUtility.EnsureTrailingSlash(serviceUrl), credentials)
         {
         }
 
@@ -20,10 +20,9 @@ namespace Kudu.TestHarness
             TaskCompletionSource<Stream> tcs = new TaskCompletionSource<Stream>();
             RequestState state = new RequestState { Manager = this, TaskCompletionSource = tcs, Request = request };
 
-            if (this._client.DefaultRequestHeaders.Authorization != null)
+            if (Client.DefaultRequestHeaders.Authorization != null)
             {
-
-                request.Headers["Authorization"] = this._client.DefaultRequestHeaders.Authorization.Scheme + " " + this._client.DefaultRequestHeaders.Authorization.Parameter;
+                request.Headers["Authorization"] = Client.DefaultRequestHeaders.Authorization.Scheme + " " + Client.DefaultRequestHeaders.Authorization.Parameter;
             }
 
             IAsyncResult result = request.BeginGetResponse(RemoteLogStreamManager.OnGetResponse, state);

--- a/Kudu.Web/Infrastructure/ApplicationExtensions.cs
+++ b/Kudu.Web/Infrastructure/ApplicationExtensions.cs
@@ -3,8 +3,8 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Kudu.Client.Deployment;
+using Kudu.Client.Infrastructure;
 using Kudu.Client.SourceControl;
-using Kudu.Contracts.Infrastructure;
 using Kudu.Core.SourceControl;
 using Kudu.Web.Models;
 
@@ -14,32 +14,26 @@ namespace Kudu.Web.Infrastructure
     {
         public static Task<RepositoryInfo> GetRepositoryInfo(this IApplication application, ICredentials credentials)
         {
-            var repositoryManager = new RemoteRepositoryManager(application.ServiceUrl + "live/scm");
-            repositoryManager.Credentials = credentials;
+            var repositoryManager = new RemoteRepositoryManager(application.ServiceUrl + "live/scm", credentials);
             return repositoryManager.GetRepositoryInfo();
         }
 
         public static RemoteDeploymentManager GetDeploymentManager(this IApplication application, ICredentials credentials)
         {
-            var deploymentManager = new RemoteDeploymentManager(application.ServiceUrl + "/deployments");
-            deploymentManager.Credentials = credentials;
+            var deploymentManager = new RemoteDeploymentManager(application.ServiceUrl + "/deployments", credentials);
             return deploymentManager;
         }
 
         public static RemoteDeploymentSettingsManager GetSettingsManager(this IApplication application, ICredentials credentials)
         {
-            var deploymentSettingsManager = new RemoteDeploymentSettingsManager(application.ServiceUrl + "/settings");
-            deploymentSettingsManager.Credentials = credentials;
+            var deploymentSettingsManager = new RemoteDeploymentSettingsManager(application.ServiceUrl + "/settings", credentials);
             return deploymentSettingsManager;
         }
 
         public static Task<XDocument> DownloadTrace(this IApplication application, ICredentials credentials)
         {
-            var client = new HttpClient(new HttpClientHandler()
-            {
-                Credentials = credentials
-            });
-
+            var clientHandler = HttpClientHelper.CreateClientHandler(application.ServiceUrl, credentials);
+            var client = new HttpClient(clientHandler);
 
             return client.GetAsync(application.ServiceUrl + "dump").Then(response =>
             {


### PR DESCRIPTION
1) Updated HttpClientHelper to expose statics for creating an HttpClient and an HttpClientHandler which is correctly set up to handle authentication. It uses a CredentialsCache along with preauthentication which handles authentication across redirects.

2) Updated KuduRemoteClientBase to make not force a teminating "/" on the base URI. This makes it possible to VFS to use the client base. Also cleaned up the class so that it is easier to use,

3) Added RemoteVfsManager to ApplicationManager which correct base URI and credentials.

4) Updated places which created an HttpClientHandler manually to instead use HttpClientHelper.CreateClientHandler
