### PR TITLE
support filter and diagnostic settings

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -24,5 +24,7 @@ namespace Kudu
         public const string DeploymentTracePath = LogFilesPath + @"\Git\deployment";
         public const string TraceFileFormat = "{0}-{1}.txt";
         public const string TraceFileEnvKey = "KUDU_TRACE_FILE";
+
+        public const string DiagnosticsSettingPath = @"diagnostics\settings.json";
     }
 }

--- a/Kudu.Core.Test/JsonSettingsFacts.cs
+++ b/Kudu.Core.Test/JsonSettingsFacts.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using Kudu.Core.Settings;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Kudu.Core.Test
+{
+    public class JsonSettingsFacts
+    {
+        const string SettingsPath = @"a:\test\settings.json";
+
+        [Fact]
+        public void ConstructorTest()
+        {
+            IFileSystem fileSystem = GetMockFileSystem(SettingsPath);
+
+            var settings = new JsonSettings(fileSystem, SettingsPath);
+
+            Assert.Equal(null, settings.GetValue("non_existing"));
+
+            Assert.Equal(0, settings.GetValues().Count());
+
+            Assert.False(settings.DeleteValue("non_existing"));
+
+            Assert.False(fileSystem.File.Exists(SettingsPath));
+        }
+
+        [Fact]
+        public void ConstructorWithValuesTest()
+        {
+            var values = new[]
+            {
+                new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()),
+                new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString())
+            };
+
+            var settings = new JsonSettings(GetMockFileSystem(SettingsPath, values), SettingsPath);
+
+            foreach (KeyValuePair<string, string> value in values)
+            {
+                Assert.Equal(value.Value, settings.GetValue(value.Key));
+            }
+
+            Assert.Equal(null, settings.GetValue("non_existing"));
+
+            Assert.Equal(values.Length, settings.GetValues().Count());
+        }
+
+        [Fact]
+        public void SetGetValueTest()
+        {
+            var value = new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+
+            Assert.Equal(null, settings.GetValue(value.Key));
+
+            settings.SetValue(value.Key, value.Value);
+
+            Assert.Equal(value.Value, settings.GetValue(value.Key));
+        }
+
+        [Fact]
+        public void SetGetValuesTest()
+        {
+            var values = new Dictionary<string, string>
+            {
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() },
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
+            };
+
+            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+
+            Assert.Equal(0, settings.GetValues().Count());
+
+            settings.SetValues(values);
+
+            Assert.Equal(values.Count, settings.GetValues().Count());
+
+            foreach (KeyValuePair<string, string> value in settings.GetValues())
+            {
+                Assert.Equal(values[value.Key], value.Value);
+            }
+
+            // Update
+            values[values.Keys.ElementAt(0)] = Guid.NewGuid().ToString();
+
+            settings.SetValues(values);
+
+            foreach (KeyValuePair<string, string> value in settings.GetValues())
+            {
+                Assert.Equal(values[value.Key], value.Value);
+            }
+        }
+
+        [Fact]
+        public void SetGetJObjectTest()
+        {
+            var values = new Dictionary<string, string>
+            {
+                { Guid.NewGuid().ToString(), null },
+                { Guid.NewGuid().ToString(), String.Empty },
+                { Guid.NewGuid().ToString(), Guid.NewGuid().ToString() }
+            };
+
+            JObject json = new JObject();
+            foreach (KeyValuePair<string, string> value in values)
+            {
+                json[value.Key] = value.Value;
+            }
+
+            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+
+            Assert.Equal(0, settings.GetValues().Count());
+
+            settings.SetValues(json);
+
+            Assert.Equal(values.Count, settings.GetValues().Count());
+
+            foreach (KeyValuePair<string, string> value in settings.GetValues())
+            {
+                Assert.Equal(json[value.Key].Value<string>(), value.Value);
+            }
+        }
+
+        [Fact]
+        public void NullOrEmptyTest()
+        {
+            var key = Guid.NewGuid().ToString();
+            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+
+            Assert.Equal(null, settings.GetValue(key));
+
+            settings.SetValue(key, String.Empty);
+            Assert.Equal(String.Empty, settings.GetValue(key));
+
+            settings.SetValue(key, null);
+            Assert.Equal(null, settings.GetValue(key));
+        }
+
+        [Fact]
+        public void DeleteValueTest()
+        {
+            var value = new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+
+            Assert.Equal(null, settings.GetValue(value.Key));
+
+            settings.SetValue(value.Key, value.Value);
+            Assert.Equal(value.Value, settings.GetValue(value.Key));
+
+            // Delete existing value
+            Assert.Equal(true, settings.DeleteValue(value.Key));
+
+            Assert.Equal(null, settings.GetValue(value.Key));
+
+            // Delete non-existing value
+            Assert.False(settings.DeleteValue(value.Key));
+        }
+
+        private IFileSystem GetMockFileSystem(string path, params KeyValuePair<string, string>[] values)
+        {
+            MemoryStream mem = null;
+            var fileSystem = new Mock<IFileSystem>();
+            var file = new Mock<FileBase>();
+            var directory = new Mock<DirectoryBase>();
+
+            // Arrange
+            file.Setup(f => f.Open(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite)).Returns(() => 
+            {
+                mem = new MemoryStream();
+                return mem;
+            });
+            file.Setup(f => f.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)).Returns(() =>
+            {
+                if (mem == null)
+                {
+                    throw new FileNotFoundException(path + " does not exist.");
+                }
+
+                byte[] bytes = mem.GetBuffer();
+                mem = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: true);
+                return mem;
+            });
+
+            if (values.Length > 0)
+            {
+                JObject json = new JObject();
+                foreach (KeyValuePair<string, string> pair in values)
+                {
+                    json[pair.Key] = pair.Value;
+                }
+
+                mem = new MemoryStream();
+                using (var writer = new JsonTextWriter(new StreamWriter(mem)))
+                {
+                    json.WriteTo(writer);
+                }
+            }
+
+            file.Setup(f => f.Exists(path)).Returns(() => mem != null);
+
+            fileSystem.Setup(fs => fs.File).Returns(file.Object);
+            fileSystem.Setup(fs => fs.Directory).Returns(directory.Object);
+
+            return fileSystem.Object;
+        }
+    }
+}

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -36,6 +36,9 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Abstractions, Version=1.4.0.35, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
@@ -70,6 +73,7 @@
     <Compile Include="Infrastructure\StringReaderFacts.cs" />
     <Compile Include="Infrastructure\VsSolutionTest.cs" />
     <Compile Include="Infrastructure\XmlUtilityFacts.cs" />
+    <Compile Include="JsonSettingsFacts.cs" />
     <Compile Include="NodeSiteEnablerFacts.cs" />
     <Compile Include="FileSystemHelpersTest.cs" />
     <Compile Include="GitRepositoryRepositoryTest.cs" />

--- a/Kudu.Core.Test/packages.config
+++ b/Kudu.Core.Test/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.0.10827" />
+  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net40" />
   <package id="System.IO.Abstractions" version="1.4.0.35" targetFramework="net40" />
   <package id="System.IO.Abstractions.TestingHelpers" version="1.4.0.35" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Abstractions, Version=1.4.0.35, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
@@ -81,6 +84,7 @@
     <Compile Include="Infrastructure\VsHelper.cs" />
     <Compile Include="Infrastructure\XmlUtility.cs" />
     <Compile Include="Settings\DeploymentSettingsManager.cs" />
+    <Compile Include="Settings\JsonSettings.cs" />
     <Compile Include="SourceControl\Git\GitDeploymentRepository.cs" />
     <Compile Include="SSHKey\SSHKeyManager.cs" />
     <Compile Include="Tracing\CascadeTracer.cs" />

--- a/Kudu.Core/Settings/JsonSettings.cs
+++ b/Kudu.Core/Settings/JsonSettings.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using Kudu.Core.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Kudu.Core.Settings
+{
+    /// <summary>
+    /// Settings implementation backed by json persistent file.
+    /// We only supports flat key-value settings (no heirachy).
+    /// Concurrency is loosely provided at FileShare.ReadWrite.
+    /// Trade-off with simplicity of synchronization across instances, we will allow 
+    /// dirty read/write concurrently.
+    /// </summary>
+    public class JsonSettings
+    {
+        private string _path;
+        private IFileSystem _fileSystem;
+
+        public JsonSettings(string path)
+            : this(new FileSystem(), path)
+        {
+        }
+
+        public JsonSettings(IFileSystem fileSystem, string path)
+        {
+            _fileSystem = fileSystem;
+            _path = path;
+        }
+
+        public string GetValue(string key)
+        {
+            return Read().Value<string>(key);
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> GetValues()
+        {
+            var dict = (IDictionary<string, JToken>)Read();
+            return dict.ToDictionary(pair => pair.Key, pair => pair.Value.Value<string>());
+        }
+
+        public void SetValue(string key, string value)
+        {
+            JObject json = Read();
+            json[key] = value;
+            Save(json);
+        }
+
+        public void SetValues(JObject values)
+        {
+            JObject json = Read();
+            foreach (KeyValuePair<string, JToken> pair in values)
+            {
+                json[pair.Key] = pair.Value.Value<string>();
+            }
+
+            Save(json);
+        }
+
+        public void SetValues(IEnumerable<KeyValuePair<string, string>> values)
+        {
+            JObject json = Read();
+            foreach (KeyValuePair<string, string> pair in values)
+            {
+                json[pair.Key] = pair.Value;
+            }
+
+            Save(json);
+        }
+
+        public bool DeleteValue(string key)
+        {
+            JObject json = Read();
+            if (json.Remove(key))
+            {
+                Save(json);
+                return true;
+            }
+
+            return false;
+        }
+
+        private JObject Read()
+        {
+            if (!_fileSystem.File.Exists(_path))
+            {
+                return new JObject();
+            }
+
+            using (var reader = new JsonTextReader(new StreamReader(_fileSystem.File.Open(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))))
+            {
+                return JObject.Load(reader);
+            }
+        }
+
+        private void Save(JObject json)
+        {
+            if (!_fileSystem.File.Exists(_path))
+            {
+                FileSystemHelpers.EnsureDirectory(_fileSystem, Path.GetDirectoryName(_path));
+            }
+
+            using (var writer = new StreamWriter(_fileSystem.File.Open(_path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite)))
+            {
+                // prefer indented-readable format
+                writer.Write(json.ToString());
+            }
+        }
+    }
+}

--- a/Kudu.Core/packages.config
+++ b/Kudu.Core/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.IO.Abstractions" version="1.4.0.35" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net40" />
   <package id="XmlSettings" version="0.1.2.0" targetFramework="net40" />
 </packages>

--- a/Kudu.FunctionalTests/DiagnosticsApiFacts.cs
+++ b/Kudu.FunctionalTests/DiagnosticsApiFacts.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using Kudu.Client;
+using Kudu.TestHarness;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Kudu.FunctionalTests
+{
+    public class DiagnosticsApiFacts
+    {
+        [Fact]
+        public void ConstructorTest()
+        {
+            string repositoryName = "Mvc3Application";
+            string appName = KuduUtils.GetRandomWebsiteName("ConstructorTest");
+
+            using (var repo = Git.CreateLocalRepository(repositoryName))
+            {
+                ApplicationManager.Run(appName, appManager =>
+                {
+                    using (HttpClient client = NewHttpClient(appManager))
+                    {
+                        HttpResponseMessage response = client.GetAsync("diagnostics/settings").Result.EnsureSuccessful();
+                        using (var reader = new JsonTextReader(new StreamReader(response.Content.ReadAsStreamAsync().Result)))
+                        {
+                            JObject json = (JObject)JToken.ReadFrom(reader);
+                            Assert.Equal(0, json.Count);
+                        }
+                    }
+
+                    using (HttpClient client = NewHttpClient(appManager))
+                    {
+                        var ex = Assert.Throws<HttpRequestException>(() => client.GetAsync("diagnostics/settings/trace_level").Result.EnsureSuccessful());
+                        Assert.Contains("404", ex.Message);
+                    }
+                });
+            }
+        }
+
+        [Fact]
+        public void SetGetDeleteValue()
+        {
+            var values = new[]
+            {
+                new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString()),
+                new KeyValuePair<string, string>(Guid.NewGuid().ToString(), String.Empty),
+                new KeyValuePair<string, string>(Guid.NewGuid().ToString(), null)
+            };
+
+            string repositoryName = "Mvc3Application";
+            string appName = KuduUtils.GetRandomWebsiteName("SetGetDeleteValue");
+
+            using (var repo = Git.CreateLocalRepository(repositoryName))
+            {
+                ApplicationManager.Run(appName, appManager =>
+                {
+                    // set values
+                    using (HttpClient client = NewHttpClient(appManager))
+                    {
+                        JObject json = new JObject();
+                        foreach (KeyValuePair<string, string> value in values)
+                        {
+                            json[value.Key] = value.Value;
+                        }
+                        client.PostAsJsonAsync("diagnostics/settings", json).Result.EnsureSuccessful();
+                    }
+
+                    // verify values
+                    VerifyValues(appManager, values);
+
+                    // delete value
+                    using (HttpClient client = NewHttpClient(appManager))
+                    {
+                        KeyValuePair<string, string> deleted = values[1];
+                        client.DeleteAsync("diagnostics/settings/" + deleted.Key).Result.EnsureSuccessful();
+                        values = values.Where(p => p.Key != deleted.Key).ToArray();
+                    }
+
+                    // update value
+                    using (HttpClient client = NewHttpClient(appManager))
+                    {
+                        KeyValuePair<string, string> updated = values[0] = new KeyValuePair<string, string>(values[0].Key, Guid.NewGuid().ToString());
+                        JObject json = new JObject();
+                        json[updated.Key] = updated.Value;
+                        client.PostAsJsonAsync("diagnostics/settings", json).Result.EnsureSuccessful();
+                    }
+
+                    // verify values
+                    VerifyValues(appManager, values);
+                });
+            }
+        }
+
+        private void VerifyValues(ApplicationManager appManager, params KeyValuePair<string, string>[] values)
+        {
+            using (HttpClient client = NewHttpClient(appManager))
+            {
+                HttpResponseMessage response = client.GetAsync("diagnostics/settings").Result.EnsureSuccessful();
+                using (var reader = new JsonTextReader(new StreamReader(response.Content.ReadAsStreamAsync().Result)))
+                {
+                    JObject json = (JObject)JToken.ReadFrom(reader);
+                    Assert.Equal(values.Length, json.Count);
+                    foreach (KeyValuePair<string, string> value in values)
+                    {
+                        Assert.Equal(value.Value, json[value.Key].Value<string>());
+                    }
+                }
+            }
+
+            foreach (KeyValuePair<string, string> value in values)
+            {
+                using (HttpClient client = NewHttpClient(appManager))
+                {
+                    if (value.Value != null)
+                    {
+                        HttpResponseMessage response = client.GetAsync("diagnostics/settings/" + value.Key).Result.EnsureSuccessful();
+                        var result = response.Content.ReadAsStringAsync().Result;
+                        Assert.Equal(value.Value, result.Trim('\"'));
+                    }
+                    else
+                    {
+                        var ex = Assert.Throws<HttpRequestException>(() => client.GetAsync("diagnostics/settings/" + value.Key).Result.EnsureSuccessful());
+                        Assert.Contains("404", ex.Message);
+                    }
+                }
+            }
+        }
+
+        private HttpClient NewHttpClient(ApplicationManager appManager)
+        {
+            var client = new HttpClient(new HttpClientHandler()
+            {
+                Credentials = appManager.DeploymentManager.Credentials
+            });
+
+            client.BaseAddress = new Uri(appManager.ServiceUrl);
+
+            return client;
+        }
+    }
+}

--- a/Kudu.FunctionalTests/DropboxTests.cs
+++ b/Kudu.FunctionalTests/DropboxTests.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web;
+using Kudu.Client;
 using Kudu.Client.Infrastructure;
 using Kudu.Contracts.Dropbox;
 using Kudu.FunctionalTests.Infrastructure;
@@ -45,8 +46,7 @@ namespace Kudu.FunctionalTests
                     ).Wait();
 
                 HttpClient client = HttpClientHelper.CreateClient(appManager.ServiceUrl, appManager.DeploymentManager.Credentials);
-                client.DefaultRequestHeaders.Add("user-agent", "dropbox");
-                client.PostAsJsonAsync("deploy", deploy).Result.EnsureSuccessStatusCode();
+                client.PostAsJsonAsync("deploy", deploy).Result.EnsureSuccessful();
 
                 KuduAssert.VerifyUrl(appManager.SiteUrl + "/default.html", "Hello Default!");
                 KuduAssert.VerifyUrl(appManager.SiteUrl + "/temp/temp.html", "Hello Temp!");
@@ -67,7 +67,7 @@ namespace Kudu.FunctionalTests
         {
             var uri = new Uri("https://api.dropbox.com/1/account/info");
             var client = GetDropboxClient(HttpMethod.Get, uri, oauth);
-            var response = client.GetAsync(uri.PathAndQuery).Result.EnsureSuccessStatusCode();
+            var response = client.GetAsync(uri.PathAndQuery).Result.EnsureSuccessful();
             using (var reader = new JsonTextReader(new StreamReader(response.Content.ReadAsStreamAsync().Result)))
             {
                 JsonSerializer serializer = new JsonSerializer();
@@ -90,7 +90,7 @@ namespace Kudu.FunctionalTests
                 client = GetDropboxClient(HttpMethod.Post, uri, oauth);
             }
 
-            var response = client.PostAsync(uri.PathAndQuery, null).Result.EnsureSuccessStatusCode();
+            var response = client.PostAsync(uri.PathAndQuery, null).Result.EnsureSuccessful();
             using (var reader = new JsonTextReader(new StreamReader(response.Content.ReadAsStreamAsync().Result)))
             {
                 JsonSerializer serializer = new JsonSerializer();

--- a/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
+++ b/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DeploymentManagerTests.cs" />
+    <Compile Include="DiagnosticsApiFacts.cs" />
     <Compile Include="DropboxTests.cs" />
     <Compile Include="GitRepositoryManagementTests.cs" />
     <Compile Include="GitStabilityTests.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -121,18 +121,6 @@ namespace Kudu.Services.Web.App_Start
             kernel.Bind<IOperationLock>().ToConstant(sshKeyLock).WhenInjectedInto<SSHKeyController>();
             kernel.Bind<IOperationLock>().ToConstant(deploymentLock);
 
-            // Setup the diagnostics service to collect information from the following paths:
-            // 1. The deployments folder
-            // 2. The profile dump
-            // 3. The npm log
-            var paths = new[] { 
-                environment.DeploymentCachePath,
-                Path.Combine(environment.RootPath, Constants.LogFilesPath),
-                Path.Combine(environment.WebRootPath, Constants.NpmDebugLogFile),
-            };
-
-            kernel.Bind<DiagnosticsController>().ToMethod(context => new DiagnosticsController(paths));
-
             var shutdownDetector = new ShutdownDetector();
             shutdownDetector.Initialize();
 
@@ -186,13 +174,13 @@ namespace Kudu.Services.Web.App_Start
                                      .InRequestScope();
 
             // Git Servicehook parsers
-            kernel.Bind<IServiceHookHandler>().To<GitHubHandler>();
-            kernel.Bind<IServiceHookHandler>().To<BitbucketHandler>();
-            kernel.Bind<IServiceHookHandler>().To<DropboxHandler>();
-            kernel.Bind<IServiceHookHandler>().To<CodePlexHandler>();
-            kernel.Bind<IServiceHookHandler>().To<CodebaseHqHandler>();
-            kernel.Bind<IServiceHookHandler>().To<GitlabHqHandler>();
-            kernel.Bind<IServiceHookHandler>().To<GitHubCompatHandler>();
+            kernel.Bind<IServiceHookHandler>().To<GitHubHandler>().InRequestScope();
+            kernel.Bind<IServiceHookHandler>().To<BitbucketHandler>().InRequestScope();
+            kernel.Bind<IServiceHookHandler>().To<DropboxHandler>().InRequestScope();
+            kernel.Bind<IServiceHookHandler>().To<CodePlexHandler>().InRequestScope();
+            kernel.Bind<IServiceHookHandler>().To<CodebaseHqHandler>().InRequestScope();
+            kernel.Bind<IServiceHookHandler>().To<GitlabHqHandler>().InRequestScope();
+            kernel.Bind<IServiceHookHandler>().To<GitHubCompatHandler>().InRequestScope();
 
             // Command executor
             kernel.Bind<ICommandExecutor>().ToMethod(context => GetCommandExecutor(environment, context))
@@ -274,6 +262,10 @@ namespace Kudu.Services.Web.App_Start
 
             // Diagnostics
             routes.MapHttpRoute("diagnostics", "dump", new { controller = "Diagnostics", action = "GetLog" });
+            routes.MapHttpRoute("diagnostics-set-setting", "diagnostics/settings", new { controller = "Diagnostics", action = "Set" }, new { verb = new HttpMethodConstraint("POST") });
+            routes.MapHttpRoute("diagnostics-get-all-settings", "diagnostics/settings", new { controller = "Diagnostics", action = "GetAll" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("diagnostics-get-setting", "diagnostics/settings/{key}", new { controller = "Diagnostics", action = "Get" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("diagnostics-delete-setting", "diagnostics/settings/{key}", new { controller = "Diagnostics", action = "Delete" }, new { verb = new HttpMethodConstraint("DELETE") });
 
             // LogStream
             routes.MapHandler<LogStreamHandler>(kernel, "logstream", "logstream/{*path}");

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -67,7 +67,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.10\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Ninject, Version=2.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\packages\Ninject.2.2.1.4\lib\net40-Full\Ninject.dll</HintPath>

--- a/Kudu.Services.Web/packages.config
+++ b/Kudu.Services.Web/packages.config
@@ -13,7 +13,7 @@
   <package id="Microsoft.Data.OData.Contrib" version="5.0.1.50822" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net40" />
   <package id="Ninject" version="2.2.1.4" />
   <package id="System.IO.Abstractions" version="1.4.0.35" targetFramework="net40" />
   <package id="System.Spatial" version="5.0.2" targetFramework="net40" />

--- a/Kudu.Services/Diagnostics/DiagnosticsController.cs
+++ b/Kudu.Services/Diagnostics/DiagnosticsController.cs
@@ -1,21 +1,37 @@
 ﻿using System;
 using System.IO;
+using System.IO.Abstractions;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Web.Http;
 using Ionic.Zip;
+using Kudu.Core;
+using Kudu.Core.Settings;
 using Kudu.Services.Infrastructure;
+using Newtonsoft.Json.Linq;
 
 namespace Kudu.Services.Performance
 {
     public class DiagnosticsController : ApiController
     {
+        private readonly JsonSettings _settings;
         private readonly string[] _paths;
         private static object _lockObj = new object();
 
-        public DiagnosticsController(params string[] paths)
+        public DiagnosticsController(IEnvironment environment, IFileSystem fileSystem)
         {
-            _paths = paths;
+            // Setup the diagnostics service to collect information from the following paths:
+            // 1. The deployments folder
+            // 2. The profile dump
+            // 3. The npm log
+            _paths = new[] { 
+                environment.DeploymentCachePath,
+                Path.Combine(environment.RootPath, Constants.LogFilesPath),
+                Path.Combine(environment.WebRootPath, Constants.NpmDebugLogFile),
+            };
+
+            _settings = new JsonSettings(fileSystem, Path.Combine(environment.SiteRootPath, Constants.DiagnosticsSettingPath));
         }
 
         /// <summary>
@@ -51,6 +67,52 @@ namespace Kudu.Services.Performance
                 response.Content.Headers.ContentDisposition.FileName = String.Format("dump-{0:MM-dd-H:mm:ss}.zip", DateTime.UtcNow);
                 return response;
             }
+        }
+
+        public HttpResponseMessage Set(JObject newSettings)
+        {
+            if (newSettings == null)
+            {
+                return Request.CreateResponse(HttpStatusCode.BadRequest);
+            }
+
+            _settings.SetValues(newSettings);
+
+            return Request.CreateResponse(HttpStatusCode.NoContent);
+        }
+
+        public HttpResponseMessage Delete(string key)
+        {
+            if (String.IsNullOrEmpty(key))
+            {
+                return Request.CreateResponse(HttpStatusCode.BadRequest);
+            }
+
+            _settings.DeleteValue(key);
+
+            return Request.CreateResponse(HttpStatusCode.NoContent);
+        }
+
+        public HttpResponseMessage GetAll()
+        {
+            return Request.CreateResponse(HttpStatusCode.OK, _settings.GetValues());
+        }
+
+        public HttpResponseMessage Get(string key)
+        {
+            if (String.IsNullOrEmpty(key))
+            {
+                return Request.CreateResponse(HttpStatusCode.BadRequest);
+            }
+
+            string value = _settings.GetValue(key);
+
+            if (value == null)
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.NotFound, String.Format(Resources.SettingDoesNotExist, key));
+            }
+
+            return Request.CreateResponse(HttpStatusCode.OK, value);
         }
     }
 }

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -56,7 +56,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.10\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.4.5.9\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Kudu.Services/packages.config
+++ b/Kudu.Services/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Data.OData.Contrib" version="5.0.1.50822" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.9" targetFramework="net40" />
   <package id="System.IO.Abstractions" version="1.4.0.35" targetFramework="net40" />
   <package id="System.Spatial" version="5.0.2" targetFramework="net40" />
   <package id="WebActivator" version="1.5.1" targetFramework="net40" />


### PR DESCRIPTION
Changes include following
1. support /logstream?filter=xxx.   (simple string contains)
2. support /diagnostics/settings.  This is requested by diagnostics team.  Consumer is Application Trace Provider.   Instead of XmlSettings, we go with a simpler Json settings format.
3. Make NewtonSoft nuget (4.5.9) consistent across Kudu.  4.5.9 (latest is 4.5.11) is picked because consistency with MVC4 and AuxPortal.   BTW, the assemblies have the same strong name just different file version.
4. all related unit and functional tests.
