### PR TITLE
filter out auth header and add logstream support for detailed errors

### DIFF
--- a/Kudu.Services.Web/Tracing/TraceModule.cs
+++ b/Kudu.Services.Web/Tracing/TraceModule.cs
@@ -43,7 +43,10 @@ namespace Kudu.Services.Web.Tracing
 
                 foreach (string key in httpContext.Request.Headers)
                 {
-                    attribs["h_" + key] = httpContext.Request.Headers[key];
+                    if (!key.Equals("Authorization", StringComparison.OrdinalIgnoreCase))
+                    {
+                        attribs["h_" + key] = httpContext.Request.Headers[key];
+                    }
                 }
 
                 if (httpContext.Request.RawUrl.Contains(".git") ||


### PR DESCRIPTION
Changes contains...

(1) filter out auth header in traces to avoid persisting PII.
(2) for logstream, do stream back detailed errors (htm).

For the latter, I have to add a ReadLine (ported from StreamReader.ReadLine()).  The reason is logstream needs to keep track of the offset where it was last read.  We used to assume that new line is  '\r\n' (works well with existing txt, log files) however not true for htm (only '\n').   
