### PR TITLE
Ignoring the CustomNodeScript test

### DIFF
--- a/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
+++ b/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
@@ -742,7 +742,7 @@ command = deploy.cmd");
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Not a valid scenario")]
         public void CustomNodeScript()
         {
             string repositoryName = "CustomNodeScript";


### PR DESCRIPTION
Ignoring the CustomNodeScript test for now since it's not a valid scenario for current kudu service, will update this test with a similar valid scenario.
