### PR TITLE
Updates to the git-backed VFS controller

### DIFF
--- a/Kudu.FunctionalTests/Vfs/VfsControllerBaseTest.cs
+++ b/Kudu.FunctionalTests/Vfs/VfsControllerBaseTest.cs
@@ -263,6 +263,20 @@ namespace Kudu.FunctionalTests
                     Assert.Equal(updatedEtag, response.Headers.ETag);
                 }
 
+                // Check that update with wildcard etag succeeds
+                using (HttpRequestMessage update6 = new HttpRequestMessage())
+                {
+                    update6.Method = HttpMethod.Put;
+                    update6.RequestUri = new Uri(fileAddress);
+                    update6.Headers.IfMatch.Add(EntityTagHeaderValue.Any);
+                    update6.Content = CreateUploadContent(_fileContent1);
+                    response = Client.SendAsync(update6).Result;
+                    Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+                    Assert.NotNull(response.Headers.ETag);
+                    Assert.NotEqual(originalEtag, response.Headers.ETag);
+                    updatedEtag = response.Headers.ETag;
+                }
+
                 // Check that delete with invalid etag fails
                 using (HttpRequestMessage deleteRequest = new HttpRequestMessage())
                 {

--- a/Kudu.Services/Editor/VfsController.cs
+++ b/Kudu.Services/Editor/VfsController.cs
@@ -24,7 +24,7 @@ namespace Kudu.Services.Editor
         {
         }
 
-        protected override HttpResponseMessage CreateItemGetResponse(FileSystemInfo info, string localFilePath)
+        protected override Task<HttpResponseMessage> CreateItemGetResponse(FileSystemInfo info, string localFilePath)
         {
             // Get current etag
             EntityTagHeaderValue currentEtag = GetCurrentEtag(info);
@@ -34,7 +34,7 @@ namespace Kudu.Services.Editor
             {
                 HttpResponseMessage notModifiedResponse = Request.CreateResponse(HttpStatusCode.NotModified);
                 notModifiedResponse.Headers.ETag = currentEtag;
-                return notModifiedResponse;
+                return Task.FromResult(notModifiedResponse);
             }
 
             // Check whether we have a conditional range request containing both a Range and If-Range header field
@@ -60,7 +60,7 @@ namespace Kudu.Services.Editor
 
                 // Set etag for the file
                 successFileResponse.Headers.ETag = currentEtag;
-                return successFileResponse;
+                return Task.FromResult(successFileResponse);
             }
             catch (InvalidByteRangeException invalidByteRangeException)
             {
@@ -72,7 +72,7 @@ namespace Kudu.Services.Editor
                 {
                     fileStream.Close();
                 }
-                return invalidByteRangeResponse;
+                return Task.FromResult(invalidByteRangeResponse);
             }
             catch (Exception e)
             {
@@ -83,7 +83,7 @@ namespace Kudu.Services.Editor
                 {
                     fileStream.Close();
                 }
-                return errorResponse;
+                return Task.FromResult(errorResponse);
             }
         }
 
@@ -100,7 +100,7 @@ namespace Kudu.Services.Editor
                 {
                     HttpResponseMessage missingIfMatchResponse = Request.CreateErrorResponse(
                         HttpStatusCode.PreconditionFailed, Resources.VfsController_MissingIfMatch);
-                    return TaskHelpers.FromResult(missingIfMatchResponse);
+                    return Task.FromResult(missingIfMatchResponse);
                 }
 
                 bool isMatch = false;
@@ -118,7 +118,7 @@ namespace Kudu.Services.Editor
                     HttpResponseMessage conflictFileResponse = Request.CreateErrorResponse(
                         HttpStatusCode.PreconditionFailed, Resources.VfsController_EtagMismatch);
                     conflictFileResponse.Headers.ETag = currentEtag;
-                    return TaskHelpers.FromResult(conflictFileResponse);
+                    return Task.FromResult(conflictFileResponse);
                 }
             }
 
@@ -169,11 +169,11 @@ namespace Kudu.Services.Editor
                 {
                     fileStream.Close();
                 }
-                return TaskHelpers.FromResult(errorResponse);
+                return Task.FromResult(errorResponse);
             }
         }
 
-        protected override HttpResponseMessage CreateItemDeleteResponse(FileSystemInfo info, string localFilePath)
+        protected override Task<HttpResponseMessage> CreateItemDeleteResponse(FileSystemInfo info, string localFilePath)
         {
             // Get current etag
             EntityTagHeaderValue currentEtag = GetCurrentEtag(info);
@@ -183,7 +183,7 @@ namespace Kudu.Services.Editor
             {
                 HttpResponseMessage conflictDirectoryResponse = Request.CreateErrorResponse(
                     HttpStatusCode.PreconditionFailed, Resources.VfsController_MissingIfMatch);
-                return conflictDirectoryResponse;
+                return Task.FromResult(conflictDirectoryResponse);
             }
 
             bool isMatch = false;
@@ -201,7 +201,7 @@ namespace Kudu.Services.Editor
                 HttpResponseMessage conflictFileResponse = Request.CreateErrorResponse(
                     HttpStatusCode.PreconditionFailed, Resources.VfsController_EtagMismatch);
                 conflictFileResponse.Headers.ETag = currentEtag;
-                return conflictFileResponse;
+                return Task.FromResult(conflictFileResponse);
             }
 
             return base.CreateItemDeleteResponse(info, localFilePath);


### PR DESCRIPTION
1) Added more robust support for handling lock contention when multiple requests arrive at the same time. Now there is an pseudo-exponential back-off algorithm which tries multiple times getting a lock rather than giving up first time.

2) If lock cannot be obtained then return a 503 status code with a Retry-After header instead of a 409. This allows for the client to detect that it is a temporary situation and it may succeed if it retries.

3) Added support for wildcard match on DELETE and PUT. If an If-Match: \* wildcard conditional request then we automatically set it to the current commit ID whatever that is.

4) Moved some of the Task stuff to .NET 4.5 so that we can use "await Task.Delay(...)".

Henrik
