### PR TITLE
Fail by default when failing to delete some files in DELETE /scm

### DIFF
--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -8,14 +8,14 @@ namespace Kudu.Core.Infrastructure
 {
     internal static class FileSystemHelpers
     {
-        public static void DeleteDirectorySafe(string path)
+        public static void DeleteDirectorySafe(string path, bool ignoreErrors = true)
         {
-            DeleteFileSystemInfo(new DirectoryInfoWrapper(new DirectoryInfo(path)));
+            DeleteFileSystemInfo(new DirectoryInfoWrapper(new DirectoryInfo(path)), ignoreErrors);
         }
 
-        public static void DeleteDirectoryContentsSafe(string path)
+        public static void DeleteDirectoryContentsSafe(string path, bool ignoreErrors = true)
         {
-            DeleteDirectoryContentsSafe(new DirectoryInfoWrapper(new DirectoryInfo(path)));
+            DeleteDirectoryContentsSafe(new DirectoryInfoWrapper(new DirectoryInfo(path)), ignoreErrors);
         }
 
         public static void DeleteIfEmpty(string path)
@@ -69,7 +69,7 @@ namespace Kudu.Core.Infrastructure
             return false;
         }
 
-        private static void DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo)
+        private static void DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo, bool ignoreErrors)
         {
             try
             {
@@ -80,19 +80,20 @@ namespace Kudu.Core.Infrastructure
             }
             catch
             {
+                if (!ignoreErrors) throw;
             }
 
             var directoryInfo = fileSystemInfo as DirectoryInfoBase;
 
             if (directoryInfo != null)
             {
-                DeleteDirectoryContentsSafe(directoryInfo);
+                DeleteDirectoryContentsSafe(directoryInfo, ignoreErrors);
             }
 
-            DoSafeAction(fileSystemInfo.Delete);
+            DoSafeAction(fileSystemInfo.Delete, ignoreErrors);
         }
 
-        private static void DeleteDirectoryContentsSafe(DirectoryInfoBase directoryInfo)
+        private static void DeleteDirectoryContentsSafe(DirectoryInfoBase directoryInfo, bool ignoreErrors)
         {
             try
             {
@@ -100,16 +101,17 @@ namespace Kudu.Core.Infrastructure
                 {
                     foreach (var fsi in directoryInfo.GetFileSystemInfos())
                     {
-                        DeleteFileSystemInfo(fsi);
+                        DeleteFileSystemInfo(fsi, ignoreErrors);
                     }
                 }
             }
             catch
             {
+                if (!ignoreErrors) throw;
             }
         }
 
-        private static void DoSafeAction(Action action)
+        private static void DoSafeAction(Action action, bool ignoreErrors)
         {
             try
             {
@@ -117,6 +119,7 @@ namespace Kudu.Core.Infrastructure
             }
             catch
             {
+                if (!ignoreErrors) throw;
             }
         }
 

--- a/Kudu.Services/SourceControl/LiveScmController.cs
+++ b/Kudu.Services/SourceControl/LiveScmController.cs
@@ -52,7 +52,7 @@ namespace Kudu.Services.SourceControl
         /// Delete the repository
         /// </summary>
         [HttpDelete]
-        public void Delete(int deleteWebRoot = 0)
+        public void Delete(int deleteWebRoot = 0, int ignoreErrors = 0)
         {
             // Fail if a deployment is in progress
             _deploymentLock.LockOperation(() =>
@@ -60,19 +60,19 @@ namespace Kudu.Services.SourceControl
                 using (_tracer.Step("Deleting deployment cache"))
                 {
                     // Delete the deployment cache
-                    FileSystemHelpers.DeleteDirectorySafe(_environment.DeploymentCachePath);
+                    FileSystemHelpers.DeleteDirectorySafe(_environment.DeploymentCachePath, ignoreErrors != 0);
                 }
 
                 using (_tracer.Step("Deleting repository"))
                 {
                     // Delete the repository
-                    FileSystemHelpers.DeleteDirectorySafe(_environment.RepositoryPath);
+                    FileSystemHelpers.DeleteDirectorySafe(_environment.RepositoryPath, ignoreErrors != 0);
                 }
 
                 using (_tracer.Step("Deleting ssh key"))
                 {
                     // Delete the ssh key
-                    FileSystemHelpers.DeleteDirectorySafe(_environment.SSHKeyPath);
+                    FileSystemHelpers.DeleteDirectorySafe(_environment.SSHKeyPath, ignoreErrors != 0);
                 }
 
                 if (deleteWebRoot != 0)
@@ -80,21 +80,21 @@ namespace Kudu.Services.SourceControl
                     using (_tracer.Step("Deleting web root"))
                     {
                         // Delete the wwwroot folder
-                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.WebRootPath);
+                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.WebRootPath, ignoreErrors != 0);
                     }
 
                     using (_tracer.Step("Deleting diagnostics"))
                     {
                         // Delete the diagnostic log. This is a slight abuse of deleteWebRoot, but the
                         // real semantic is more to reset the site to a fully clean state
-                        FileSystemHelpers.DeleteDirectorySafe(_environment.DiagnosticsPath);
+                        FileSystemHelpers.DeleteDirectorySafe(_environment.DiagnosticsPath, ignoreErrors != 0);
                     }
 
                     using (_tracer.Step("Deleting Logs"))
                     {
                         // Cleanup the trace directories
-                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.TracePath);
-                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.DeploymentTracePath);
+                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.TracePath, ignoreErrors != 0);
+                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.DeploymentTracePath, ignoreErrors != 0);
                     }
                 }
             },


### PR DESCRIPTION
By default, DELETE /scm will fail if it fails to delete anything. There is an ignoreErrors flag that can be set to ignore exceptions and keep in deleting as much as it can (old behavior).
