### PR TITLE
Support simple payload to force fetch and deploy

### DIFF
--- a/Kudu.Services.Test/CodeBaseHqFacts.cs
+++ b/Kudu.Services.Test/CodeBaseHqFacts.cs
@@ -62,7 +62,6 @@ namespace Kudu.Services.Test
             Assert.Equal(DeployAction.ProcessDeployment, result);
             Assert.NotNull(deploymentInfo);
             Assert.Equal("CodebaseHQ", deploymentInfo.Deployer);
-            Assert.False(deploymentInfo.IsPrivate);
             Assert.Equal(RepositoryType.Git, deploymentInfo.RepositoryType);
             Assert.Equal("https://test.codebasehq.com/test-repositories/git1.git", deploymentInfo.RepositoryUrl);
             Assert.Equal("840daf31f4f87cb5cafd295ef75de989095f415b", deploymentInfo.TargetChangeset.Id);

--- a/Kudu.Services.Test/GenericHandlerFacts.cs
+++ b/Kudu.Services.Test/GenericHandlerFacts.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Web;
+using Kudu.Core.SourceControl;
+using Kudu.Services.ServiceHookHandlers;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Kudu.Services.Test
+{
+    public class GenericHandlerFacts
+    {
+        [Theory, ClassData(typeof(SimpleTestData))]
+        public void GenericHandlerSimpleTest(DeployAction expected, IDictionary<string, object> values)
+        {
+            // Arrange
+            var handler = new GenericHandler();
+            var payload = new JObject();
+            foreach (var pair in values)
+            {
+                payload[pair.Key] = JToken.FromObject(pair.Value);
+            }
+
+            // Act
+            DeploymentInfo deploymentInfo;
+            DeployAction result = handler.TryParseDeploymentInfo(request: null, payload: payload, targetBranch: null, deploymentInfo: out deploymentInfo);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("https://scm.com/repo", null, RepositoryType.Git)]
+        [InlineData("https://scm.com/repo", false, RepositoryType.Git)]
+        [InlineData("https://scm.com/repo", true, RepositoryType.Mercurial)]
+        [InlineData("git@scm.com:user/repo", null, RepositoryType.Git)]
+        [InlineData("git@scm.com:user/repo", false, RepositoryType.Git)]
+        [InlineData("git@scm.com:user/repo", true, RepositoryType.Mercurial)]
+        [InlineData("hg@scm.com:user/repo", null, RepositoryType.Mercurial)]
+        [InlineData("hg@scm.com:user/repo", false, RepositoryType.Git)]
+        [InlineData("hg@scm.com:user/repo", true, RepositoryType.Mercurial)]
+        public void GenericHandlerRepositoryTypeTest(string url, bool? is_hg, RepositoryType expected)
+        {
+            // Arrange
+            var handler = new GenericHandler();
+            var payload = new JObject();
+            payload["url"] = url;
+            if (is_hg != null)
+            {
+                payload["is_hg"] = is_hg.Value;
+            }
+
+            // Act
+            DeploymentInfo deploymentInfo;
+            DeployAction result = handler.TryParseDeploymentInfo(request: null, payload: payload, targetBranch: null, deploymentInfo: out deploymentInfo);
+
+            // Assert
+            Assert.Equal(DeployAction.ProcessDeployment, result);
+            Assert.NotNull(deploymentInfo);
+            Assert.Equal(expected, deploymentInfo.RepositoryType);
+        }
+
+        [Theory]
+        [InlineData("http://scm1.com/repo", "scm1.com")]
+        [InlineData("https://scm2.com/repo", "scm2.com")]
+        [InlineData("git@scm3.com:user/repo", "scm3.com")]
+        [InlineData("hg@scm4.com:user/repo", "scm4.com")]
+        public void GenericHandlerDeployerTest(string url, string expected)
+        {
+            // Arrange
+            var handler = new GenericHandler();
+            var payload = new JObject();
+            payload["url"] = url;
+
+            // Act
+            DeploymentInfo deploymentInfo;
+            DeployAction result = handler.TryParseDeploymentInfo(request: null, payload: payload, targetBranch: null, deploymentInfo: out deploymentInfo);
+
+            // Assert
+            Assert.Equal(DeployAction.ProcessDeployment, result);
+            Assert.NotNull(deploymentInfo);
+            Assert.Equal(expected, deploymentInfo.Deployer);
+        }
+
+        class SimpleTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // Valid payload
+                yield return new object[] { DeployAction.ProcessDeployment, new Dictionary<string, object> {
+                    { "url", "http://scm.com/repo" }
+                }};
+                yield return new object[] { DeployAction.ProcessDeployment, new Dictionary<string, object> {
+                    { "url", "http://scm.com/repo" },
+                    { "is_hg", true }
+                }};
+                yield return new object[] { DeployAction.ProcessDeployment, new Dictionary<string, object> {
+                    { "url", "http://scm.com/repo" },
+                    { "is_hg", "false" }
+                }};
+                yield return new object[] { DeployAction.ProcessDeployment, new Dictionary<string, object> {
+                    { "url", "git@scm.com:suwatch/repo" }
+                }};
+                yield return new object[] { DeployAction.ProcessDeployment, new Dictionary<string, object> {
+                    { "url", "hg@scm.com:suwatch/repo" }
+                }};
+
+                // Invalid payload
+                yield return new object[] { DeployAction.UnknownPayload, new Dictionary<string, object> {
+                }};
+                yield return new object[] { DeployAction.UnknownPayload, new Dictionary<string, object> {
+                    { "url", "http://scm.com/repo" },
+                    { "garbage", 1 }
+                }};
+                yield return new object[] { DeployAction.UnknownPayload, new Dictionary<string, object> {
+                    { "url", "invalid_uri" }
+                }};
+                yield return new object[] { DeployAction.UnknownPayload, new Dictionary<string, object> {
+                    { "url", 1 },
+                }};
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+    }
+}

--- a/Kudu.Services.Test/GithubHandlerFacts.cs
+++ b/Kudu.Services.Test/GithubHandlerFacts.cs
@@ -103,7 +103,6 @@ namespace Kudu.Services.Test
             Assert.Equal(DeployAction.ProcessDeployment, result);
             Assert.NotNull(deploymentInfo);
             Assert.Equal("GitHub", deploymentInfo.Deployer);
-            Assert.False(deploymentInfo.IsPrivate);
             Assert.Equal(RepositoryType.Git, deploymentInfo.RepositoryType);
             Assert.Equal("https://github.com/KuduApps/PostCommitTest", deploymentInfo.RepositoryUrl);
             Assert.Equal("f94996d67d6d5a060aaf2fcb72c333d0899549ab", deploymentInfo.TargetChangeset.Id);

--- a/Kudu.Services.Test/Kudu.Services.Test.csproj
+++ b/Kudu.Services.Test/Kudu.Services.Test.csproj
@@ -68,6 +68,7 @@
     <Compile Include="BitbucketHandlerFacts.cs" />
     <Compile Include="CodeBaseHqFacts.cs" />
     <Compile Include="CodePlexHandlerFacts.cs" />
+    <Compile Include="GenericHandlerFacts.cs" />
     <Compile Include="GithubHandlerFacts.cs" />
     <Compile Include="Infrastructure\MediaTypeMapTest.cs" />
     <Compile Include="KilnHgHandlerFacts.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -169,6 +169,7 @@ namespace Kudu.Services.Web.App_Start
                                      .InRequestScope();
 
             // Git Servicehook parsers
+            kernel.Bind<IServiceHookHandler>().To<GenericHandler>().InRequestScope();
             kernel.Bind<IServiceHookHandler>().To<GitHubHandler>().InRequestScope();
             kernel.Bind<IServiceHookHandler>().To<BitbucketHandler>().InRequestScope();
             kernel.Bind<IServiceHookHandler>().To<DropboxHandler>().InRequestScope();

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ServiceHookHandlers\CodebaseHqHandler.cs" />
     <Compile Include="ServiceHookHandlers\CodePlexHandler.cs" />
     <Compile Include="ServiceHookHandlers\DropboxHandler.cs" />
+    <Compile Include="ServiceHookHandlers\GenericHandler.cs" />
     <Compile Include="ServiceHookHandlers\GitDeploymentInfo.cs" />
     <Compile Include="ServiceHookHandlers\GitHubCompatHandler.cs" />
     <Compile Include="ServiceHookHandlers\GitlabHqHandler.cs" />

--- a/Kudu.Services/ServiceHookHandlers/BitbucketHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/BitbucketHandler.cs
@@ -47,10 +47,10 @@ namespace Kudu.Services.ServiceHookHandlers
             string server = payload.Value<string>("canon_url");     // e.g. https://bitbucket.org
             string path = repository.Value<string>("absolute_url"); // e.g. /davidebbo/testrepo/
             string scm = repository.Value<string>("scm"); // e.g. hg
+            bool isPrivate = repository.Value<bool>("is_private");
 
             // Combine them to get the full URL
             info.RepositoryUrl = server + path;
-            info.IsPrivate = repository.Value<bool>("is_private");
             info.RepositoryType = scm.Equals("hg", StringComparison.OrdinalIgnoreCase) ? RepositoryType.Mercurial : RepositoryType.Git;
 
             info.TargetChangeset = new ChangeSet(
@@ -64,7 +64,7 @@ namespace Kudu.Services.ServiceHookHandlers
             info.Deployer = request.UserAgent;
 
             // private repo, use SSH
-            if (info.IsPrivate)
+            if (isPrivate)
             {
                 var uri = new UriBuilder(info.RepositoryUrl);
                 if (uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase))
@@ -72,11 +72,9 @@ namespace Kudu.Services.ServiceHookHandlers
                     uri.Scheme = "ssh";
                     uri.Port = -1;
                     uri.Host = (info.RepositoryType == RepositoryType.Mercurial ? "hg@" : "git@") + uri.Host;
-                    info.Host = uri.Host;
 
                     // Private repo paths are of the format ssh://git@bitbucket.org/accountname/reponame.git
                     info.RepositoryUrl = uri.ToString();
-                    info.UseSSH = true;
                 }
             }
 

--- a/Kudu.Services/ServiceHookHandlers/CodebaseHqHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/CodebaseHqHandler.cs
@@ -32,10 +32,10 @@ namespace Kudu.Services.ServiceHookHandlers
             // CodebaseHq format, see http://support.codebasehq.com/kb/howtos/repository-push-commit-notifications
             var repository = payload.Value<JObject>("repository");
             var urls = repository.Value<JObject>("clone_urls");
-            info.IsPrivate = repository.Value<bool>("private");
+            var isPrivate = repository.Value<bool>("private");
             info.NewRef = payload.Value<string>("after");
 
-            if (info.IsPrivate)
+            if (isPrivate)
             {
                 info.RepositoryUrl = urls.Value<string>("ssh");
             }

--- a/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
+++ b/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
@@ -7,9 +7,6 @@ namespace Kudu.Services.ServiceHookHandlers
     {
         public RepositoryType RepositoryType { get; set; }
         public string RepositoryUrl { get; set; }
-        public bool IsPrivate { get; set; }
-        public bool UseSSH { get; set; }
-        public string Host { get; set; }
         public string Deployer { get; set; }
         public ChangeSet TargetChangeset { get; set; } 
         public IServiceHookHandler Handler { get; set; }

--- a/Kudu.Services/ServiceHookHandlers/GenericHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/GenericHandler.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Web;
+using Kudu.Core.SourceControl;
+using Newtonsoft.Json.Linq;
+
+namespace Kudu.Services.ServiceHookHandlers
+{
+    /// <summary>
+    /// Generic Servicehook Handler, uses simplest format.
+    /// </summary>
+    public class GenericHandler : ServiceHookHandlerBase
+    {
+        // { 
+        //   'url':'http://host/repository',
+        //   'is_hg':true // optional
+        // }
+        public override DeployAction TryParseDeploymentInfo(HttpRequestBase request, JObject payload, string targetBranch, out DeploymentInfo deploymentInfo)
+        {
+            deploymentInfo = null;
+
+            string url = null;
+            bool? is_hg = null;
+            foreach (var pair in payload)
+            {
+                if (pair.Key == "url" && url == null)
+                {
+                    url = (string)pair.Value;
+                }
+                else if (pair.Key == "is_hg" && is_hg == null)
+                {
+                    is_hg = (bool)pair.Value;
+                }
+                else
+                {
+                    // Unknown property
+                    return DeployAction.UnknownPayload;
+                }
+            }
+
+            if (String.IsNullOrEmpty(url))
+            {
+                return DeployAction.UnknownPayload;
+            }
+
+            var info = new DeploymentInfo();
+            info.RepositoryUrl = url;
+
+            if (is_hg != null)
+            {
+                info.RepositoryType = is_hg.Value ? RepositoryType.Mercurial : RepositoryType.Git;
+            }
+            else
+            {
+                info.RepositoryType = url.StartsWith("hg@", StringComparison.OrdinalIgnoreCase) ? RepositoryType.Mercurial : RepositoryType.Git;
+            }
+
+            Uri uri;
+            if (Uri.TryCreate(url, UriKind.Absolute, out uri))
+            {
+                info.Deployer = uri.Host;
+            }
+            else
+            {
+                int at = url.IndexOf("@");
+                int colon = url.IndexOf(":");
+                if (at <= 0 || colon <= 0 || at >= colon)
+                {
+                    return DeployAction.UnknownPayload;
+                }
+
+                info.Deployer = url.Substring(at + 1, colon - at - 1);
+            }
+
+            deploymentInfo = info;
+            return DeployAction.ProcessDeployment;
+        }
+    }
+}

--- a/Kudu.Services/ServiceHookHandlers/GitHubCompatHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/GitHubCompatHandler.cs
@@ -54,7 +54,6 @@ namespace Kudu.Services.ServiceHookHandlers
             // github format
             // { repository: { url: "https//...", private: False }, ref: "", before: "", after: "" } 
             info.RepositoryUrl = repository.Value<string>("url");
-            info.IsPrivate = repository.Value<bool>("private");
             info.Deployer = GetDeployer(request);
             info.NewRef = payload.Value<string>("after");
             var commits = payload.Value<JArray>("commits");
@@ -62,14 +61,14 @@ namespace Kudu.Services.ServiceHookHandlers
             info.TargetChangeset = ParseChangeSet(info.NewRef, commits);
 
             // private repo, use SSH
-            if (info.IsPrivate)
+            bool isPrivate = repository.Value<bool>("private");
+            if (isPrivate)
             {
                 Uri uri = new Uri(info.RepositoryUrl);
                 if (uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 {
-                    info.Host = "git@" + uri.Host;
-                    info.RepositoryUrl = info.Host + ":" + uri.AbsolutePath.TrimStart('/');
-                    info.UseSSH = true;
+                    var host = "git@" + uri.Host;
+                    info.RepositoryUrl = host + ":" + uri.AbsolutePath.TrimStart('/');
                 }
             }
 

--- a/Kudu.Services/ServiceHookHandlers/GitlabHqHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/GitlabHqHandler.cs
@@ -42,13 +42,10 @@ namespace Kudu.Services.ServiceHookHandlers
 
             // work around missing 'private' property, if missing assume is private.
             JToken priv;
+            bool isPrivate = true;
             if (repository.TryGetValue("private", out priv))
             {
-                info.IsPrivate = priv.ToObject<bool>();
-            }
-            else
-            {
-                info.IsPrivate = true;
+                isPrivate = priv.ToObject<bool>();
             }
 
             // The format of ref is refs/something/something else
@@ -62,14 +59,13 @@ namespace Kudu.Services.ServiceHookHandlers
             info.Deployer = "GitlabHQ";
 
             // private repo, use SSH
-            if (info.IsPrivate)
+            if (isPrivate)
             {
                 Uri uri = new Uri(info.RepositoryUrl);
                 if (uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 {
-                    info.Host = "git@" + uri.Host;
-                    info.RepositoryUrl = info.Host + ":" + uri.AbsolutePath.TrimStart('/');
-                    info.UseSSH = true;
+                    var host = "git@" + uri.Host;
+                    info.RepositoryUrl = host + ":" + uri.AbsolutePath.TrimStart('/');
                 }
             }
 

--- a/Kudu.Services/ServiceHookHandlers/KilnHgHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/KilnHgHandler.cs
@@ -102,7 +102,6 @@ namespace Kudu.Services.ServiceHookHandlers
             var info = new DeploymentInfo
             {
                 Deployer = "Kiln",
-                IsPrivate = !String.IsNullOrWhiteSpace(accessToken), // assume a private repo if an access token is provided
                 RepositoryUrl = repository.Value<string>("url"),
                 RepositoryType = RepositoryType.Mercurial,
                 TargetChangeset = new ChangeSet(
@@ -114,7 +113,8 @@ namespace Kudu.Services.ServiceHookHandlers
                     )
             };
 
-            if (info.IsPrivate)
+            bool isPrivate = !String.IsNullOrWhiteSpace(accessToken); // assume a private repo if an access token is provided
+            if (isPrivate)
             {
                 var uri = new UriBuilder(info.RepositoryUrl)
                 {


### PR DESCRIPTION
This is to support simple payload as little as url to initiate the fetch and deploy from any SCM.   This would allow an simple on-demand fetch.  This in a way lets us do a unit test on fetch and deploy w/o initiating payload from SCM.   Other details ...

(1) The Deployer is the host name of the url.  
(2) Optional is_hg for using Mercurial client.
(3) Cleanup properties that are no longer used.
