### PR TITLE
Prevent Receive-Pack and Info-Refs controller from initializing a git

### DIFF
--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Settings\DeploymentSettingsExtension.cs" />
     <Compile Include="Settings\IDeploymentSettingsManager.cs" />
     <Compile Include="Settings\SettingsKeys.cs" />
+    <Compile Include="SourceControl\IRepositoryFactory.cs" />
     <Compile Include="SourceControl\ScmType.cs" />
     <Compile Include="SSHKey\ISSHKeyManager.cs" />
     <Compile Include="Tracing\ITracer.cs" />

--- a/Kudu.Contracts/SourceControl/IRepositoryFactory.cs
+++ b/Kudu.Contracts/SourceControl/IRepositoryFactory.cs
@@ -1,0 +1,11 @@
+﻿using Kudu.Core.SourceControl;
+
+namespace Kudu.Contracts.SourceControl
+{
+    public interface IRepositoryFactory
+    {
+        IRepository EnsureRepository(RepositoryType repositoryType);
+
+        IRepository GetRepository();
+    }
+}

--- a/Kudu.Core/SourceControl/RepositoryFactory.cs
+++ b/Kudu.Core/SourceControl/RepositoryFactory.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Kudu.Contracts.Settings;
+using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl.Git;
@@ -11,7 +12,7 @@ using Kudu.Core.Tracing;
 namespace Kudu.Core.SourceControl
 {
     // TODO: Add unit tests via FileSystem once they add support for EnumerateFiles
-    public class RepositoryFactory
+    public class RepositoryFactory : IRepositoryFactory
     {
         private readonly IEnvironment _environment;
         private readonly ITraceFactory _traceFactory;

--- a/Kudu.Services.Test/InfoRefsControllerFacts.cs
+++ b/Kudu.Services.Test/InfoRefsControllerFacts.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.SourceControl;
+using Kudu.Contracts.Tracing;
+using Kudu.Core;
+using Kudu.Core.Deployment;
+using Kudu.Core.SourceControl;
+using Kudu.Core.SourceControl.Git;
+using Kudu.Services.GitServer;
+using Moq;
+using Xunit;
+
+namespace Kudu.Services.Test
+{
+    public class InfoRefsControllerFacts
+    {
+        [Fact]
+        public void InfoRefsControllerReturns403IfScmIsNotAvailable()
+        {
+            // Arrange
+            var settings = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+            settings.Setup(s => s.GetValue("ScmType")).Returns("None");
+
+            var request = new HttpRequestMessage();
+            InfoRefsController controller = CreateController(settings: settings.Object);
+            controller.Request = request;
+
+            // Act
+            var response = controller.Execute("upload-pack");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public void InfoRefsControllerThrowsIfPushingAGitRepositoryWhenHgRepositoryIsAlreadyPresent()
+        {
+            // Arrange
+            var settings = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+            settings.Setup(s => s.GetValue("ScmType")).Returns("Git");
+
+            var exception = new Exception();
+            var repositoryFactory = new Mock<IRepositoryFactory>(MockBehavior.Strict);
+            repositoryFactory.Setup(s => s.EnsureRepository(RepositoryType.Git)).Throws(exception);
+
+            InfoRefsController controller = CreateController(settings: settings.Object, repositoryFactory: repositoryFactory.Object);
+
+            // Act and Assert
+            var ex = Assert.Throws<Exception>(() => controller.Execute("upload-pack"));
+
+            // Assert
+            Assert.Equal(exception, ex);
+        }
+
+        private InfoRefsController CreateController(IGitServer gitServer = null,
+                                                    IDeploymentManager deploymentManager = null,
+                                                    IDeploymentSettingsManager settings = null,
+                                                    IRepositoryFactory repositoryFactory = null)
+        {
+            return new InfoRefsController(Mock.Of<ITracer>(),
+                                          gitServer ?? Mock.Of<IGitServer>(),
+                                          deploymentManager ?? Mock.Of<IDeploymentManager>(),
+                                          settings ?? Mock.Of<IDeploymentSettingsManager>(),
+                                          Mock.Of<IEnvironment>(),
+                                          repositoryFactory ?? Mock.Of<IRepositoryFactory>());
+        }
+    }
+}

--- a/Kudu.Services.Test/Kudu.Services.Test.csproj
+++ b/Kudu.Services.Test/Kudu.Services.Test.csproj
@@ -45,8 +45,14 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -70,9 +76,11 @@
     <Compile Include="CodePlexHandlerFacts.cs" />
     <Compile Include="GenericHandlerFacts.cs" />
     <Compile Include="GithubHandlerFacts.cs" />
+    <Compile Include="InfoRefsControllerFacts.cs" />
     <Compile Include="Infrastructure\MediaTypeMapTest.cs" />
     <Compile Include="KilnHgHandlerFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReceivePackHandlerFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Kudu.Services.Test/ReceivePackHandlerFacts.cs
+++ b/Kudu.Services.Test/ReceivePackHandlerFacts.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Web;
+using Kudu.Contracts.Infrastructure;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.SourceControl;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Deployment;
+using Kudu.Core.SourceControl;
+using Kudu.Core.SourceControl.Git;
+using Kudu.Services.GitServer;
+using Moq;
+using Xunit;
+
+namespace Kudu.Services.Test
+{
+    public class ReceivePackHandlerFacts
+    {
+        [Fact]
+        public void ReceivePackHandlerReturns403IfScmIsNotAvailable()
+        {
+            // Arrange
+            var settings = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+            settings.Setup(s => s.GetValue("ScmType")).Returns("None");
+
+            var response = Mock.Of<HttpResponseBase>();
+            var context = new Mock<HttpContextBase>();
+            context.SetupGet(c => c.Response).Returns(response);
+
+            ReceivePackHandler handler = CreateHandler(settings: settings.Object);
+
+            // Act
+            handler.ProcessRequestBase(context.Object);
+
+            // Assert
+            Assert.Equal(403, response.StatusCode);
+        }
+
+        [Fact]
+        public void ReceivePackHandlerThrowsIfPushingAGitRepositoryWhenHgRepositoryIsAlreadyPresent()
+        {
+            // Arrange
+            var settings = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+            settings.Setup(s => s.GetValue("ScmType")).Returns("Git");
+
+            var exception = new Exception();
+            var repositoryFactory = new Mock<IRepositoryFactory>(MockBehavior.Strict);
+            repositoryFactory.Setup(s => s.EnsureRepository(RepositoryType.Git)).Throws(exception);
+
+            ReceivePackHandler handler = CreateHandler(settings: settings.Object, repositoryFactory: repositoryFactory.Object);
+
+            // Act and Assert
+            var ex = Assert.Throws<Exception>(() => handler.ProcessRequestBase(Mock.Of<HttpContextBase>()));
+
+            // Assert
+            Assert.Equal(exception, ex);
+        }
+
+        private ReceivePackHandler CreateHandler(IGitServer gitServer = null, 
+                                                IDeploymentManager deploymentManager = null, 
+                                                IDeploymentSettingsManager settings = null, 
+                                                IRepositoryFactory repositoryFactory = null)
+        {
+            return new ReceivePackHandler(Mock.Of<ITracer>(),
+                                          gitServer ?? Mock.Of<IGitServer>(),
+                                          Mock.Of<IOperationLock>(),
+                                          deploymentManager ?? Mock.Of<IDeploymentManager>(),
+                                          settings ?? Mock.Of<IDeploymentSettingsManager>(),
+                                          repositoryFactory ?? Mock.Of<IRepositoryFactory>());
+        }
+    }
+}

--- a/Kudu.Services.Test/packages.config
+++ b/Kudu.Services.Test/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net45" />
 </packages>

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using Kudu.Contracts.Infrastructure;
+using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment;
 using Kudu.Core.SourceControl;
@@ -20,12 +21,12 @@ namespace Kudu.Services.Deployment
         private readonly IDeploymentManager _deploymentManager;
         private readonly ITracer _tracer;
         private readonly IOperationLock _deploymentLock;
-        private readonly RepositoryFactory _repositoryFactory;
+        private readonly IRepositoryFactory _repositoryFactory;
 
         public DeploymentController(ITracer tracer,
                                     IDeploymentManager deploymentManager,
                                     IOperationLock deploymentLock,
-                                    RepositoryFactory repositoryFactory)
+                                    IRepositoryFactory repositoryFactory)
         {
             _tracer = tracer;
             _deploymentManager = deploymentManager;

--- a/Kudu.Services/GitServer/GitServerHttpHandler.cs
+++ b/Kudu.Services/GitServer/GitServerHttpHandler.cs
@@ -58,9 +58,14 @@ namespace Kudu.Services.GitServer
             }
         }
 
-        public abstract void ProcessRequest(HttpContext context);
+        public void ProcessRequest(HttpContext context)
+        {
+            ProcessRequestBase(new HttpContextWrapper(context));
+        }
 
-        protected void UpdateNoCacheForResponse(HttpResponse response)
+        public abstract void ProcessRequestBase(HttpContextBase context);
+
+        protected void UpdateNoCacheForResponse(HttpResponseBase response)
         {
             response.Buffer = false;
             response.BufferOutput = false;

--- a/Kudu.Services/GitServer/UploadPackHandler.cs
+++ b/Kudu.Services/GitServer/UploadPackHandler.cs
@@ -41,7 +41,7 @@ namespace Kudu.Services.GitServer
         {
         }
 
-        public override void ProcessRequest(HttpContext context)
+        public override void ProcessRequestBase(HttpContextBase context)
         {
             using (_tracer.Step("RpcService.UploadPackHandler"))
             {

--- a/Kudu.Services/HttpRequestExtensions.cs
+++ b/Kudu.Services/HttpRequestExtensions.cs
@@ -6,7 +6,7 @@ namespace Kudu.Services
 {
     public static class HttpRequestExtensions
     {
-        public static Stream GetInputStream(this HttpRequest request)
+        public static Stream GetInputStream(this HttpRequestBase request)
         {
             var contentEncoding = request.Headers["Content-Encoding"];
 

--- a/Kudu.Services/Infrastructure/AuthUtility.cs
+++ b/Kudu.Services/Infrastructure/AuthUtility.cs
@@ -28,7 +28,7 @@ namespace Kudu.Services.Infrastructure
             return false;
         }
 
-        public static bool TryExtractBasicAuthUser(HttpRequest request, out string username)
+        public static bool TryExtractBasicAuthUser(HttpRequestBase request, out string username)
         {
             string authorizationHeader = request.Headers[HttpAuthorizationHeader];
 


### PR DESCRIPTION
endpoint when a non-Git repository already exists at the target directory

Fixes #329
