### PR TITLE
Fix Dropbox issue with socket leak

### DIFF
--- a/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
@@ -46,11 +46,11 @@ namespace Kudu.Services.ServiceHookHandlers
             return DeployAction.UnknownPayload;
         }
 
-        public virtual void Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch)
+        public virtual void Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger)
         {
             // Sync with dropbox
             var dropboxInfo = ((DropboxInfo)deploymentInfo);
-            deploymentInfo.TargetChangeset = _dropBoxHelper.Sync(dropboxInfo.DeployInfo, targetBranch);
+            deploymentInfo.TargetChangeset = _dropBoxHelper.Sync(dropboxInfo.DeployInfo, targetBranch, logger);
         }
 
         internal class DropboxInfo : DeploymentInfo

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -168,7 +168,7 @@ namespace Kudu.Services
 
                         // Fetch changes from the repository
                         innerLogger = logger.Log(Resources.FetchingChanges);
-                        deploymentInfo.Handler.Fetch(repository, deploymentInfo, targetBranch);
+                        deploymentInfo.Handler.Fetch(repository, deploymentInfo, targetBranch, innerLogger);
 
                         // set to null as Deploy() below takes over logging
                         innerLogger = null;

--- a/Kudu.Services/ServiceHookHandlers/IServiceHookHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/IServiceHookHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Web;
+using Kudu.Core.Deployment;
 using Kudu.Core.SourceControl;
 using Newtonsoft.Json.Linq;
 
@@ -13,7 +14,7 @@ namespace Kudu.Services.ServiceHookHandlers
         /// <returns>True if successfully parsed</returns>
         DeployAction TryParseDeploymentInfo(HttpRequestBase request, JObject payload, string targetBranch, out DeploymentInfo deploymentInfo);
 
-        void Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch);
+        void Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger);
     }
 
     public enum DeployAction

--- a/Kudu.Services/ServiceHookHandlers/ServiceHookHandlerBase.cs
+++ b/Kudu.Services/ServiceHookHandlers/ServiceHookHandlerBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Kudu.Core.Deployment;
 using Kudu.Core.SourceControl;
 
 namespace Kudu.Services.ServiceHookHandlers
@@ -8,7 +9,7 @@ namespace Kudu.Services.ServiceHookHandlers
     {
         public abstract DeployAction TryParseDeploymentInfo(System.Web.HttpRequestBase request, Newtonsoft.Json.Linq.JObject payload, string targetBranch, out DeploymentInfo deploymentInfo);
 
-        public void Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch)
+        public void Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger)
         {
             repository.FetchWithoutConflict(deploymentInfo.RepositoryUrl, "external", targetBranch);
         }


### PR DESCRIPTION
We did not dispose the HttpClient and its Response causing a leak in sockets and PICO limited at 250 handles.   Although, in time, GC will clean up and user can retry, the fix is dispose punctually.  I validate the repro before fix, apply the fix and it is no longer repro.

I also add more info (ILogger) to temp deployment in case of failures so users can diagnose what the issue could be.   
