### PR TITLE
Implement dropbox rate limit

### DIFF
--- a/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
+++ b/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
@@ -123,6 +123,10 @@
       <Project>{5320177C-725A-44BD-8FA6-F88D9725B46C}</Project>
       <Name>Kudu.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Kudu.Services\Kudu.Services.csproj">
+      <Project>{d163e227-9eb6-4619-ad37-d8eef831aef0}</Project>
+      <Name>Kudu.Services</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Kudu.SiteManagement\Kudu.SiteManagement.csproj">
       <Project>{D5669C1D-3408-4CEE-8C1B-D86D03D27EE2}</Project>
       <Name>Kudu.SiteManagement</Name>


### PR DESCRIPTION
Dropbox rate limit calls at 600/mins (we were cranking at 700-800/mins causing failures).  We put in place a rate limit for now (90% of 600/mins).  
