### PR TITLE
Fix #373 Dropbox specialchar hash causing 403

### DIFF
--- a/Kudu.FunctionalTests/DropboxTests.cs
+++ b/Kudu.FunctionalTests/DropboxTests.cs
@@ -72,6 +72,27 @@ namespace Kudu.FunctionalTests
         }
 
         [Fact]
+        public void TestDropboxSpecialFolderChars()
+        {
+            OAuthInfo oauth = GetOAuthInfo();
+            if (oauth == null)
+            {
+                // only run in private kudu
+                return;
+            }
+
+            AccountInfo account = GetAccountInfo(oauth);
+            DropboxDeployInfo deploy = GetDeployInfo("/!@#$faiztest$#!@", oauth, account);
+
+            string appName = "SpecialCharsTest";
+            ApplicationManager.Run(appName, appManager =>
+            {
+                HttpClient client = HttpClientHelper.CreateClient(appManager.ServiceUrl, appManager.DeploymentManager.Credentials);
+                client.PostAsJsonAsync("deploy", deploy).Result.EnsureSuccessful();
+            });
+        }
+
+        [Fact]
         public void TestDropboxRateLimiter()
         {
             // Set the limit to 60/sec, let it run for 5s


### PR DESCRIPTION
Any other special chars work except "#" causes 403 if not encoded properly in request url to dropbox.  i follow the implementation of  http://nuget.org/packages/Spring.Social.Dropbox/ to fix the issue.    
