### PR TITLE
Fix #320

### DIFF
--- a/Kudu.Client/Command/RemoteCommandExecutor.cs
+++ b/Kudu.Client/Command/RemoteCommandExecutor.cs
@@ -1,0 +1,24 @@
+﻿using Kudu.Client.Infrastructure;
+using Kudu.Core;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Kudu.Client.Deployment
+{
+    public class RemoteCommandExecutor : KuduRemoteClientBase
+    {
+        public RemoteCommandExecutor(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
+            : base(serviceUrl, credentials, handler)
+        {
+        }
+
+        public Task<CommandResult> ExecuteCommand(string command, string workingDirectory)
+        {
+            JObject payload = new JObject(new JProperty("command", command), new JProperty("dir", workingDirectory));
+            return Client.PostJsonAsync<JObject, CommandResult>(String.Empty, payload);
+        }
+    }
+}

--- a/Kudu.Client/Infrastructure/HttpClientExtensions.cs
+++ b/Kudu.Client/Infrastructure/HttpClientExtensions.cs
@@ -74,5 +74,16 @@ namespace Kudu.Client.Infrastructure
                 return result.EnsureSuccessful();
             });
         }
+
+        public static Task<TOutput> PostJsonAsync<TInput, TOutput>(this HttpClient client, string url, TInput param)
+        {
+            return client.PostAsJsonAsync(url, param).Then(result =>
+            {
+                return result.EnsureSuccessful().Content.ReadAsStringAsync().Then(content =>
+                {
+                    return JsonConvert.DeserializeObject<TOutput>(content);
+                });
+            });
+        }
     }
 }

--- a/Kudu.Client/Kudu.Client.csproj
+++ b/Kudu.Client/Kudu.Client.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Command\RemoteCommandExecutor.cs" />
     <Compile Include="Diagnostics\RemoteLogStreamManager.cs" />
     <Compile Include="Editor\RemoteVfsManager.cs" />
     <Compile Include="Infrastructure\BasicAuthCredentialProvider.cs" />

--- a/Kudu.Core/Deployment/CustomBuilder.cs
+++ b/Kudu.Core/Deployment/CustomBuilder.cs
@@ -39,14 +39,14 @@ namespace Kudu.Core.Deployment
             // the repository root
             var exe = new Executable(StarterScriptPath, _repositoryPath, _settings.GetCommandIdleTimeout());
             exe.AddDeploymentSettingsAsEnvironmentVariables(_settings);
-            exe.EnvironmentVariables[ExternalCommandBuilder.SourcePath] = _repositoryPath;
-            exe.EnvironmentVariables[ExternalCommandBuilder.TargetPath] = context.OutputPath;
+            exe.EnvironmentVariables[ExternalCommandFactory.SourcePath] = _repositoryPath;
+            exe.EnvironmentVariables[ExternalCommandFactory.TargetPath] = context.OutputPath;
             exe.EnvironmentVariables[ExternalCommandBuilder.PreviousManifestPath] = (context.PreviousManifest != null) ? context.PreviousManifest.ManifestFilePath : String.Empty;
             exe.EnvironmentVariables[ExternalCommandBuilder.NextManifestPath] = context.ManifestWriter.ManifestFilePath;
-            exe.EnvironmentVariables[ExternalCommandBuilder.MSBuildPath] = PathUtility.ResolveMSBuildPath();
-            exe.EnvironmentVariables[ExternalCommandBuilder.KuduSyncCommandKey] = KuduSyncCommand;
-            exe.EnvironmentVariables[ExternalCommandBuilder.SelectNodeVersionCommandKey] = SelectNodeVersionCommand;
-            exe.EnvironmentVariables[ExternalCommandBuilder.NpmJsPathKey] = PathUtility.ResolveNpmJsPath();
+            exe.EnvironmentVariables[ExternalCommandFactory.MSBuildPath] = PathUtility.ResolveMSBuildPath();
+            exe.EnvironmentVariables[ExternalCommandFactory.KuduSyncCommandKey] = KuduSyncCommand;
+            exe.EnvironmentVariables[ExternalCommandFactory.SelectNodeVersionCommandKey] = SelectNodeVersionCommand;
+            exe.EnvironmentVariables[ExternalCommandFactory.NpmJsPathKey] = PathUtility.ResolveNpmJsPath();
             exe.EnvironmentVariables[WellKnownEnvironmentVariables.NuGetPackageRestoreKey] = "true";
 
             exe.SetHomePath(_homePath);
@@ -75,7 +75,7 @@ namespace Kudu.Core.Deployment
 
             try
             {
-                exe.ExecuteWithProgressWriter(customLogger, context.Tracer, ExternalCommandBuilder.ShouldFilterOutMsBuildWarnings, ExternalCommandBuilder.ShouldFilterOutNodeRedundantOutput, _command, String.Empty);
+                exe.ExecuteWithProgressWriter(customLogger, context.Tracer, ExternalCommandFactory.ShouldFilterOutMsBuildWarnings, ExternalCommandFactory.ShouldFilterOutNodeRedundantOutput, _command, String.Empty);
 
                 tcs.SetResult(null);
             }
@@ -124,7 +124,7 @@ namespace Kudu.Core.Deployment
         {
             get
             {
-                return Path.Combine(_scriptPath, ExternalCommandBuilder.StarterScriptName);
+                return Path.Combine(_scriptPath, ExternalCommandFactory.StarterScriptName);
             }
         }
     }

--- a/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
@@ -1,0 +1,104 @@
+﻿using Kudu.Contracts.Settings;
+using Kudu.Core.Infrastructure;
+using System.IO;
+
+namespace Kudu.Core.Deployment.Generator
+{
+    internal class ExternalCommandFactory
+    {
+        // TODO: Once CustomBuilder is removed, change all internals back to privates
+
+        internal const string SourcePath = "DEPLOYMENT_SOURCE";
+        internal const string TargetPath = "DEPLOYMENT_TARGET";
+        internal const string MSBuildPath = "MSBUILD_PATH";
+        internal const string KuduSyncCommandKey = "KUDU_SYNC_CMD";
+        internal const string SelectNodeVersionCommandKey = "KUDU_SELECT_NODE_VERSION_CMD";
+        internal const string NpmJsPathKey = "NPM_JS_PATH";
+        internal const string StarterScriptName = "starter.cmd";
+
+        private IEnvironment _environment;
+        private IDeploymentSettingsManager _deploymentSettings;
+        private string _repositoryPath;
+
+        public ExternalCommandFactory(IEnvironment environment, IDeploymentSettingsManager settings, string repositoryPath)
+        {
+            _environment = environment;
+
+            _deploymentSettings = settings;
+            _repositoryPath = repositoryPath;
+        }
+
+        public Executable BuildExternalCommandExecutable(string workingDirectory, string deploymentTargetPath)
+        {
+            // Creates an executable pointing to cmd and the working directory being
+            // the repository root
+            var exe = new Executable(StarterScriptPath, workingDirectory, _deploymentSettings.GetCommandIdleTimeout());
+            exe.AddDeploymentSettingsAsEnvironmentVariables(_deploymentSettings);
+            exe.EnvironmentVariables[SourcePath] = _repositoryPath;
+            exe.EnvironmentVariables[TargetPath] = deploymentTargetPath;
+            exe.EnvironmentVariables[MSBuildPath] = PathUtility.ResolveMSBuildPath();
+            exe.EnvironmentVariables[KuduSyncCommandKey] = KuduSyncCommand;
+            exe.EnvironmentVariables[SelectNodeVersionCommandKey] = SelectNodeVersionCommand;
+            exe.EnvironmentVariables[NpmJsPathKey] = PathUtility.ResolveNpmJsPath();
+
+            // Disable this for now
+            // exe.EnvironmentVariables[NuGetCachePathKey] = Environment.NuGetCachePath;
+
+            // NuGet.exe 1.8 will require an environment variable to make package restore work
+            exe.EnvironmentVariables[WellKnownEnvironmentVariables.NuGetPackageRestoreKey] = "true";
+
+            exe.SetHomePath(_environment.SiteRootPath);
+
+            // Set the path so we can add more variables
+            exe.EnvironmentVariables["PATH"] = System.Environment.GetEnvironmentVariable("PATH");
+
+            // Add the msbuild path and git path to the %PATH% so more tools are available
+            var toolsPaths = new[] {
+                Path.GetDirectoryName(PathUtility.ResolveMSBuildPath()),
+                Path.GetDirectoryName(PathUtility.ResolveGitPath())
+            };
+
+            exe.AddToPath(toolsPaths);
+
+            return exe;
+        }
+
+        private string KuduSyncCommand
+        {
+            get
+            {
+                return Path.Combine(_environment.ScriptPath, "kudusync");
+            }
+        }
+
+        private string SelectNodeVersionCommand
+        {
+            get
+            {
+                return "node \"" + Path.Combine(_environment.ScriptPath, "selectNodeVersion") + "\"";
+            }
+        }
+
+        private string StarterScriptPath
+        {
+            get
+            {
+                return Path.Combine(_environment.ScriptPath, StarterScriptName);
+            }
+        }
+
+        // TODO: Remove this filter once we figure out how to run the msbuild command without getting these warnings
+        internal static bool ShouldFilterOutMsBuildWarnings(string outputLine)
+        {
+            return outputLine.Contains("MSB3644:") || outputLine.Contains("MSB3270:");
+        }
+
+        /// <summary>
+        /// Node spits out some disturbing output to the error stream when running in Azure
+        /// </summary>
+        internal static bool ShouldFilterOutNodeRedundantOutput(string outputLine)
+        {
+            return outputLine.Contains("GetConsoleTitleW:") || outputLine.Contains("SetConsoleTitleW:");
+        }
+    }
+}

--- a/Kudu.Core/Deployment/MsBuildSiteBuilder.cs
+++ b/Kudu.Core/Deployment/MsBuildSiteBuilder.cs
@@ -41,7 +41,7 @@ namespace Kudu.Core.Deployment
 
         public virtual string ExecuteMSBuild(ITracer tracer, string arguments, params object[] args)
         {
-            return _msbuildExe.ExecuteWithProgressWriter(tracer, ExternalCommandBuilder.ShouldFilterOutMsBuildWarnings, _ => false, arguments, args).Item1;
+            return _msbuildExe.ExecuteWithProgressWriter(tracer, ExternalCommandFactory.ShouldFilterOutMsBuildWarnings, _ => false, arguments, args).Item1;
         }
 
         public abstract Task Build(DeploymentContext context);

--- a/Kudu.Core/Infrastructure/Executable.cs
+++ b/Kudu.Core/Infrastructure/Executable.cs
@@ -351,7 +351,7 @@ namespace Kudu.Core.Infrastructure
         }
 #endif
 
-        private Process CreateProcess(string arguments, object[] args)
+        internal Process CreateProcess(string arguments, object[] args)
         {
             var psi = new ProcessStartInfo
             {

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="Commands\CommandExecutor.cs" />
     <Compile Include="Deployment\CascadeLogger.cs" />
+    <Compile Include="Deployment\Generator\ExternalCommandFactory.cs" />
     <Compile Include="Deployment\SiteBuilderFactoryDispatcher.cs" />
     <Compile Include="Deployment\Generator\BasicBuilder.cs" />
     <Compile Include="Deployment\Generator\BaseBasicBuilder.cs" />

--- a/Kudu.FunctionalTests/CommandExecutorTests.cs
+++ b/Kudu.FunctionalTests/CommandExecutorTests.cs
@@ -1,0 +1,114 @@
+﻿using Kudu.Core;
+using Kudu.TestHarness;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kudu.FunctionalTests
+{
+    public class CommandExecutorTests
+    {
+        [Fact]
+        public void CommandExecutorEnvironmentSetCorrectly()
+        {
+            // Arrange
+            string appName = "CommandExecuterEnvironmentSetCorrectly";
+            ApplicationManager.Run(appName, appManager =>
+            {
+                List<CommandTestSettings> tests = new List<CommandTestSettings>();
+
+                var commandTestSettings = new CommandTestSettings("set MSBUILD_PATH");
+                commandTestSettings.ExpectedResult.Output = "msbuild";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("set NONEXISTING");
+                commandTestSettings.ExpectedResult.Error = "NONEXISTING";
+                commandTestSettings.ExpectedResult.ExitCode = 1;
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %DEPLOYMENT_SOURCE%");
+                commandTestSettings.ExpectedResult.Output = "\\";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %DEPLOYMENT_TARGET%");
+                commandTestSettings.ExpectedResult.Output = "\\wwwroot";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %KUDU_SYNC_CMD%");
+                commandTestSettings.ExpectedResult.Output = "\\kudusync";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %KUDU_SELECT_NODE_VERSION_CMD%");
+                commandTestSettings.ExpectedResult.Output = "\\selectNodeVersion";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %NPM_JS_PATH%");
+                commandTestSettings.ExpectedResult.Output = "\\npm";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %PATH%");
+                commandTestSettings.ExpectedResult.Output = "git";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("dir");
+                commandTestSettings.WorkingDirectory = ".\\site";
+                commandTestSettings.ExpectedResult.Output = "wwwroot";
+                tests.Add(commandTestSettings);
+
+                commandTestSettings = new CommandTestSettings("echo %EnableNuGetPackageRestore%");
+                commandTestSettings.ExpectedResult.Output = "true";
+                tests.Add(commandTestSettings);
+
+                foreach (CommandTestSettings test in tests)
+                {
+                    VerifyCommand(test, appManager);
+                }
+            });
+        }
+
+        private void VerifyCommand(CommandTestSettings commandTestSettings, ApplicationManager appManager)
+        {
+            TestTracer.Trace("Running command - '{0}' on '{1}'", commandTestSettings.Command, commandTestSettings.WorkingDirectory);
+            CommandResult commandResult = appManager.CommandExecutor.ExecuteCommand(commandTestSettings.Command, commandTestSettings.WorkingDirectory).Result;
+
+            TestTracer.Trace("Received result\nOutput\n======\n{0}\nError\n======\n{1}\nExit Code - {2}", commandResult.Output, commandResult.Error, commandResult.ExitCode);
+
+            Assert.Equal(commandTestSettings.ExpectedResult.ExitCode, commandResult.ExitCode);
+            AssertOutput(commandTestSettings.ExpectedResult.Error, commandResult.Error);
+            AssertOutput(commandTestSettings.ExpectedResult.Output, commandResult.Output);
+        }
+
+        private void AssertOutput(string expected, string actual)
+        {
+            if (!String.IsNullOrEmpty(expected))
+            {
+                Assert.Contains(expected, actual, StringComparison.InvariantCultureIgnoreCase);
+            }
+            else
+            {
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        class CommandTestSettings
+        {
+            public CommandResult ExpectedResult { get; set; }
+            public string WorkingDirectory { get; set; }
+            public string Command { get; set; }
+
+            public CommandTestSettings(string command)
+            {
+                ExpectedResult = new CommandResult()
+                {
+                    Output = String.Empty,
+                    Error = String.Empty,
+                    ExitCode = 0
+                };
+
+                WorkingDirectory = ".";
+
+                Command = command;
+            }
+        }
+    }
+}

--- a/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
+++ b/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
@@ -78,6 +78,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommandExecutorTests.cs" />
     <Compile Include="DeploymentManagerTests.cs" />
     <Compile Include="DiagnosticsApiFacts.cs" />
     <Compile Include="DropboxTests.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -309,7 +309,7 @@ namespace Kudu.Services.Web.App_Start
                 throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
-            return new CommandExecutor(environment.RootPath);
+            return new CommandExecutor(environment.RootPath, environment, context.Kernel.Get<IDeploymentSettingsManager>());
         }
 
         private static string GetSettingsPath(IEnvironment environment)

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -12,6 +12,7 @@ using Kudu.Client.SourceControl;
 using Kudu.Client.SSHKey;
 using Kudu.Core.Infrastructure;
 using Kudu.SiteManagement;
+using Kudu.Core.Commands;
 
 namespace Kudu.TestHarness
 {
@@ -86,6 +87,12 @@ namespace Kudu.TestHarness
         }
 
         public RemoteVfsManager LiveScmVfsManager
+        {
+            get;
+            private set;
+        }
+
+        public RemoteCommandExecutor CommandExecutor
         {
             get;
             private set;
@@ -321,6 +328,7 @@ namespace Kudu.TestHarness
                 VfsManager = new RemoteVfsManager(site.ServiceUrl + "vfs"),
                 VfsWebRootManager = new RemoteVfsManager(site.ServiceUrl + "vfs/site/wwwroot"),
                 LiveScmVfsManager = new RemoteVfsManager(site.ServiceUrl + "scmvfs"),
+                CommandExecutor = new RemoteCommandExecutor(site.ServiceUrl + "command"),
                 RepositoryManager = repositoryManager,
             };
 


### PR DESCRIPTION
The command executor will now have some more environment settings set by kudu service (yet it'll still be missing some that the deployment script has like the manifests path).
Refactored code in ExternalCommandBuilder for reuse with the CommandExecutor, the refactored code is now in ExternalCommandFactory.
Added tests for the CommandExecutor.
