### PR TITLE
fix #423 reusable payload for retry

### DIFF
--- a/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
+++ b/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
@@ -5,10 +5,16 @@ namespace Kudu.Services.ServiceHookHandlers
 {
     public class DeploymentInfo
     {
+        public DeploymentInfo()
+        {
+            IsReusable = true;
+        }
+
         public RepositoryType RepositoryType { get; set; }
         public string RepositoryUrl { get; set; }
         public string Deployer { get; set; }
-        public ChangeSet TargetChangeset { get; set; } 
+        public ChangeSet TargetChangeset { get; set; }
+        public bool IsReusable { get; set; }
         public IServiceHookHandler Handler { get; set; }
 
         public bool IsValid()

--- a/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
@@ -60,6 +60,7 @@ namespace Kudu.Services.ServiceHookHandlers
                 DeployInfo = payload.ToObject<DropboxDeployInfo>();
                 // This ensure that the fetch handler provides an underlying Git repository.
                 RepositoryType = RepositoryType.Git;
+                IsReusable = false;
             }
 
             public DropboxDeployInfo DeployInfo { get; set; }

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -181,22 +181,24 @@ namespace Kudu.Services
                         if (deploymentInfo.TargetChangeset != null)
                         {
                             // Perform the actual deployment
-                            _deploymentManager.Deploy(repository, deploymentInfo.TargetChangeset.IsTemporary ? null : deploymentInfo.TargetChangeset, deploymentInfo.Deployer, clean: false);
+                            _deploymentManager.Deploy(repository, null, deploymentInfo.Deployer, clean: false);
+                        }
 
-                            if (MarkerFileExists())
+                        if (MarkerFileExists())
+                        {
+                            _tracer.Trace("Pending deployment marker file exists");
+
+                            hasPendingDeployment = DeleteMarkerFile();
+
+                            if (hasPendingDeployment)
                             {
-                                _tracer.Trace("Pending deployment marker file exists");
+                                _tracer.Trace("Deleted marker file");
 
-                                hasPendingDeployment = DeleteMarkerFile();
-
-                                if (hasPendingDeployment)
-                                {
-                                    _tracer.Trace("Deleted marker file");
-                                }
-                                else
-                                {
-                                    _tracer.TraceError("Failed to delete marker file");
-                                }
+                                hasPendingDeployment = deploymentInfo.IsReusable;
+                            }
+                            else
+                            {
+                                _tracer.TraceError("Failed to delete marker file");
                             }
                         }
                     }

--- a/Kudu.TestHarness/LogStreamWaitHandle.cs
+++ b/Kudu.TestHarness/LogStreamWaitHandle.cs
@@ -72,14 +72,20 @@ namespace Kudu.TestHarness
 
         public string WaitNextLine(int millisecs)
         {
-            if (this.sem.WaitOne(millisecs))
+            try
             {
-                lock (lines)
+                if (this.sem.WaitOne(millisecs))
                 {
-                    string result = lines[0];
-                    lines.RemoveAt(0);
-                    return result;
+                    lock (lines)
+                    {
+                        string result = lines[0];
+                        lines.RemoveAt(0);
+                        return result;
+                    }
                 }
+            }
+            catch (ObjectDisposedException)
+            {
             }
 
             return null;


### PR DESCRIPTION
add additional bool on payload to indicate whether it is reusable in retry deployment case.  If not (like in Dropbox), we will not retry.
