### PR TITLE
fix #435 add Kudu Startup trace

### DIFF
--- a/Kudu.Contracts/Tracing/TraceExtensions.cs
+++ b/Kudu.Contracts/Tracing/TraceExtensions.cs
@@ -6,6 +6,8 @@ namespace Kudu.Contracts.Tracing
 {
     public static class TraceExtensions
     {
+        public const string AlwaysTrace = "alwaysTrace";
+
         private static readonly Dictionary<string, string> _empty = new Dictionary<string, string>();
 
         public static IDisposable Step(this ITracer tracer, string message)
@@ -56,7 +58,7 @@ namespace Kudu.Contracts.Tracing
 
         public static bool ShouldTrace(this ITracer tracer, IDictionary<string, string> attributes)
         {
-            return tracer.TraceLevel >= TraceLevel.Verbose || tracer.TraceLevel >= GetTraceLevel(attributes);
+            return tracer.TraceLevel >= TraceLevel.Verbose || tracer.TraceLevel >= GetTraceLevel(attributes) || attributes.ContainsKey(AlwaysTrace);
         }
 
         private static TraceLevel GetTraceLevel(IDictionary<string, string> attributes)

--- a/Kudu.FunctionalTests/GitStabilityTests.cs
+++ b/Kudu.FunctionalTests/GitStabilityTests.cs
@@ -47,5 +47,18 @@ namespace Kudu.FunctionalTests
                 // Assert.NotEqual<TimeSpan>(TimeSpan.Zero, upTime);
             });
         }
+
+        [Fact]
+        public void KuduStartupRequestTest()
+        {
+            ApplicationManager.Run("KuduStartupRequestTest", appManager =>
+            {
+                // read the trace file
+                var traces = appManager.VfsManager.ReadAllText("LogFiles/Git/trace/trace.xml");
+
+                // verify
+                Assert.Contains("Startup Request", traces);
+            });
+        }
     }
 }


### PR DESCRIPTION
This traces the request that startup Kudu.  It is useful from diagnostic to detect if Kudu spin down unexpectedly.
