### PR TITLE
add Exception Filter trace

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -196,6 +196,7 @@ namespace Kudu.Services.Web.App_Start
             var jsonFormatter = new JsonMediaTypeFormatter();
             GlobalConfiguration.Configuration.Formatters.Add(jsonFormatter);
             GlobalConfiguration.Configuration.DependencyResolver = new NinjectWebApiDependencyResolver(kernel);
+            GlobalConfiguration.Configuration.Filters.Add(new TraceExceptionFilterAttribute());
 
             // Git Service
             routes.MapHttpRoute("git-info-refs-root", "info/refs", new { controller = "InfoRefs", action = "Execute" });

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Security\BlockLocalhostModule.cs" />
     <Compile Include="Services\DeploymentEnvironment.cs" />
     <Compile Include="Services\NinjectWebApiDependencyResolver.cs" />
+    <Compile Include="Tracing\TraceExceptionFilterAttribute.cs" />
     <Compile Include="Tracing\TraceModule.cs" />
     <Compile Include="Tracing\TraceServices.cs" />
     <Compile Include="App_Start\NinjectServices.cs" />

--- a/Kudu.Services.Web/Tracing/TraceExceptionFilterAttribute.cs
+++ b/Kudu.Services.Web/Tracing/TraceExceptionFilterAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics;
+using System.Web.Http.Filters;
+using Kudu.Contracts.Tracing;
+
+namespace Kudu.Services.Web.Tracing
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
+    public sealed class TraceExceptionFilterAttribute : ExceptionFilterAttribute
+    {
+        public override void OnException(HttpActionExecutedContext context)
+        {
+            ITracer tracer = TraceServices.CurrentRequestTracer;
+
+            if (tracer == null || tracer.TraceLevel <= TraceLevel.Off)
+            {
+                return;
+            }
+
+            tracer.TraceError(context.Exception);
+        }
+    }
+}


### PR DESCRIPTION
There are two service implementation in Kudu.
1. IHttpHandler
2. APIController

For HttpHandler, the runnaway exception is handled by TraceModule (see onError).   For APIController (this PR), it is handled by TraceExceptionFilter. 
