### PR TITLE
Address issues with HgRepository::FetchWithoutConflict

### DIFF
--- a/Kudu.Core.Test/HgRepositoryFacts.cs
+++ b/Kudu.Core.Test/HgRepositoryFacts.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
+using Kudu.Core.Tracing;
 using Mercurial;
+using Moq;
 using Xunit;
 using Xunit.Extensions;
 
@@ -64,5 +68,48 @@ namespace Kudu.Core.Test
             Assert.Equal(2, changeSetDetail.Deletions);
         }
 
-    }
+        [Fact]
+        public void FetchWithoutConflictsRetriesWithRecoveryIfInitialFetchFails()
+        {
+            // Arrange
+            var executable = new Mock<IExecutable>();
+            executable.Setup(e => e.EnvironmentVariables).Returns(new Dictionary<string, string>());
+            executable.Setup(e => e.Execute(It.IsAny<ITracer>(), "pull {0} --branch {1} --noninteractive", It.IsAny<object[]>()))
+                      .Throws(new CommandLineException("hg.exe", "", "Fetching\r\nabort: abandoned transaction found - run hg recover!\r\n") { ExitCode = 255 })
+                      .Verifiable();
+            executable.Setup(e => e.Execute(It.IsAny<ITracer>(), "recover"))
+                      .Verifiable();
+
+            
+            var hgRepository = new HgRepository(executable.Object, @"x:\some-path", Mock.Of<ITraceFactory>());
+
+            // Act and Assert
+            Assert.Throws<CommandLineException>(() => hgRepository.FetchWithoutConflict("https://some-remote", "external", "default"));
+            executable.Verify(e => e.Execute(It.IsAny<ITracer>(), "pull {0} --branch {1} --noninteractive", It.IsAny<object[]>()), Times.Exactly(2));
+            executable.Verify(e => e.Execute(It.IsAny<ITracer>(), "recover", It.IsAny<object[]>()), Times.Once());
+        }
+
+        [Fact]
+        public void FetchWithoutConflictsDoesNotExecuteRecoverIfFirstAttemptSucceeds()
+        {
+            // Arrange
+            var executable = new Mock<IExecutable>();
+            executable.Setup(e => e.EnvironmentVariables).Returns(new Dictionary<string, string>());
+            executable.Setup(e => e.Execute(It.IsAny<ITracer>(), "pull {0} --branch {1} --noninteractive", It.IsAny<object[]>()))
+                      .Returns(Tuple.Create("foo", "bar"))
+                      .Verifiable();
+            executable.Setup(e => e.Execute(It.IsAny<ITracer>(), "recover"))
+                      .Verifiable();
+
+
+            var hgRepository = new HgRepository(executable.Object, @"x:\some-path", Mock.Of<ITraceFactory>());
+
+            // Act
+            hgRepository.FetchWithoutConflict("https://some-remote", "external", "default");
+
+            // Assert
+            executable.Verify(e => e.Execute(It.IsAny<ITracer>(), "pull {0} --branch {1} --noninteractive", It.IsAny<object[]>()), Times.Once());
+            executable.Verify(e => e.Execute(It.IsAny<ITracer>(), "recover", It.IsAny<object[]>()), Times.Never());
+        }
+   }
 }

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -54,6 +54,7 @@
     <Compile Include="AuthUtilityFacts.cs" />
     <Compile Include="Deployment\DeploymentManagerFacts.cs" />
     <Compile Include="Deployment\WapBuilderFacts.cs" />
+    <Compile Include="HgRepositoryFacts.cs" />
     <Compile Include="Infrastructure\MsBuildSiteBuilderFacts.cs" />
     <Compile Include="Infrastructure\DisposableActionFacts.cs" />
     <Compile Include="Infrastructure\ExecutableExtensionFacts.cs" />

--- a/Kudu.Core/Infrastructure/Executable.cs
+++ b/Kudu.Core/Infrastructure/Executable.cs
@@ -13,7 +13,7 @@ using Kudu.Core.Deployment;
 
 namespace Kudu.Core.Infrastructure
 {
-    internal class Executable
+    internal class Executable : IExecutable
     {
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Method is used, misdiagnosed due to linking of this file")]
         public Executable(string path, string workingDirectory, TimeSpan idleTimeout)

--- a/Kudu.Core/Infrastructure/IExecutable.cs
+++ b/Kudu.Core/Infrastructure/IExecutable.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kudu.Core.Infrastructure
+{
+    public interface IExecutable
+    {
+        string WorkingDirectory { get; }
+
+        string Path { get; }
+
+        IDictionary<string, string> EnvironmentVariables { get; }
+
+        Encoding Encoding { get; set; }
+
+        TimeSpan IdleTimeout { get; }
+
+        void SetHomePath(string homePath);
+
+#if SITEMANAGEMENT
+        Tuple<string, string> Execute(string arguments, params object[] args); 
+#else
+        Tuple<string, string> Execute(Kudu.Contracts.Tracing.ITracer tracer, string arguments, params object[] args);
+#endif
+
+    }
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Deployment\WellKnownEnvironmentVariables.cs" />
     <Compile Include="Infrastructure\CommandLineException.cs" />
     <Compile Include="Infrastructure\ExecutableExtensions.cs" />
+    <Compile Include="Infrastructure\IExecutable.cs" />
     <Compile Include="Infrastructure\ProcessExtensions.cs" />
     <Compile Include="Infrastructure\ProgressWriter.cs" />
     <Compile Include="Infrastructure\DisposableAction.cs" />

--- a/Kudu.SiteManagement/Kudu.SiteManagement.csproj
+++ b/Kudu.SiteManagement/Kudu.SiteManagement.csproj
@@ -42,6 +42,9 @@
     <Compile Include="..\Kudu.Core\Infrastructure\DisposableAction.cs">
       <Link>DisposableAction.cs</Link>
     </Compile>
+    <Compile Include="..\Kudu.Core\Infrastructure\IExecutable.cs">
+      <Link>IExecutable.cs</Link>
+    </Compile>
     <Compile Include="..\Kudu.Core\Infrastructure\Executable.cs">
       <Link>Executable.cs</Link>
     </Compile>


### PR DESCRIPTION
- Ensure recover is called if the repository is in bad state
- Use --non-interactive to prevent hg from prompting

Fixes #483
