### PR TITLE
Updated test to verify that custom deployments work, even for deployment...

### DIFF
--- a/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
+++ b/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
@@ -82,6 +82,8 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+    <EmbeddedResource Include="Vfs\CustomDeploy.cmd" />
+    <EmbeddedResource Include="Vfs\DotDeployment.txt" />
     <None Include="ZippedRepositories\Mvc3Application.zip" />
     <None Include="ZippedRepositories\Mvc3Application_NoSolution.zip" />
   </ItemGroup>

--- a/Kudu.FunctionalTests/Vfs/CustomDeploy.cmd
+++ b/Kudu.FunctionalTests/Vfs/CustomDeploy.cmd
@@ -1,0 +1,79 @@
+@echo off
+
+:: ----------------------
+:: KUDU Deployment Script
+:: ----------------------
+
+:: Prerequisites
+:: -------------
+
+:: Verify node.js installed
+where node 2>nul >nul
+IF %ERRORLEVEL% NEQ 0 (
+  echo Missing node.js executable, please install node.js, if already installed make sure it can be reached from current environment.
+  goto error
+)
+
+:: Setup
+:: -----
+
+setlocal enabledelayedexpansion
+
+SET ARTIFACTS=%~dp0%artifacts
+
+IF NOT DEFINED DEPLOYMENT_SOURCE (
+  SET DEPLOYMENT_SOURCE=%~dp0%.
+)
+
+IF NOT DEFINED DEPLOYMENT_TARGET (
+  SET DEPLOYMENT_TARGET=%ARTIFACTS%\wwwroot
+)
+
+IF NOT DEFINED NEXT_MANIFEST_PATH (
+  SET NEXT_MANIFEST_PATH=%ARTIFACTS%\manifest
+
+  IF NOT DEFINED PREVIOUS_MANIFEST_PATH (
+    SET PREVIOUS_MANIFEST_PATH=%ARTIFACTS%\manifest
+  )
+)
+
+:: Set the target location to a custom value
+SET DEPLOYMENT_TARGET=%DEPLOYMENT_TARGET%\test
+
+IF NOT DEFINED KUDU_SYNC_CMD (
+  :: Install kudu sync
+  echo Installing Kudu Sync
+  call npm install kudusync -g --silent
+  IF !ERRORLEVEL! NEQ 0 goto error
+
+  :: Locally just running "kuduSync" would also work
+  SET KUDU_SYNC_CMD=node "%appdata%\npm\node_modules\kuduSync\bin\kuduSync"
+)
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Deployment
+:: ----------
+
+echo Handling Basic Web Site deployment.
+
+:: 1. KuduSync
+call %KUDU_SYNC_CMD% -v 50 -f "%DEPLOYMENT_SOURCE%" -t "%DEPLOYMENT_TARGET%" -n "%NEXT_MANIFEST_PATH%" -p "%PREVIOUS_MANIFEST_PATH%" -i ".git;.hg;.deployment;deploy.cmd"
+IF !ERRORLEVEL! NEQ 0 goto error
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+goto end
+
+:error
+echo An error has occurred during web site deployment.
+call :exitSetErrorLevel
+call :exitFromFunction 2>nul
+
+:exitSetErrorLevel
+exit /b 1
+
+:exitFromFunction
+()
+
+:end
+echo Finished successfully.

--- a/Kudu.FunctionalTests/Vfs/DotDeployment.txt
+++ b/Kudu.FunctionalTests/Vfs/DotDeployment.txt
@@ -1,0 +1,2 @@
+[config]
+command = ..\CustomDeploy.cmd

--- a/Kudu.FunctionalTests/Vfs/LiveScmEditorControllerTest.cs
+++ b/Kudu.FunctionalTests/Vfs/LiveScmEditorControllerTest.cs
@@ -13,7 +13,7 @@ namespace Kudu.FunctionalTests
 
             ApplicationManager.Run(appName, appManager =>
             {
-                VfsControllerBaseTest suite = new VfsControllerBaseTest(appManager.LiveScmVfsManager, testConflictingUpdates: true, deploymentClient: appManager.LiveScmVfsManager);
+                VfsControllerBaseTest suite = new VfsControllerBaseTest(appManager.LiveScmVfsManager, testConflictingUpdates: true, deploymentClient: appManager.VfsManager);
 
                 // Act + Assert
                 suite.RunIntegrationTest().Wait();


### PR DESCRIPTION
... scripts that sit outside the repository itself.

Also added etag on successful delete requests as that allows a client to keep track of the latest etag when deleting as well as creating/updating content.

Fixed bug where we did not deploy content in case of a merge. A test bug prevented us from discovering it. The test bug has also been fixed.

Lastly, removed an extraneous row in exponential backoff numbers so we are back to 8 instead of 9.
