### PR TITLE
Create a SSH key pair when initializing repositories

### DIFF
--- a/Kudu.Contracts/SSHKey/ISSHKeyManager.cs
+++ b/Kudu.Contracts/SSHKey/ISSHKeyManager.cs
@@ -9,15 +9,15 @@ namespace Kudu.Core.SSHKey
         void SetPrivateKey(string key);
         
         /// <summary>
-        /// Reads an exisiting public key or generates a new key pair and returns it.
+        /// Reads an exisiting public key or generates a new key pair.
         /// </summary>
-        /// <returns></returns>
-        string GetKey();
+        /// <param name="ensurePublicKey">Determines if a public key should be generated if it doesn't already exist</param>
+        string GetPublicKey(bool ensurePublicKey);
         
         /// <summary>
-        /// Create a new key pair overwritting any existing key files on disk.
+        /// Deletes the key pair
         /// </summary>
         /// <returns></returns>
-        string CreateKey();
+        void DeleteKeyPair();
     }
 }

--- a/Kudu.Core.Test/SSHKeyManagerFacts.cs
+++ b/Kudu.Core.Test/SSHKeyManagerFacts.cs
@@ -148,8 +148,10 @@ AP1a+ov5cqO34vONhqb7iikB5o0X8Mm0hua4HlRu
             fileBase.Verify(s => s.WriteAllText(sshPath + @"\id_rsa.pub", publicKey));
         }
 
-        [Fact]
-        public void GetSSHKeyReturnsExistingKeyIfPresentOnDisk()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetSSHKeyReturnsExistingKeyIfPresentOnDisk(bool ensurePublicKey)
         {
             // Arrange
             string sshPath = @"x:\path\.ssh";
@@ -167,14 +169,39 @@ AP1a+ov5cqO34vONhqb7iikB5o0X8Mm0hua4HlRu
             var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
 
             // Act 
-            var actual = sshKeyManager.GetKey();
+            var actual = sshKeyManager.GetPublicKey(ensurePublicKey);
 
             // Assert
             Assert.Equal(expected, actual);
         }
 
         [Fact]
-        public void GetSSHKeyCreatesKeyIfPublicAndPrivateKeyDoesNotAlreadyExist()
+        public void GetSSHKeyNoOpsIfPublicKeyPairIsNotFoundAndEnsurePublicKeyIsNotSet()
+        {
+            // Arrange
+            string sshPath = @"x:\path\.ssh";
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            fileBase.Setup(s => s.Exists(It.IsAny<string>()))
+                    .Returns(false);
+
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
+
+            var environment = new Mock<IEnvironment>();
+            environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
+
+            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+
+            // Act 
+            var actual = sshKeyManager.GetPublicKey(ensurePublicKey: false);
+
+            // Assert
+            fileBase.Verify();
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void GetSSHKeyCreatesKeyIfPublicAndPrivateKeyDoesNotAlreadyExistAndEnsurePublicKeyIsSet()
         {
             // Arrange
             string sshPath = @"x:\path\.ssh";
@@ -199,15 +226,17 @@ AP1a+ov5cqO34vONhqb7iikB5o0X8Mm0hua4HlRu
             var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
 
             // Act 
-            var actual = sshKeyManager.GetKey();
+            var actual = sshKeyManager.GetPublicKey(ensurePublicKey: true);
 
             // Assert
             fileBase.Verify();
             Assert.Equal(keyOnDisk, actual);
         }
 
-        [Fact]
-        public void GetSSHKeyReturnsPublicKeyIfItExists()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetSSHKeyReturnsPublicKeyIfItExists(bool ensurePublicKey)
         {
             // Arrange
             string sshPath = @"x:\path\.ssh";
@@ -227,55 +256,7 @@ AP1a+ov5cqO34vONhqb7iikB5o0X8Mm0hua4HlRu
             var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
 
             // Act 
-            var actual = sshKeyManager.GetKey();
-
-            // Assert
-            Assert.Equal(publicKey, actual);
-        }
-
-        [Fact]
-        public void GetSSHKeyDecodesPublicKeyFromPrivateKeyIfItExists()
-        {
-            // Arrange
-            string sshPath = @"x:\path\.ssh";
-            string privateKey = @"-----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDGpVEX9AjH9sAZvORj6lU8BD8E/VY9nqFtZRlOvItLc4n6ssmZ
-ZN7bvGGij+y5MRSvrI5pRV5LFODTQu/CyLWqx3Wkxxm2OwHwIeSF2eyntbGoZgjL
-SKX0N0IzLqa/xnzQl/S3zBqGinoqVvnBEomnGMjIgQiDFTBa4ykG5LC4fQIDAQAB
-AoGAKaWHNupm3OWSqNK9X2VFsWuCet1SM2EKnxDPGX7WBV+X0gOh2JMZViBMp/Rc
-wQbVO2+F+/QbLMqXyDMEaWYDEAhqBeF2VPKuoHPWyxpiOxYUiqgskB7FH4QWdml2
-eAZp5DGL1f98JMGpb2NVqe2+Dxg92Yf7aKwjlf8OGVrKJVECQQDjDgRuUXpQHsoT
-d1UVk7HIAhWLFEW45l/ueI+OwKvT/HxK9DfIxhrXg5OwvjvbIpO8MisQJuYfwB2O
-7z+FYcz/AkEA3/gqdG19aGYIuKj7Fe38tGGt5S4NEFvR0i2up+5lr9aoTZj9moFI
-CqP+Ojkvvr5n1RSueTX3JQ5rorNmLDEugwJAVxvOmWBK86gMUNGMY/3Iy/n4t+Xs
-JdbEYSIBuXuzsF2CdeMh77YJIDuLktg48IZgdWgt20GBMhcrf+XL0elGkwJBAJVU
-MXpPRj5FSatVf5Ovib37IqabfbpafhtUug7dtI744F5ckzpg2Fe/39GSL3NOIIzB
-rVLD2HSsmLdyRb1RTWECQQDZ20WQgZk43lFZyrl0A4bjaeO9vOtElQ66Hasdur1J
-9OzikqfmQg95sRA6oXENazTTmnTruaK6ZEaEtndujEl7
------END RSA PRIVATE KEY-----
-";
-            var publicKeyParams = new RSAParameters
-            {
-                Exponent = new byte[] { 1, 0, 1 },
-                Modulus = Convert.FromBase64String("xqVRF/QIx/bAGbzkY+pVPAQ/BP1WPZ6hbWUZTryLS3OJ+rLJmWTe27xhoo/suTEUr6yOaUVeSxTg00Lvwsi1qsd1pMcZtjsB8CHkhdnsp7WxqGYIy0il9DdCMy6mv8Z80Jf0t8wahop6Klb5wRKJpxjIyIEIgxUwWuMpBuSwuH0=")
-            };
-            string publicKey = SSHEncoding.GetString(publicKeyParams);
-            var fileBase = new Mock<FileBase>();
-            fileBase.Setup(s => s.Exists(sshPath + "\\id_rsa"))
-                    .Returns(true);
-            fileBase.Setup(s => s.ReadAllText(sshPath + "\\id_rsa"))
-                    .Returns(privateKey);
-
-            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-            fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
-
-            var environment = new Mock<IEnvironment>();
-            environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
-
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
-
-            // Act 
-            var actual = sshKeyManager.GetKey();
+            var actual = sshKeyManager.GetPublicKey(ensurePublicKey);
 
             // Assert
             Assert.Equal(publicKey, actual);
@@ -336,175 +317,6 @@ rVLD2HSsmLdyRb1RTWECQQDZ20WQgZk43lFZyrl0A4bjaeO9vOtElQ66Hasdur1J
 
             // Assert
             Assert.Equal(expected, output);
-        }
-
-
-        public static IEnumerable<object[]> PrivateKey
-        {
-            get
-            {
-                yield return new object[]
-                {
-                    "yhP4LGiDCwMvd/Q+aQz++0RE6swY9aiVNxa+teB/JODRLMaMXHJU4ZLOrx3swBDzyCfQ2p7v/p0MBIWJEwsLU6JRHQLlAsOevpXw0oxSpqe/MQGNCyBdSylD56TZSFs/L5p+B1Or9cU+AG/XMGhOR80KrFYwIVPDZPff7ZOmaBM=",
-                    new byte[] { 1, 0, 1 },
-                    @"-----BEGIN RSA PRIVATE KEY-----
-MIICXgIBAAKBgQDKE/gsaIMLAy939D5pDP77RETqzBj1qJU3Fr614H8k4NEsxoxc
-clThks6vHezAEPPIJ9Danu/+nQwEhYkTCwtTolEdAuUCw56+lfDSjFKmp78xAY0L
-IF1LKUPnpNlIWz8vmn4HU6v1xT4Ab9cwaE5HzQqsVjAhU8Nk99/tk6ZoEwIDAQAB
-AoGBAIzky347CFMfT3N1aiZYl1edy+dhkm2FszQLucCZ3ExcK7vqW2cBmEkG0PCs
-DqwDpdWCXU5wzqhZ200zxdTvOF9CS/GbQ3uYb1A/CxwPN9/FtwNenh0NU0Z2CFgp
-+4QsU83hYGtokYauWKkz3Taz9w8i5uCu4KEBdaloBiJH7fZxAkEA/8eVbuuWbY/S
-LBVZhDqeSbUB+VrG5aNZWGliKZZcbBx9FwdIXS1TI0YaN/S1Z9Sg9QqzBiyLRbhd
-G0FgT/3HTwJBAMpAinwLq9iuRtuom3OShReZ1ireECEh4hOkVUPA9ymR0Nx2mIvz
-2s3OTxgJrvmhWyHI2QVtJhsA5YUzYsCU4f0CQAXAtWmzPsTkETQQntzMfLbnrU2w
-bvzHOcE1TZHl4dpEocOc1FHULSSD9R8BD/tv2tboELK42cENrnpodAQYjx0CQQDK
-KAzDxF62LCxDLpqCwHcrieaZ3nA8zcNNYrqfCGeEM22SjzAW411WzNod6r/sYC3Y
-7QqO8/RclV7U7vHMEIR5AkEAqqC8CgH3XWuBnXc935oGGvtc0hrKctSefnRBv/HI
-n76PtB67TZo31AX3NBvZNenRyYaG8fgPUhsSU/yA6WydLQ==
------END RSA PRIVATE KEY-----
-"
-                };
-
-                yield return new object[] 
-                { 
-                    
-                    "xqVRF/QIx/bAGbzkY+pVPAQ/BP1WPZ6hbWUZTryLS3OJ+rLJmWTe27xhoo/suTEUr6yOaUVeSxTg00Lvwsi1qsd1pMcZtjsB8CHkhdnsp7WxqGYIy0il9DdCMy6mv8Z80Jf0t8wahop6Klb5wRKJpxjIyIEIgxUwWuMpBuSwuH0=",
-                    new byte[] { 1, 0, 1 },
-                    @"-----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDGpVEX9AjH9sAZvORj6lU8BD8E/VY9nqFtZRlOvItLc4n6ssmZ
-ZN7bvGGij+y5MRSvrI5pRV5LFODTQu/CyLWqx3Wkxxm2OwHwIeSF2eyntbGoZgjL
-SKX0N0IzLqa/xnzQl/S3zBqGinoqVvnBEomnGMjIgQiDFTBa4ykG5LC4fQIDAQAB
-AoGAKaWHNupm3OWSqNK9X2VFsWuCet1SM2EKnxDPGX7WBV+X0gOh2JMZViBMp/Rc
-wQbVO2+F+/QbLMqXyDMEaWYDEAhqBeF2VPKuoHPWyxpiOxYUiqgskB7FH4QWdml2
-eAZp5DGL1f98JMGpb2NVqe2+Dxg92Yf7aKwjlf8OGVrKJVECQQDjDgRuUXpQHsoT
-d1UVk7HIAhWLFEW45l/ueI+OwKvT/HxK9DfIxhrXg5OwvjvbIpO8MisQJuYfwB2O
-7z+FYcz/AkEA3/gqdG19aGYIuKj7Fe38tGGt5S4NEFvR0i2up+5lr9aoTZj9moFI
-CqP+Ojkvvr5n1RSueTX3JQ5rorNmLDEugwJAVxvOmWBK86gMUNGMY/3Iy/n4t+Xs
-JdbEYSIBuXuzsF2CdeMh77YJIDuLktg48IZgdWgt20GBMhcrf+XL0elGkwJBAJVU
-MXpPRj5FSatVf5Ovib37IqabfbpafhtUug7dtI744F5ckzpg2Fe/39GSL3NOIIzB
-rVLD2HSsmLdyRb1RTWECQQDZ20WQgZk43lFZyrl0A4bjaeO9vOtElQ66Hasdur1J
-9OzikqfmQg95sRA6oXENazTTmnTruaK6ZEaEtndujEl7
------END RSA PRIVATE KEY-----
-"
-                };
-
-                yield return new object[]
-                {
-                    "wmC8M8FGoMGZMImAy828M2cjlHOvOwAL+1EjnXbMjfU6xNaakuPs5gGmKyU2jeTDKufxyZ2bujM62JTllxePQFqByOXPfF6w2dfqO8SMDa6rb2Fdx2R6APjlwVfRPNR7YR0yfyZ0ysWJkBtRegBm/p8utalIgesC8um+bOYtgdoFD1IMcpp+Mx7HOp47Jfqu9DUzxEqb6lpXWlihTCNqeEpr4hDBlL9nNraSMllxnkWWBExPvTikHtiYSD/MqOeAhVt7eoMPmTISayJoa6ikMD6hbZtA4xoSwhbv3ltONebf3GjLjrm29l+rbmIpU30s1Zzuq2BC0Slv8DRoUAkzx8WsjtCsiD3kqdzKJznz4gjGNBWPE5vqaBDttRJTBrVq0WdBGyXg/rp3YN4gfGFxszlCihUed9YaEEYdMTx+bUZ1uRW9AnTi5u2w4ZDuPDYKMR2Y7oJmXpWXGnzGxDTqUxyMjNf5QFq7IbN+EifXU05Gst9t0GrjHWDGJg/99T4t",
-                    new byte[] { 1, 0, 1},
-                    @"-----BEGIN RSA PRIVATE KEY-----
-MIIG5AIBAAKCAYEAwmC8M8FGoMGZMImAy828M2cjlHOvOwAL+1EjnXbMjfU6xNaa
-kuPs5gGmKyU2jeTDKufxyZ2bujM62JTllxePQFqByOXPfF6w2dfqO8SMDa6rb2Fd
-x2R6APjlwVfRPNR7YR0yfyZ0ysWJkBtRegBm/p8utalIgesC8um+bOYtgdoFD1IM
-cpp+Mx7HOp47Jfqu9DUzxEqb6lpXWlihTCNqeEpr4hDBlL9nNraSMllxnkWWBExP
-vTikHtiYSD/MqOeAhVt7eoMPmTISayJoa6ikMD6hbZtA4xoSwhbv3ltONebf3GjL
-jrm29l+rbmIpU30s1Zzuq2BC0Slv8DRoUAkzx8WsjtCsiD3kqdzKJznz4gjGNBWP
-E5vqaBDttRJTBrVq0WdBGyXg/rp3YN4gfGFxszlCihUed9YaEEYdMTx+bUZ1uRW9
-AnTi5u2w4ZDuPDYKMR2Y7oJmXpWXGnzGxDTqUxyMjNf5QFq7IbN+EifXU05Gst9t
-0GrjHWDGJg/99T4tAgMBAAECggGAaZM5JbM4tV/x4JcOyaN5MUI35Q3gg19HIr2z
-Znd8Ky6jOP6G/nml1lfW9WBE/VTfXJKWlTdxufTRZYmaGjLFr+J407FevOKBlBDe
-PJBIsbXJj7mGwiIk0hpeUGFuWGfgi6LcJouwq+IXEZqE6osFZg73w9uqckY/V8j1
-kRiEZx8P2H5sHGMlYIa7F2+SGNLL7ABpmZgcj3F6OKwjD8O8tJFXf3YybqR3XxRS
-294RBDIvhS4dsVzuZ4KlU7izZJo4E+SQCRiLgIRk2inna2U7Jc766ZfqTJbX6RWP
-k6JUM6/29o6mhQNPEwqybotiW2UhMQWkWq9wjyHE5avQGgAUnoC046sW1It/DJ9a
-zfE13oJ6oellH0qnWiluPHugixQE1V/B/Yrz4TMEm27iHygBmGJgzCs7qxKD0U9J
-pUHG2tKOqp2rQcEUkmeoeUCPICMYdK1o8d5ksg8np7bcLVaO08GIyFdp1E3lkd7t
-K77PcnGFFs2QToot5T3yKfukwp5RAoHBAP2eTI6aLCcqPBcXq5z8j1jvXdEZOH6S
-OTrQvbdyz4D/j+zYXfvqD1c/NEqDu0r/THPDynaFZeLTqbuK5yC2bKsGZ6ZCYS6B
-uxD0GqdGKPulCXC6P9SYrly/8DjVgPYO9gPfNBITkx4ygd0w5RjiI25jWy5Xpzs5
-rh1BfPHlTNeEoVNzsi5SJDUY75tyWT2Gg2HQenSKysi8rufSi2uAEvdi4UP2F3gc
-3fpH+BBJp9jCjgKKIO3hXMVJMOdNC0MqXwKBwQDENAV8Fk7EvL6pxwIKcieTUTcQ
-kEX61NsrLfgXTXgiGlroIW+lq1mPHpW9VEhqEvG9/4ktYH4RGRM4QMAOnRf1Ykw2
-bdOuaL2EjZzKsIk57WFsmCjHg9WDAum1WyJHC4uMObjhvWbYkgsZ2HVA9hSWctIc
-G05Iyurmih0X7v9wdvAQDEQx22oB6uKUcgEgRRVab2XhywdfgcmRouz7p0ML3V2K
-wgy72E1KXmI6+JmBgCGv4fMwE26WJO9uW711uvMCgcBkL8FsX8jrW8rLEIWxiS+T
-YVN9Q2pGzbqf2k/nhQolmk8fr8VIu4h93bDpcqptEPcBkCmNslqyRQz60f9Fs+qv
-kOMnEXfUaFkedF+HDrcn2WUmS9zlPb87UnMx8F12ViinFOg779GhDzCv0R3fO43l
-kIg3gVbFlZ6LXhBeekdlp7YXAlAz7izxcL1Oedh47oc9/54wJZe/vpGVcF21BK35
-Xe1A7JkO0NB7iyyaOo58mTaCGFCzx9/e62/PH2dAjB8CgcEAv7ZpKY+OlfQrhS9c
-kiJrAyqXWIrwpiB4q192jCZ5XTFNZIbPVhzxHMRw4hfJzkQGjHV1b65aYJCU1CGI
-yH69m1raR1DXRxM3I59P9km7PKvzxy2CozjxVttwy3FqM+tXBsScH493P+SsDiwQ
-nlIVWdCF90rDGqOUFYIc3Xb9h8Hf3n5t4B2aHpeJoC0pZoO6UqyI67D72lmyQKjn
-URpli+FYdq4XzTCUjTdeWmrxa7VstTRd8Lr8Ep+yiK4BmVj7AoHBAOB4pm8m98W0
-ANqPyRrKlFg+Yn2ABRBYNAZfKBuAAAWUCoC6SmpGy9hx0V9RdGwyjy7GaRSheOUL
-6+YgsS0zxVesN4pEhG9KQCwW8USo7TVTUOyu0weLGQ2CzPRWe9POkSCXKt07Yyr2
-jEMV3cxf6Sqv6O0fKvrYEH/kXm6ZR2TIZJlbFYZTcJMADvXHRri/fO6H/ytrIIy0
-kmQlyj/15tKa/JW3WNhcR7HtRGWDtpBLFx9JtaTxysnLYNmGmHpoBg==
------END RSA PRIVATE KEY-----
-"
-                };
-
-                yield return new object[] 
-                {
-                    "1YXT32rLPUWv3eDmv/B9ZWDm6LFx+RN+PJSgVga0gyyCNzuEiuRXJYT/rB2XG8KycQ+df//0eYZ2rcUr+HE8UsqUQTCo3oH4L2xReD6uPCpOzrBhzowrokLUyUn4SpPWoO9ikBZaj0GfA5RRQWaQ84rqK0cGCm1tCwmEkAjZkz1Zvjbix9fI+F2WqhMZuIwby+L69jRu8gA4fv2QQRJyTLd3QD/Hci0SggPQfaMheLOgK0b1PqxmZjm7SZNyeNSR5W72GYT/YZUsc3bmp/0OyfPngoFnUqM1Vs08RL3e3mZgz+wIAiNs02JQCPqIuUl7cKjVkbkpvGohMRVWqfAZngKpM58siwBke7N2Ll6dc+hl9S86jSirdA8He4pjq4N1J2THlSETkAyj0mDVtLzQVHh8naG9Nuk67kg3J6lmyLHBXd8HMQ2jFDrOps96tcieOGNykZd0phF653BTvhdZihLgsqCqb5wuSm06AJX3rKWB8VqrE1aK13bTI3V743Oj3nT1uc9Qmd9ghLyaPSqzrL34ls141WQRb3GKIB3pZE6J0I30hwZpGlm/TLWH5Ph3ei2MCRFAdTF76UlXGUzGixqqa3y+ksl92VUoWDZL2yVtV2iqBXfUJjwn2CHMA5aqaenZuO0nnyvFsClnJtpRj110ndAnnZc5OHf8E+ubKVk=",
-                    new byte[] { 1, 0, 1 },
-                    @"-----BEGIN RSA PRIVATE KEY-----
-MIIJKQIBAAKCAgEA1YXT32rLPUWv3eDmv/B9ZWDm6LFx+RN+PJSgVga0gyyCNzuE
-iuRXJYT/rB2XG8KycQ+df//0eYZ2rcUr+HE8UsqUQTCo3oH4L2xReD6uPCpOzrBh
-zowrokLUyUn4SpPWoO9ikBZaj0GfA5RRQWaQ84rqK0cGCm1tCwmEkAjZkz1Zvjbi
-x9fI+F2WqhMZuIwby+L69jRu8gA4fv2QQRJyTLd3QD/Hci0SggPQfaMheLOgK0b1
-PqxmZjm7SZNyeNSR5W72GYT/YZUsc3bmp/0OyfPngoFnUqM1Vs08RL3e3mZgz+wI
-AiNs02JQCPqIuUl7cKjVkbkpvGohMRVWqfAZngKpM58siwBke7N2Ll6dc+hl9S86
-jSirdA8He4pjq4N1J2THlSETkAyj0mDVtLzQVHh8naG9Nuk67kg3J6lmyLHBXd8H
-MQ2jFDrOps96tcieOGNykZd0phF653BTvhdZihLgsqCqb5wuSm06AJX3rKWB8Vqr
-E1aK13bTI3V743Oj3nT1uc9Qmd9ghLyaPSqzrL34ls141WQRb3GKIB3pZE6J0I30
-hwZpGlm/TLWH5Ph3ei2MCRFAdTF76UlXGUzGixqqa3y+ksl92VUoWDZL2yVtV2iq
-BXfUJjwn2CHMA5aqaenZuO0nnyvFsClnJtpRj110ndAnnZc5OHf8E+ubKVkCAwEA
-AQKCAgBkRrdcA1FzcxjGwOpdVdnuFHYc7ciyyt7MIJi0De4UdICq4765Y8cxjaZs
-9HCUzvjyc/zpshDkSavOq/ycbsF/uDer7ehApxUhYGNab0VwaAYet2MXl2ieiXhZ
-F+4NSCTR69qEBJt/D7hX+/21EzAb0C9tJ6vEleNR/aRN6HoV1gghdrFGXSa6zWkG
-cnXv34zmUbC+k51O9Z+StA5dIQag1MCiYdGO42//sz7k4gnEH8emy2o9hsWIWLCG
-O0LVUC88asIU9grhjycTCtIELqoVWgBtn8wgWRmhrD0To3/ZPodU3mpcZrqjA1bH
-ALHZIpNgM0opZ6YcIFN6M6VBpcrBOI3jeNWYMQX69UwkdeOx9xQgh8n54ONyjgVT
-utvDw09ho9jup08FdI5M1c79X/gFRIqYi505QZqYaLaWxbtNfsonrikZLkPBUgkx
-JOMmRclPcaCan6u8xQNylU/dEewPqfFlVRiDazJxmHfQnHNEbHROTPlsMRp2pGM6
-DSUthnj1+xqD1fkU3rrdvYMShNkBSbX32zwxlkWVKnL33VewxXTkZeh6Zkon0TfS
-FFOVQyr4fiXIZNlW0D2UDdSvzp95857epmrLZElfH06SA8//fFCITM1tDNd3wRZ5
-rnC4e7+wxjhXVfK2QK4fyJr3/aIUKrrRwP0E9yoPxupVo6GxIQKCAQEA8je1SUB7
-bHCfzGWsY4o2nZfnjt0qBM08B3hzd7AhEYTggnJbjTpKvstvL9acXkV0dMKbcdVq
-wjLyrQwy9MXs3oxxyWELujeFKRkbcQEO7F8k64WPbDmXbPei/nlMFjlcfm1zICGG
-TDhgZSkbMeP1+Hlc48YClL1uRvUddBCuTHZcnXm14Ui3bL1DYPU/lQEDuo/fHkCB
-+bRiac/WqBkRV5GORA5nFZ0sPtV47JzLOyHEVpSO1Cb/832oLAZCyjDIxiodIlc0
-1HHrIlJ+5HWBKQu0RMrsAzAzKk33cKfiJzCOGvJPzBKEpuA4T/5E/+sxaCp5BGwY
-Q6juhGHUr79bPQKCAQEA4awh7/jtkgE74J4TZ+sZiV6M4wjiBtQXti4VVG5zDAV+
-3kCklxQi9K6r2nHV2oNyCMBncbdqNrxxKBfprHn4zYl5rmdz902NZAhlEvLdABUL
-jxTqFCeS2nnJ4u+irlKWGWPu2ar1n/Xw3GuEFs6nQeE28m42pdVDzOv+USQvplEn
-HMynv/GJUVHJ3SBoRHBIzj+7WdBuizEWranMflnyVmz5HsGkHjTMQfFV69atBZzy
-AAlwZuf0SgRoLdQTlXjTWv+uFA7RskQt32l+EnT1OTdlLeeicdun8LY0jy9rE2pA
-GloqFEXcIBVj9sxF4Dz/LiyLq3yoE3FbKTNNrGsYTQKCAQEA7gbGtSST5Z3Lu15T
-CUKipz3HBULb7voMur6oof7IkGHHCwn8ZA3btCFQs28wHQgeCDvR7AyxLARLLLkn
-Phley9iyXRZsIuQ6jIeqyuMiWjCppHWM2urBnwi/+VkT52cZOPivwOyRAEgKmn7J
-xb5iUnpZSVCl6qs5OqvX9N4LmwJZwzr+/FOsRUS8eQSpJfFoS6bkuOLll5CngZoI
-NQrlWuukJccNkFTzTRAVFFiE8ygcvISi02M79XkPkavZaL6GHw71sHCIbxk/22u8
-XSAH/GEPFudfBUcRkMorll60xJRXoa1rs3yjNSZ00E9sWR40YEwUvr7HHX5eXmOR
-UeA3dQKCAQB9EanpVhtMHLTzoof8wtXvROBt/wFNaYQOqnGVznSiR/Vs9YSCWl2Z
-H6kMsqQjq0+qu/9YjZ8m4L8RylbuCNc0CinO13T0rR1cQC7MFp8WqZMzZBLqwpfn
-zzFtPQP6+rhHMBQyvEXOtj4b2tZk0Xju0QNjzmMo+w3NZ0kV7SkfUsCLfHzHqvRA
-hkSK8af3rgcbj0Sk3Rg2uijobD9yEyV0coaKXiU3vGkrbrYAs4RGpRmVnaWW0pyX
-3ONj6rJD16fDOgpfAWuEEbcep1eAoSM655GCpGpqEaN8i26LoGsGYo9OS4QgoisB
-+Pji0Yk0YnnGPFfX3YlE5UDxj4ZPtTbNAoIBAQDZWp23QY0FuwFeIfBya/bRukDT
-+GVVriOIn4CtNgau7ez7Dzm5JLrkBp0nShL781dDznHIhl5QC4GqJDd+xD/dLMo7
-8VhiNZM9POND6Bfp9eZKED5BwDrl4SfO87fBZAgfJvTIPqDLDUZNEy8enWm2xqch
-RgpHrCFY5Uztt+dRIb7yfuqUdhflr/ME5s2m7t611j2Sv5XM7WordAs+8wyYRFLo
-SbgpyH1fDnyUM835nSfqcWr1vcZq655CLnPOQp6BtguHw8UY7IyM8cEfK6jHclrl
-r1haBjoWUKxtwpjBbR49srwH1JF4nprfuNGq5tquHhF8ssip56i0RsNEilIo
------END RSA PRIVATE KEY-----
-"
-                };
-                
-            }
-        }
-
-        [Theory]
-        [PropertyData("PrivateKey")]
-        public void ExtractPublicKeysExtractsKeysFromPEMEncodedPrivateKey(string expectedModulus, byte[] expectedExponent, string privateKey)
-        {
-            // Act
-            RSAParameters output = PEMEncoding.ExtractPublicKey(privateKey);
-
-            // Assert
-            Assert.Equal(expectedModulus, Convert.ToBase64String(output.Modulus));
-            Assert.Equal(expectedExponent, output.Exponent);
         }
     }
 }

--- a/Kudu.Core/SSHKey/PEMEncoder.cs
+++ b/Kudu.Core/SSHKey/PEMEncoder.cs
@@ -22,46 +22,6 @@ namespace Kudu.Core.SSHKey
 
         private static byte[] zeroAsn1 = new byte[] { 0x00 };
 
-
-        public static RSAParameters ExtractPublicKey(string privateKey)
-        {
-            string pem;
-            if (!TryParsePEM(privateKey, out pem))
-            {
-                throw new FormatException("Unsupported private key format.");
-            }
-
-            byte[] encoding = Convert.FromBase64String(pem);
-
-            using (var mem = new MemoryStream(encoding))
-            {
-
-                int tag = mem.ReadTag();
-                if (tag != (SequenceTag | ConstructedTag))
-                {
-                    throw new ArgumentException("Unexpected tag in PEM!");
-                }
-
-                int length = mem.ReadLength(encoding.Length - (int)mem.Position);
-                if (length != (encoding.Length - (int)mem.Position))
-                {
-                    throw new ArgumentException("Unexpected PEM length!");
-                }
-
-                byte[] version = mem.ReadAsn1(encoding.Length - (int)mem.Position);
-                if (version.Length != zeroAsn1.Length || version[0] != zeroAsn1[0])
-                {
-                    throw new ArgumentException("Unsupported PEM version 0!");
-                }
-
-                return new RSAParameters
-                {
-                    Modulus = FromAsn1(mem.ReadAsn1(encoding.Length - (int)mem.Position)),
-                    Exponent = FromAsn1(mem.ReadAsn1(encoding.Length - (int)mem.Position))
-                };
-            }
-        }
-
         /// <summary>
         /// Get PEM encoding string
         /// </summary>
@@ -144,33 +104,6 @@ namespace Kudu.Core.SSHKey
             return bytes;
         }
 
-        // Convert ASN.1 to RSAParameters (big-endian) 
-        private static byte[] FromAsn1(byte[] bytes)
-        {
-            Debug.Assert(bytes != null && bytes.Length > 0);
-
-            // find the highest bit that is not zero
-            byte highest = 0x00;
-            for (int i = 0; i < bytes.Length; ++i)
-            {
-                if (bytes[i] != 0x00)
-                {
-                    highest = bytes[i];
-                    break;
-                }
-            }
-
-            // pretty much reverse process of ToAsn1
-            if (0x80 == (highest & 0x80))
-            {
-                byte[] temp = new byte[bytes.Length - 1];
-                Array.Copy(bytes, 1, temp, 0, temp.Length);
-                bytes = temp;
-            }
-
-            return bytes;
-        }
-
         private static void WriteLength(this MemoryStream mem, int length)
         {
             if (length > 127)
@@ -199,124 +132,6 @@ namespace Kudu.Core.SSHKey
         private static void WriteTag(this MemoryStream mem, int tag)
         {
             mem.WriteByte((byte)tag);
-        }
-
-        private static int ReadTag(this MemoryStream mem)
-        {
-            return mem.ReadByte();
-        }
-
-        private static bool TryParsePEM(string text, out string pem)
-        {
-            pem = null;
-            using (var reader = new StringReader(text.Trim()))
-            {
-                string line = reader.ReadLine();
-                if (line == null || !line.Trim().Equals(PEMHeader, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-
-                var builder = new StringBuilder();
-                // Read header
-                while ((line = reader.ReadLine()) != null && !String.IsNullOrEmpty(line = line.Trim()) && !line.Equals(PEMFooter, StringComparison.OrdinalIgnoreCase))
-                {
-                    string[] header = line.Split(new string[] { ": " }, StringSplitOptions.None);
-                    if (header.Length == 1)
-                    {
-                        builder.Append(header[0].Trim());
-                        break;
-                    }
-                    else if (header.Length == 2)
-                    {
-                        if (header[0].Trim() == "Proc-Type" && header[1].Trim() == "4,ENCRYPTED")
-                        {
-                            throw new FormatException("Passphrase is not supported!");
-                        }
-                    }
-                    else
-                    {
-                        throw new FormatException("Invalid PEM format!");
-                    }
-                }
-
-                while ((line = reader.ReadLine()) != null && !string.IsNullOrEmpty(line = line.Trim()) && !line.Equals(PEMFooter, StringComparison.OrdinalIgnoreCase))
-                {
-                    builder.Append(line);
-                }
-
-                if (line == null || !line.Equals(PEMFooter, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new FormatException("Missing PEM footer!");
-                }
-
-                pem = builder.ToString();
-                return pem.Length > 0;
-            }
-        }
-
-        private static byte[] ReadAsn1(this MemoryStream mem, int limit)
-        {
-            int tag = mem.ReadTag();
-            if (tag != IntegerTag)
-            {
-                throw new ArgumentException("Invalid Integer tag!");
-            }
-
-            int length = mem.ReadLength(limit);
-            byte[] bytes = new byte[length];
-            mem.Read(bytes, 0, bytes.Length);
-            return bytes;
-        }
-
-        private static int ReadLength(this MemoryStream mem, int limit)
-        {
-            int length = mem.ReadByte();
-            if (length < 0)
-            {
-                throw new ArgumentException("EOF found when length expected");
-            }
-
-            if (length == 0x80)
-            {
-                throw new ArgumentException("Indefinite-length encoding");
-            }
-
-            if (length > 127)
-            {
-                int size = length & 0x7f;
-
-                // Note: The invalid long form "0xff" (see X.690 8.1.3.5c) will be caught here
-                if (size > 4)
-                {
-                    throw new ArgumentException("DER length more than 4 bytes: " + size);
-                }
-
-                length = 0;
-                for (int i = 0; i < size; i++)
-                {
-                    int next = mem.ReadByte();
-
-                    if (next < 0)
-                    {
-                        throw new ArgumentException("EOF found reading length");
-                    }
-
-                    length = (length << 8) + next;
-                }
-
-                if (length < 0)
-                {
-                    throw new ArgumentException("Corrupted stream - negative length found");
-                }
-
-                if (length >= limit)   // after all we must have read at least 1 byte
-                {
-                    throw new ArgumentException("Corrupted stream - out of bounds length found");
-                }
-            }
-
-            return length;
         }
     }
 }

--- a/Kudu.Core/SourceControl/Git/GitExeRepository.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeRepository.cs
@@ -91,6 +91,12 @@ echo $i > pushinfo
 
                     File.WriteAllText(PostReceiveHookPath, content);
                 }
+
+                using (profiler.Step("Configure git server"))
+                {
+                    // Allow getting pushes even though we're not bare
+                    _gitExe.Execute(profiler, "config receive.denyCurrentBranch ignore");
+                }
             }
         }
 

--- a/Kudu.Core/SourceControl/RepositoryFactory.cs
+++ b/Kudu.Core/SourceControl/RepositoryFactory.cs
@@ -75,8 +75,6 @@ namespace Kudu.Core.SourceControl
             if (!repository.Exists)
             {
                 repository.Initialize();
-                // Attempt to create a key pair when creating a repository. This would allow for fetching SSH-based repository urls to work.
-                _sshKeyManager.GetKey();
             }
             return repository;
         }
@@ -84,15 +82,15 @@ namespace Kudu.Core.SourceControl
         public IRepository GetRepository()
         {
             ITracer tracer = _traceFactory.GetTracer();
-            if (IsHgRepository)
-            {
-                tracer.Trace("Found mercurial repository at {0}", _environment.RepositoryPath);
-                return new HgRepository(_environment.RepositoryPath, _environment.SiteRootPath, _settings, _traceFactory);
-            }
-            else if (IsGitRepository)
+            if (IsGitRepository)
             {
                 tracer.Trace("Assuming git repository at {0}", _environment.RepositoryPath);
                 return new GitExeRepository(_environment.RepositoryPath, _environment.SiteRootPath, _settings, _traceFactory);
+            } 
+            else if (IsHgRepository)
+            {
+                tracer.Trace("Found mercurial repository at {0}", _environment.RepositoryPath);
+                return new HgRepository(_environment.RepositoryPath, _environment.SiteRootPath, _settings, _traceFactory);
             }
             return null;
         }

--- a/Kudu.FunctionalTests/DeploymentManagerTests.cs
+++ b/Kudu.FunctionalTests/DeploymentManagerTests.cs
@@ -291,18 +291,15 @@ namespace Kudu.FunctionalTests
                 });
 
                 var resultsTask = appManager.DeploymentManager.GetResultsAsync();
-                var sshKeyTask = appManager.SSHKeyManager.GetPublicKey();
                 var traceTask = KuduAssert.VerifyTraceAsync(appManager, "arguments=\"fetch external --progress\"");
 
-                await Task.WhenAll(resultsTask, sshKeyTask, traceTask);
+                await Task.WhenAll(resultsTask, traceTask);
 
                 var results = resultsTask.Result.ToList();
                 Assert.Equal(1, results.Count);
                 Assert.Equal(DeployStatus.Success, results[0].Status);
                 Assert.Equal("GitHub", results[0].Deployer);
                 KuduAssert.VerifyUrl(appManager.SiteUrl, "Welcome to ASP.NET!");
-
-                Assert.True(sshKeyTask.Result.StartsWith("ssh-rsa"));
             });
         }
 

--- a/Kudu.Services.Test/SSHKeyControllerTests.cs
+++ b/Kudu.Services.Test/SSHKeyControllerTests.cs
@@ -15,7 +15,9 @@ namespace Kudu.Services.Test
             // Arrange
             var sshKeyManager = new Mock<ISSHKeyManager>(MockBehavior.Strict);
             string expected = "public-key";
-            sshKeyManager.Setup(s => s.GetKey()).Returns(expected).Verifiable();
+            sshKeyManager.Setup(s => s.GetPublicKey(false))
+                         .Returns(expected)
+                         .Verifiable();
             var tracer = Mock.Of<ITracer>();
             var operationLock = new Mock<IOperationLock>();
             operationLock.Setup(l => l.Lock()).Returns(true);
@@ -35,14 +37,16 @@ namespace Kudu.Services.Test
             // Arrange
             var sshKeyManager = new Mock<ISSHKeyManager>(MockBehavior.Strict);
             string expected = "public-key";
-            sshKeyManager.Setup(s => s.CreateKey()).Returns(expected).Verifiable();
+            sshKeyManager.Setup(s => s.GetPublicKey(true))
+                         .Returns(expected)
+                         .Verifiable();
             var tracer = Mock.Of<ITracer>();
             var operationLock = new Mock<IOperationLock>();
             operationLock.Setup(l => l.Lock()).Returns(true);
             var controller = new SSHKeyController(tracer, sshKeyManager.Object, operationLock.Object);
 
             // Act
-            string actual = controller.GetPublicKey(forceCreate: true);
+            string actual = controller.GetPublicKey(ensurePublicKey: true);
 
             // Assert
             sshKeyManager.Verify();

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -182,6 +182,7 @@ namespace Kudu.Services.Web.App_Start
                                                                            environment.SiteRootPath,
                                                                            initLock,
                                                                            GetRequestTraceFile(context.Kernel),
+                                                                           context.Kernel.Get<IRepositoryFactory>(),
                                                                            context.Kernel.Get<IDeploymentEnvironment>(),
                                                                            context.Kernel.Get<IDeploymentSettingsManager>(),
                                                                            context.Kernel.Get<ITraceFactory>()))
@@ -268,6 +269,7 @@ namespace Kudu.Services.Web.App_Start
             // SSHKey
             routes.MapHttpRoute("get-sshkey", "sshkey", new { controller = "SSHKey", action = "GetPublicKey" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("put-sshkey", "sshkey", new { controller = "SSHKey", action = "SetPrivateKey" }, new { verb = new HttpMethodConstraint("PUT") });
+            routes.MapHttpRoute("delete-sshkey", "sshkey", new { controller = "SSHKey", action = "DeleteKeyPair" }, new { verb = new HttpMethodConstraint("DELETE") });
 
             // Environment
             routes.MapHttpRoute("get-env", "environment", new { controller = "Environment", action = "Get" }, new { verb = new HttpMethodConstraint("GET") });

--- a/Kudu.Services/SSHKey/SSHKeyController.cs
+++ b/Kudu.Services/SSHKey/SSHKeyController.cs
@@ -80,7 +80,7 @@ namespace Kudu.Services.SSHKey
             }
         }
 
-        public string GetPublicKey(bool forceCreate = false)
+        public string GetPublicKey(bool ensurePublicKey = false)
         {
             using (_tracer.Step("SSHKeyController.GetPublicKey"))
             {
@@ -89,7 +89,7 @@ namespace Kudu.Services.SSHKey
                 {
                     try
                     {
-                        key = forceCreate ? _sshKeyManager.CreateKey() : _sshKeyManager.GetKey();
+                        key = _sshKeyManager.GetPublicKey(ensurePublicKey) ?? String.Empty;
                     }
                     catch (InvalidOperationException ex)
                     {
@@ -105,6 +105,32 @@ namespace Kudu.Services.SSHKey
                 }
 
                 return key;
+            }
+        }
+
+        [HttpDelete]
+        public void DeleteKeyPair()
+        {
+            using (_tracer.Step("SSHKeyController.GetPublicKey"))
+            {
+                bool success = _sshKeyLock.TryLockOperation(() =>
+                {
+                    try
+                    {
+                        _sshKeyManager.DeleteKeyPair();
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.Conflict, ex));
+                    }
+                }, TimeSpan.FromSeconds(LockTimeoutSecs));
+
+                if (!success)
+                {
+                    throw new HttpResponseException(Request.CreateErrorResponse(
+                        HttpStatusCode.Conflict,
+                        String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, LockTimeoutSecs)));
+                }
             }
         }
 


### PR DESCRIPTION
- Updated SSHKeyManager to allow multiple invocation of SetPrivateKey
- Extract public key from private key when invoked
- Support back compat by extracting public key from private key when
  GetKey is invoked

Fixes #408
