### PR TITLE
fix multiple traces related issues

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -12,6 +12,7 @@ namespace Kudu
         public const string InitLockFile = "init.lock";
         public const string SSHKeyLockFile = "sshkey.lock";
         public const string SSHKeyPath = ".ssh";
+        public const string TraceLockFile = "trace.lock";
         public const string NpmDebugLogFile = "npm-debug.log";
 
         public const string DeploymentCachePath = "deployments";

--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -116,7 +116,9 @@ namespace Kudu.Console
         {
             if (level > TraceLevel.Off)
             {
-                var tracer = new Tracer(Path.Combine(env.TracePath, Constants.TraceFile), level);
+                string traceLockPath = Path.Combine(env.TracePath, Constants.TraceLockFile);
+                var traceLock = new LockFile(NullTracerFactory.Instance, traceLockPath);
+                var tracer = new Tracer(Path.Combine(env.TracePath, Constants.TraceFile), level, traceLock);
                 string logFile = System.Environment.GetEnvironmentVariable(Constants.TraceFileEnvKey);
                 if (!String.IsNullOrEmpty(logFile))
                 {

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PurgeDeploymentsTests.cs" />
     <Compile Include="SSHKeyManagerFacts.cs" />
+    <Compile Include="TracerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kudu.Contracts\Kudu.Contracts.csproj">

--- a/Kudu.Core.Test/TracerTests.cs
+++ b/Kudu.Core.Test/TracerTests.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Kudu.Core.Tracing;
+using Moq;
+using Xunit;
+using Xunit.Extensions;
+
+using MockOperationLock = Kudu.Core.Test.OperationLockTests.MockOperationLock;
+
+namespace Kudu.Core.Test
+{
+    public class TracerTests
+    {
+        [Fact]
+        public void TracerMaxLogEntriesTest()
+        {
+            // Mock
+            var path = @"x:\git\trace\trace.xml";
+            var fs = GetMockFileSystem();
+            var traceLock = new MockOperationLock();
+            var tracer = new Tracer(fs, path, TraceLevel.Verbose, traceLock);
+            var threads = 5;
+            var tasks = new List<Task>(threads);
+            var total = 0;
+
+            // Test writing 5*50 traces which > 200 limits
+            // also test concurrency and locking with multiple threads
+            for (int i = 0; i < threads; i++)
+            {
+                tasks.Add(Task.Factory.StartNew(() =>
+                {
+                    for (int j = 0; j < 50; ++j)
+                    {
+                        tracer.Trace(Guid.NewGuid().ToString(), new Dictionary<string, string>());
+                        Interlocked.Increment(ref total);
+                    }
+                }));
+            }
+
+            Task.WaitAll(tasks.ToArray());
+
+            XDocument document = ReadTraceFile(fs, path);
+
+            // Assert
+            Assert.True(total > Tracer.MaxLogEntries);
+            Assert.Equal(Tracer.MaxLogEntries, document.Root.Elements().Count());
+        }
+
+        [Theory]
+        [PropertyData("Requests")]
+        public void TracerRequestsTest(TraceLevel traceLevel, RequestInfo[] requests)
+        {
+            // Mock
+            var path = @"x:\git\trace\trace.xml";
+            var fs = GetMockFileSystem();
+            var traceLock = new MockOperationLock();
+            var tracer = new Tracer(fs, path, traceLevel, traceLock);
+
+            // Test
+            IntializeTraceFile(fs, path);
+
+            foreach (var request in requests)
+            {
+                Dictionary<string, string> attribs = new Dictionary<string, string>
+                {
+                    { "url", request.Url },
+                    { "statusCode", ((int)request.StatusCode).ToString() },
+                };
+
+                using (tracer.Step("Incoming Request", attribs))
+                {
+                    tracer.Trace("Outgoing response", attribs);
+                }
+            }
+
+            XDocument document = ReadTraceFile(fs, path);
+            IEnumerable<RequestInfo> traces = document.Root.Elements().Select(e => new RequestInfo { Url = e.Attribute("url").Value });
+
+            // Assert
+            Assert.Equal(requests.Where(r => r.Traced), traces, RequestInfoComparer.Instance);
+        }
+
+        public static IEnumerable<object[]> Requests
+        {
+            get
+            {
+                // Trace level is Off, expect no traces regardless of status
+                yield return new object[] { TraceLevel.Off, new[]
+                {
+                    new RequestInfo { Url = "/any1", Traced = false },
+                    new RequestInfo { Url = "/any2", StatusCode = HttpStatusCode.BadRequest, Traced = false },
+                }};
+
+                // Trace level is Verbose, expect all traces
+                yield return new object[] { TraceLevel.Verbose, new[]
+                {
+                    new RequestInfo { Url = "/any1" },
+                    new RequestInfo { Url = "/deployments?a=1" },
+                    new RequestInfo { Url = "/any2" },
+                    new RequestInfo { Url = "/deployments?a=2", StatusCode = HttpStatusCode.NotModified },
+                }};
+
+                // Trace level is Error, expect all traces except /deployments NotModified
+                yield return new object[] { TraceLevel.Error, new[]
+                {
+                    new RequestInfo { Url = "/any1" },
+                    new RequestInfo { Url = "/deployments?a=1" },
+                    new RequestInfo { Url = "/any2" },
+                    new RequestInfo { Url = "/deployments?a=2", StatusCode = HttpStatusCode.NotModified, Traced = false },
+                    new RequestInfo { Url = "/vfs/any3", StatusCode = HttpStatusCode.NotModified },
+                }};
+            }
+        }
+
+        private void IntializeTraceFile(IFileSystem fs, string path)
+        {
+            using (var writer = new StreamWriter(fs.File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Read)))
+            {
+                writer.WriteLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                writer.WriteLine("<trace/>");
+            }
+        }
+
+        private XDocument ReadTraceFile(IFileSystem fs, string path)
+        {
+            using (var stream = fs.File.OpenRead(path))
+            {
+                return XDocument.Load(stream);
+            }
+        }
+
+        private IFileSystem GetMockFileSystem()
+        {
+            var files = new Dictionary<string, MemoryStream>();
+            var fs = new Mock<IFileSystem>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var dirInfoBase = new Mock<DirectoryInfoBase>(MockBehavior.Strict);
+
+            // Setup
+            fs.Setup(f => f.File)
+              .Returns(fileBase.Object);
+            fs.Setup(f => f.Directory)
+              .Returns(dirBase.Object);
+
+            fileBase.Setup(f => f.Exists(It.IsAny<string>()))
+                    .Returns((string path) => files.ContainsKey(path));
+            fileBase.Setup(f => f.Open(It.IsAny<string>(), FileMode.Create, FileAccess.Write, FileShare.Read))
+                    .Returns((string path, FileMode fileMode, FileAccess fileAccess, FileShare fileShare) =>
+                    {
+                        var stream = MockMemoryStream();
+                        files[path] = stream;
+                        return stream;
+                    });
+            fileBase.Setup(f => f.OpenRead(It.IsAny<string>()))
+                    .Returns((string path) =>
+                    {
+                        MemoryStream stream = files[path];
+                        stream.Position = 0;
+                        return stream;
+                    });
+
+            dirBase.Setup(d => d.CreateDirectory(It.IsAny<string>()))
+                   .Returns(dirInfoBase.Object);
+
+            return fs.Object;
+        }
+
+        private MemoryStream MockMemoryStream()
+        {
+            // Override Close with no-op
+            var stream = new Mock<MemoryStream> { CallBase = true };
+            stream.Setup(s => s.Close());
+            return stream.Object;
+        }
+
+        public class RequestInfo
+        {
+            public RequestInfo()
+            {
+                StatusCode = HttpStatusCode.OK;
+                Traced = true;
+            }
+
+            public string Url { get; set; }
+            public HttpStatusCode StatusCode { get; set; }
+            public bool Traced { get; set; }
+        }
+
+        public class RequestInfoComparer : IEqualityComparer<RequestInfo>
+        {
+            public static RequestInfoComparer Instance = new RequestInfoComparer();
+
+            public bool Equals(RequestInfo x, RequestInfo y)
+            {
+                return x.Url == y.Url;
+            }
+
+            public int GetHashCode(RequestInfo obj)
+            {
+                return obj.Url.GetHashCode();
+            }
+        }
+    }
+}

--- a/Kudu.Core/Tracing/Tracer.cs
+++ b/Kudu.Core/Tracing/Tracer.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Xml.Linq;
+using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 
@@ -14,7 +15,7 @@ namespace Kudu.Core.Tracing
     public class Tracer : ITracer
     {
         // TODO: Make this configurable
-        private const int MaxLogEntries = 200;
+        public const int MaxLogEntries = 200;
 
         private readonly Stack<TraceStep> _currentSteps = new Stack<TraceStep>();
         private readonly List<TraceStep> _steps = new List<TraceStep>();
@@ -23,27 +24,22 @@ namespace Kudu.Core.Tracing
         private readonly string _path;
         private readonly IFileSystem _fileSystem;
         private readonly TraceLevel _level;
+        private readonly IOperationLock _traceLock;
 
         private const string TraceRoot = "trace";
 
-        private static readonly ConcurrentDictionary<string, object> _pathLocks = new ConcurrentDictionary<string, object>();
-
-        public Tracer(string path, TraceLevel level)
-            : this(new FileSystem(), path, level)
+        public Tracer(string path, TraceLevel level, IOperationLock traceLock)
+            : this(new FileSystem(), path, level, traceLock)
         {
 
         }
 
-        public Tracer(IFileSystem fileSystem, string path, TraceLevel level)
+        public Tracer(IFileSystem fileSystem, string path, TraceLevel level, IOperationLock traceLock)
         {
             _fileSystem = fileSystem;
             _path = path;
             _level = level;
-
-            if (!_pathLocks.ContainsKey(path))
-            {
-                _pathLocks.TryAdd(path, new object());
-            }
+            _traceLock = traceLock;
         }
 
         public TraceLevel TraceLevel
@@ -61,7 +57,6 @@ namespace Kudu.Core.Tracing
 
         public IDisposable Step(string title, IDictionary<string, string> attributes)
         {
-            var shouldTrace = this.ShouldTrace(attributes);
             var newStep = new TraceStep(title);
             var newStepElement = new XElement("step", new XAttribute("title", title),
                                                       new XAttribute("date", DateTime.UtcNow.ToString("MM/dd H:mm:ss")));
@@ -100,26 +95,26 @@ namespace Kudu.Core.Tracing
                     TraceStep current = _currentSteps.Pop();
                     XElement stepElement = _elements.Pop();
 
-                    if (shouldTrace || stepElement.HasElements)
-                    {
-                        stepElement.Add(new XAttribute("elapsed", current.ElapsedMilliseconds));
+                    stepElement.Add(new XAttribute("elapsed", current.ElapsedMilliseconds));
 
-                        if (_elements.Count > 0)
-                        {
-                            XElement parent = _elements.Peek();
-                            parent.Add(stepElement);
-                        }
-                        else
+                    if (_elements.Count > 0)
+                    {
+                        XElement parent = _elements.Peek();
+                        parent.Add(stepElement);
+                    }
+                    else
+                    {
+                        if (ShouldTrace(attributes, stepElement.LastNode as XElement))
                         {
                             // Add this element to the list
                             Save(stepElement);
                         }
+                    }
 
-                        if (_currentSteps.Count > 0)
-                        {
-                            TraceStep parent = _currentSteps.Peek();
-                            parent.Children.Add(current);
-                        }
+                    if (_currentSteps.Count > 0)
+                    {
+                        TraceStep parent = _currentSteps.Peek();
+                        parent.Children.Add(current);
                     }
                 }
                 catch (Exception ex)
@@ -129,9 +124,42 @@ namespace Kudu.Core.Tracing
             });
         }
 
+        private bool ShouldTrace(IDictionary<string, string> attributes, XElement element)
+        {
+            // if traceLevel is off, never trace anything
+            // we should not be here in the first place
+            if (this.TraceLevel <= TraceLevel.Off)
+            {
+                return false;
+            }
+
+            // if traceLevel is verbose or no last child, always trace
+            // No last child indicates this is not a request-related trace
+            if (this.TraceLevel >= TraceLevel.Verbose || element == null)
+            {
+                return true;
+            }
+
+            // trace any request which url is not /deployments
+            string url;
+            if (!attributes.TryGetValue("url", out url) || !url.StartsWith("/deployments", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // for /deployments, only trace if not NotModified
+            var statusCode = element.Attributes("statusCode").FirstOrDefault();
+            if (statusCode == null || statusCode.Value != "304")
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private void Save(XElement stepElement)
         {
-            lock (_pathLocks[_path])
+            _traceLock.LockOperation(() =>
             {
                 XDocument document = GetDocument();
 
@@ -139,17 +167,17 @@ namespace Kudu.Core.Tracing
                 EnsureSize(document);
 
                 document.Root.Add(stepElement);
-                document.Save(_path);
-            }
+
+                using (var stream = _fileSystem.File.Open(_path, FileMode.Create, FileAccess.Write, FileShare.Read))
+                {
+                    document.Save(stream);
+                }
+
+            }, TimeSpan.FromMinutes(1));
         }
 
         public void Trace(string value, IDictionary<string, string> attributes)
         {
-            if (!this.ShouldTrace(attributes))
-            {
-                return;
-            }
-
             // Add a fake step
             using (Step(value, attributes)) { }
         }

--- a/Kudu.Services.Web/Tracing/TraceServices.cs
+++ b/Kudu.Services.Web/Tracing/TraceServices.cs
@@ -54,6 +54,13 @@ namespace Kudu.Services.Web.Tracing
             return httpContext.Items[_traceKey] as ITracer;
         }
 
+        internal static void RemoveRequestTracer(HttpContext httpContext)
+        {
+            httpContext.Items.Remove(_traceKey);
+            httpContext.Items.Remove(_loggerKey);
+            httpContext.Items.Remove(_traceFileKey);
+        }
+
         internal static ITracer CreateRequestTracer(HttpContext httpContext)
         {
             var tracer = (ITracer)httpContext.Items[_traceKey];


### PR DESCRIPTION
See each issue for details.
#498 Trace when Kudu is stopped
#497 Dump %SCMXXX% env during startup Trace
#496 Write a unit test to ensure 200 limit in Trace.xml
#495 Trace.xml should always trace all explicit user event regardless of Error/Info/Warning.
#493 Proper lock the operation when writing to trace XML
