### PR TITLE
fix multiple deployment due to Bitbucket retry

### DIFF
--- a/Kudu.Contracts/Deployment/IDeploymentManager.cs
+++ b/Kudu.Contracts/Deployment/IDeploymentManager.cs
@@ -25,7 +25,7 @@ namespace Kudu.Core.Deployment
         /// </summary>
         /// <param name="statusText"></param>
         /// <returns></returns>
-        IDisposable CreateTemporaryDeployment(string statusText, ChangeSet changeset = null, string deployedBy = null);
+        IDisposable CreateTemporaryDeployment(string statusText, out ChangeSet tempChangeSet, ChangeSet changeset = null, string deployedBy = null);
 
         ILogger GetLogger(string id);
     }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -235,7 +235,7 @@ namespace Kudu.Core.Deployment
             }
         }
 
-        public IDisposable CreateTemporaryDeployment(string statusText, ChangeSet changeSet = null, string deployedBy = null)
+        public IDisposable CreateTemporaryDeployment(string statusText, out ChangeSet tempChangeSet, ChangeSet changeSet = null, string deployedBy = null)
         {
             var tracer = _traceFactory.GetTracer();
             using (tracer.Step("Creating temporary deployment"))
@@ -252,6 +252,8 @@ namespace Kudu.Core.Deployment
                 statusFile.IsTemporary = changeSet.IsTemporary;
                 statusFile.Save();
             }
+
+            tempChangeSet = changeSet;
 
             // Return a handle that deletes the deployment on dispose.
             return new DisposableAction(() =>

--- a/Kudu.Core/Deployment/DeploymentStatusFileExtensions.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusFileExtensions.cs
@@ -46,8 +46,15 @@ namespace Kudu.Core.Deployment
         {
             try
             {
-                statusFile.Progress = progress;
-                statusFile.Save();
+                // it is unexpected to UpdateProgress while not in Pending/Deploying/Building state
+                // instead of throwing, we simply make it more robust by checking status
+                if (statusFile.Status == DeployStatus.Pending ||
+                    statusFile.Status == DeployStatus.Deploying ||
+                    statusFile.Status == DeployStatus.Building)
+                {
+                    statusFile.Progress = progress;
+                    statusFile.Save();
+                }
             }
             catch
             {

--- a/Kudu.Core/Deployment/DeploymentStatusManager.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusManager.cs
@@ -43,6 +43,16 @@ namespace Kudu.Core.Deployment
             _statusLock.LockOperation(() =>
             {
                 FileSystemHelpers.DeleteDirectorySafe(path, ignoreErrors: true);
+
+                // Used for ETAG
+                if (_fileSystem.File.Exists(_activeFile))
+                {
+                    _fileSystem.File.SetLastWriteTimeUtc(_activeFile, DateTime.UtcNow);
+                }
+                else
+                {
+                    _fileSystem.File.WriteAllText(_activeFile, String.Empty);
+                }
             }, LockTimeout);
         }
 

--- a/Kudu.Services/GitServer/ReceivePackHandler.cs
+++ b/Kudu.Services/GitServer/ReceivePackHandler.cs
@@ -77,7 +77,8 @@ namespace Kudu.Services.GitServer
                     context.Response.ContentType = "application/x-git-receive-pack-result";
 
                     // This temporary deployment is for ui purposes only, it will always be deleted via finally.
-                    using (DeploymentManager.CreateTemporaryDeployment(Resources.ReceivingChanges))
+                    ChangeSet tempChangeSet;
+                    using (DeploymentManager.CreateTemporaryDeployment(Resources.ReceivingChanges, out tempChangeSet))
                     {
                         GitServer.Receive(context.Request.GetInputStream(), context.Response.OutputStream);
                     }

--- a/Kudu.Services/ServiceHookHandlers/BitbucketHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/BitbucketHandler.cs
@@ -43,7 +43,7 @@ namespace Kudu.Services.ServiceHookHandlers
                 return null;
             }
 
-            var info = new DeploymentInfo();
+            var info = new DeploymentInfo { IsContinuous = true };
             string server = payload.Value<string>("canon_url");     // e.g. https://bitbucket.org
             string path = repository.Value<string>("absolute_url"); // e.g. /davidebbo/testrepo/
             string scm = repository.Value<string>("scm"); // e.g. hg
@@ -77,8 +77,6 @@ namespace Kudu.Services.ServiceHookHandlers
                     info.RepositoryUrl = uri.ToString();
                 }
             }
-
-            // Identity the latest commit 
 
             return info;
         }

--- a/Kudu.Services/ServiceHookHandlers/CodePlexHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/CodePlexHandler.cs
@@ -26,6 +26,7 @@ namespace Kudu.Services.ServiceHookHandlers
             {
                 RepositoryUrl = payload.Value<string>("url"),
                 Deployer = "CodePlex",
+                IsContinuous = true,
                 TargetChangeset = new ChangeSet(newRef, authorName: null, authorEmail: null, message: null, timestamp: DateTimeOffset.Now)
             };
 

--- a/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
+++ b/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
@@ -15,6 +15,8 @@ namespace Kudu.Services.ServiceHookHandlers
         public string Deployer { get; set; }
         public ChangeSet TargetChangeset { get; set; }
         public bool IsReusable { get; set; }
+        // indicating that this is a CI triggered by SCM provider 
+        public bool IsContinuous { get; set; }
         public IServiceHookHandler Handler { get; set; }
 
         public bool IsValid()

--- a/Kudu.Services/ServiceHookHandlers/GitDeploymentInfo.cs
+++ b/Kudu.Services/ServiceHookHandlers/GitDeploymentInfo.cs
@@ -3,6 +3,11 @@ namespace Kudu.Services.ServiceHookHandlers
 {
     public class GitDeploymentInfo : DeploymentInfo
     {
+        public GitDeploymentInfo()
+        {
+            IsContinuous = true;
+        }
+
         public string NewRef { get; set; }
     }
 }

--- a/Kudu.Services/ServiceHookHandlers/KilnHgHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/KilnHgHandler.cs
@@ -104,6 +104,7 @@ namespace Kudu.Services.ServiceHookHandlers
                 Deployer = "Kiln",
                 RepositoryUrl = repository.Value<string>("url"),
                 RepositoryType = RepositoryType.Mercurial,
+                IsContinuous = true,
                 TargetChangeset = new ChangeSet(
                     id: targetCommit.Value<string>("id"),
                     authorName: ParseNameFromAuthor(author),


### PR DESCRIPTION
Fix issues below.   See detail in each issue how we fix it.
#505 Fix condition that leaves some deployment with the string 'Fetching changes'
#501 Second deployment happens when /deploy is called from Bitbucket
