### PR TITLE
Removed extra last modified check on files about to be read/written as l...

### DIFF
--- a/Kudu.Services/Editor/VfsController.cs
+++ b/Kudu.Services/Editor/VfsController.cs
@@ -44,7 +44,7 @@ namespace Kudu.Services.Editor
             Stream fileStream = null;
             try
             {
-                fileStream = GetFileReadStream(localFilePath, validate: info);
+                fileStream = GetFileReadStream(localFilePath);
                 MediaTypeHeaderValue mediaType = MediaTypeMap.GetMediaType(info.Extension);
                 HttpResponseMessage successFileResponse = Request.CreateResponse(isRangeRequest ? HttpStatusCode.PartialContent : HttpStatusCode.OK);
 
@@ -126,7 +126,7 @@ namespace Kudu.Services.Editor
             Stream fileStream = null;
             try
             {
-                fileStream = GetFileWriteStream(localFilePath, fileExists: itemExists, validate: info);
+                fileStream = GetFileWriteStream(localFilePath, fileExists: itemExists);
                 return Request.Content.CopyToAsync(fileStream)
                     .Then(() =>
                     {

--- a/Kudu.Services/Infrastructure/VfsControllerBase.cs
+++ b/Kudu.Services/Infrastructure/VfsControllerBase.cs
@@ -191,7 +191,7 @@ namespace Kudu.Services.Infrastructure
             Stream fileStream = null;
             try
             {
-                fileStream = GetFileDeleteStream(localFilePath, validate: info);
+                fileStream = GetFileDeleteStream(localFilePath);
                 File.Delete(localFilePath);
                 HttpResponseMessage successResponse = Request.CreateResponse(HttpStatusCode.OK);
                 return Task.FromResult(successResponse);
@@ -240,13 +240,9 @@ namespace Kudu.Services.Infrastructure
         }
 
         /// <summary>
-        /// Provides a common way for opening a file stream for shared reading from a file. In addition,
-        /// if <paramref name="validate"/> is passed then validate that the file has not changed since the 
-        /// <see cref="FileSystemInfo"/> was obtained. This check can prevent a class of race conditions where
-        /// another request comes in and changes the file between when the <see cref="FileSystemInfo"/> was
-        /// obtained and the file opened exclusively.
+        /// Provides a common way for opening a file stream for shared reading from a file.
         /// </summary>
-        protected static Stream GetFileReadStream(string localFilePath, FileSystemInfo validate = null)
+        protected static Stream GetFileReadStream(string localFilePath)
         {
             Contract.Assert(localFilePath != null);
 
@@ -255,13 +251,9 @@ namespace Kudu.Services.Infrastructure
         }
 
         /// <summary>
-        /// Provides a common way for opening a file stream for writing exclusively to a file. In addition,
-        /// if <paramref name="validate"/> is passed then validate that the file has not changed since the 
-        /// <see cref="FileSystemInfo"/> was obtained. This check can prevent a class of race conditions where
-        /// another request comes in and changes the file between when the <see cref="FileSystemInfo"/> was
-        /// obtained and the file opened exclusively.
+        /// Provides a common way for opening a file stream for writing exclusively to a file. 
         /// </summary>
-        protected static Stream GetFileWriteStream(string localFilePath, bool fileExists, FileSystemInfo validate = null)
+        protected static Stream GetFileWriteStream(string localFilePath, bool fileExists)
         {
             Contract.Assert(localFilePath != null);
 
@@ -276,12 +268,9 @@ namespace Kudu.Services.Infrastructure
         }
 
         /// <summary>
-        /// Provides a common way for opening a file stream for exclusively deleting the file. While 
-        /// creating a stream may seem like a strange way to preparing a file for deletion, it allows us 
-        /// to conclusively verify that a file hasn't changed and so it avoids certain race conditions.
-        /// The stream is never actually used other than for "locking" the file.
+        /// Provides a common way for opening a file stream for exclusively deleting the file. 
         /// </summary>
-        private static Stream GetFileDeleteStream(string localFilePath, FileSystemInfo validate = null)
+        private static Stream GetFileDeleteStream(string localFilePath)
         {
             Contract.Assert(localFilePath != null);
 


### PR DESCRIPTION
...ast modified can not be reliably compared across different OSs.

Create etag based on last modified time only instead of both LM and creation time.
