### PR TITLE
Generate deploy.cmd script outside of the repository and into deployments\tools

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -1,7 +1,8 @@
 using System;
-namespace Kudu 
+
+namespace Kudu
 {
-    public static class Constants 
+    public static class Constants
     {
         public const string WebRoot = "wwwroot";
         public const string MappedSite = "/_app";
@@ -16,6 +17,7 @@ namespace Kudu
         public const string NpmDebugLogFile = "npm-debug.log";
 
         public const string DeploymentCachePath = "deployments";
+        public const string DeploymentToolsPath = "tools";
         public const string LogFilesPath = @"LogFiles";
         public const string TracePath = LogFilesPath + @"\Git\trace";
         public const string DeploySettingsPath = "settings.xml";
@@ -27,6 +29,7 @@ namespace Kudu
 
         // Kudu trace text file related
         public const string DeploymentTracePath = LogFilesPath + @"\Git\deployment";
+
         public const string TraceFileFormat = "{0}-{1}.txt";
         public const string TraceFileEnvKey = "KUDU_TRACE_FILE";
 

--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -150,7 +150,7 @@ namespace Kudu.Console
 
         private static string GetSettingsPath(IEnvironment environment)
         {
-            return Path.Combine(environment.DeploymentCachePath, Constants.DeploySettingsPath);
+            return Path.Combine(environment.DeploymentsPath, Constants.DeploySettingsPath);
         }
 
         private static IEnvironment GetEnvironment(string siteRoot)

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -1,5 +1,4 @@
-﻿using Kudu.Core.SourceControl;
-namespace Kudu.Core
+﻿namespace Kudu.Core
 {
     public interface IEnvironment
     {
@@ -7,7 +6,8 @@ namespace Kudu.Core
         string SiteRootPath { get; }            // e.g. /site
         string RepositoryPath { get; }          // e.g. /site/repository
         string WebRootPath { get; }             // e.g. /site/wwwroot
-        string DeploymentCachePath { get; }     // e.g. /site/deployments
+        string DeploymentsPath { get; }         // e.g. /site/deployments
+        string DeploymentToolsPath { get; }     // e.g. /site/deployments/tools
         string DiagnosticsPath { get; }         // e.g. /site/diagnostics
         string SSHKeyPath { get; }
         string TempPath { get; }

--- a/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
+++ b/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.IO.Abstractions;
-using Kudu.Services.Web;
 using Moq;
 using Xunit;
-
-using SystemEnvironment = System.Environment;
 
 namespace Kudu.Core.Test
 {
@@ -86,10 +83,10 @@ namespace Kudu.Core.Test
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem.Setup(s => s.Directory).Returns(directory.Object);
 
-            var environment = CreateEnvironment(mockFileSystem.Object, deployCachePath: deployCachePath);
+            var environment = CreateEnvironment(mockFileSystem.Object, deploymentsPath: deployCachePath);
 
             // Act
-            string output = environment.DeploymentCachePath;
+            string output = environment.DeploymentsPath;
 
             // Assert
             Assert.Equal(deployCachePath, output);
@@ -125,7 +122,7 @@ namespace Kudu.Core.Test
             string tempPath = null,
             string repositoryPath = null,
             string webRootPath = null,
-            string deployCachePath = null,
+            string deploymentsPath = ".",
             string diagnosticsPath = null,
             string sshKeyPath = null,
             string scriptPath = null,
@@ -141,7 +138,7 @@ namespace Kudu.Core.Test
                     tempPath,
                     repositoryPath,
                     webRootPath,
-                    deployCachePath,
+                    deploymentsPath,
                     diagnosticsPath,
                     sshKeyPath,
                     scriptPath,

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -584,7 +584,7 @@ namespace Kudu.Core.Deployment
 
         private IEnumerable<DeployResult> EnumerateResults()
         {
-            if (!_fileSystem.Directory.Exists(_environment.DeploymentCachePath))
+            if (!_fileSystem.Directory.Exists(_environment.DeploymentsPath))
             {
                 yield break;
             }
@@ -592,7 +592,7 @@ namespace Kudu.Core.Deployment
             string activeDeploymentId = _status.ActiveDeploymentId;
             bool isDeploying = IsDeploying;
 
-            foreach (var id in _fileSystem.Directory.GetDirectories(_environment.DeploymentCachePath))
+            foreach (var id in _fileSystem.Directory.GetDirectories(_environment.DeploymentsPath))
             {
                 DeployResult result = GetResult(id, activeDeploymentId, isDeploying);
 
@@ -710,7 +710,7 @@ namespace Kudu.Core.Deployment
 
         private string GetRoot(string id, bool ensureDirectory = true)
         {
-            string path = Path.Combine(_environment.DeploymentCachePath, id);
+            string path = Path.Combine(_environment.DeploymentsPath, id);
 
             if (ensureDirectory)
             {

--- a/Kudu.Core/Deployment/DeploymentStatusFile.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusFile.cs
@@ -22,8 +22,8 @@ namespace Kudu.Core.Deployment
 
         private DeploymentStatusFile(string id, IEnvironment environment, IFileSystem fileSystem, IOperationLock statusLock, XDocument document = null)
         {
-            _activeFile = Path.Combine(environment.DeploymentCachePath, Constants.ActiveDeploymentFile);
-            _statusFile = Path.Combine(environment.DeploymentCachePath, id, StatusFile);
+            _activeFile = Path.Combine(environment.DeploymentsPath, Constants.ActiveDeploymentFile);
+            _statusFile = Path.Combine(environment.DeploymentsPath, id, StatusFile);
             _fileSystem = fileSystem;
             _statusLock = statusLock;
 
@@ -37,7 +37,7 @@ namespace Kudu.Core.Deployment
 
         public static DeploymentStatusFile Create(string id, IFileSystem fileSystem, IEnvironment environment, IOperationLock statusLock)
         {
-            string path = Path.Combine(environment.DeploymentCachePath, id);
+            string path = Path.Combine(environment.DeploymentsPath, id);
 
             FileSystemHelpers.EnsureDirectory(fileSystem, path);
 
@@ -53,7 +53,7 @@ namespace Kudu.Core.Deployment
         {
             return statusLock.LockOperation(() =>
             {
-                string path = Path.Combine(environment.DeploymentCachePath, id, StatusFile);
+                string path = Path.Combine(environment.DeploymentsPath, id, StatusFile);
                 XDocument document = null;
 
                 if (!fileSystem.File.Exists(path))

--- a/Kudu.Core/Deployment/DeploymentStatusManager.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusManager.cs
@@ -23,7 +23,7 @@ namespace Kudu.Core.Deployment
             _environment = environment;
             _fileSystem = fileSystem;
             _statusLock = statusLock;
-            _activeFile = Path.Combine(environment.DeploymentCachePath, Constants.ActiveDeploymentFile);
+            _activeFile = Path.Combine(environment.DeploymentsPath, Constants.ActiveDeploymentFile);
         }
 
         public IDeploymentStatusFile Create(string id)
@@ -38,7 +38,7 @@ namespace Kudu.Core.Deployment
 
         public void Delete(string id)
         {
-            string path = Path.Combine(_environment.DeploymentCachePath, id);
+            string path = Path.Combine(_environment.DeploymentsPath, id);
 
             _statusLock.LockOperation(() =>
             {

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -9,7 +9,8 @@ namespace Kudu.Core
     {
         private readonly IFileSystem _fileSystem;
         private readonly string _webRootPath;
-        private readonly string _deployCachePath;
+        private readonly string _deploymentsPath;
+        private readonly string _deploymentToolsPath;
         private readonly string _diagnosticsPath;
         private readonly string _sshKeyPath;
         private readonly string _tempPath;
@@ -27,7 +28,7 @@ namespace Kudu.Core
                 string tempPath,
                 string repositoryPath,
                 string webRootPath,
-                string deployCachePath,
+                string deploymentsPath,
                 string diagnosticsPath,
                 string sshKeyPath,
                 string scriptPath,
@@ -48,7 +49,8 @@ namespace Kudu.Core
             _tempPath = tempPath;
             _repositoryPath = repositoryPath;
             _webRootPath = webRootPath;
-            _deployCachePath = deployCachePath;
+            _deploymentsPath = deploymentsPath;
+            _deploymentToolsPath = Path.Combine(_deploymentsPath, Constants.DeploymentToolsPath);
             _diagnosticsPath = diagnosticsPath;
             _sshKeyPath = sshKeyPath;
             _scriptPath = scriptPath;
@@ -62,8 +64,7 @@ namespace Kudu.Core
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _repositoryPath);
-                return _repositoryPath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _repositoryPath);
             }
         }
 
@@ -71,17 +72,23 @@ namespace Kudu.Core
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _webRootPath);
-                return _webRootPath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _webRootPath);
             }
         }
 
-        public string DeploymentCachePath
+        public string DeploymentsPath
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _deployCachePath);
-                return _deployCachePath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentsPath);
+            }
+        }
+
+        public string DeploymentToolsPath
+        {
+            get
+            {
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentToolsPath);
             }
         }
 
@@ -89,8 +96,7 @@ namespace Kudu.Core
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _diagnosticsPath);
-                return _diagnosticsPath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _diagnosticsPath);
             }
         }
 
@@ -98,8 +104,7 @@ namespace Kudu.Core
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _sshKeyPath);
-                return _sshKeyPath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _sshKeyPath);
             }
         }
 
@@ -151,8 +156,7 @@ namespace Kudu.Core
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _tracePath);
-                return _tracePath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _tracePath);
             }
         }
 
@@ -160,8 +164,7 @@ namespace Kudu.Core
         {
             get
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentTracePath);
-                return _deploymentTracePath;
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentTracePath);
             }
         }
     }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -365,7 +365,7 @@ namespace Kudu.Services.Web.App_Start
 
         private static string GetSettingsPath(IEnvironment environment)
         {
-            return Path.Combine(environment.DeploymentCachePath, Constants.DeploySettingsPath);
+            return Path.Combine(environment.DeploymentsPath, Constants.DeploySettingsPath);
         }
 
         private static IEnvironment GetEnvironment()

--- a/Kudu.Services/Diagnostics/DiagnosticsController.cs
+++ b/Kudu.Services/Diagnostics/DiagnosticsController.cs
@@ -27,7 +27,7 @@ namespace Kudu.Services.Performance
             // 2. The profile dump
             // 3. The npm log
             _paths = new[] { 
-                environment.DeploymentCachePath,
+                environment.DeploymentsPath,
                 Path.Combine(environment.RootPath, Constants.LogFilesPath),
                 Path.Combine(environment.WebRootPath, Constants.NpmDebugLogFile),
             };

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -57,7 +57,7 @@ namespace Kudu.Services
         {
             get
             {
-                return Path.Combine(_environment.DeploymentCachePath, "pending");
+                return Path.Combine(_environment.DeploymentsPath, "pending");
             }
         }
 

--- a/Kudu.Services/SourceControl/LiveScmController.cs
+++ b/Kudu.Services/SourceControl/LiveScmController.cs
@@ -89,7 +89,7 @@ namespace Kudu.Services.SourceControl
                 using (_tracer.Step("Deleting deployment cache"))
                 {
                     // Delete the deployment cache
-                    FileSystemHelpers.DeleteDirectorySafe(_environment.DeploymentCachePath, ignoreErrors != 0);
+                    FileSystemHelpers.DeleteDirectorySafe(_environment.DeploymentsPath, ignoreErrors != 0);
                 }
             }, TimeSpan.Zero);
 


### PR DESCRIPTION
With this fix also remove caching of the deploy.cmd script (as it's not required, yet still keeping the cache key).

Relates to amitapl/azure-sdk-tools-xplat@b29ea5d7583a33f93597271291bd51799f8d384e

Fixes #568
