### PR TITLE
Fix #525 FetchHandler's marker file throws file in use exception

### DIFF
--- a/Kudu.Client/Diagnostics/RemoteProcessManager.cs
+++ b/Kudu.Client/Diagnostics/RemoteProcessManager.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kudu.Client.Infrastructure;
+using Kudu.Core.Diagnostics;
+
+namespace Kudu.Client.Diagnostics
+{
+    public class RemoteProcessManager : KuduRemoteClientBase
+    {
+        public RemoteProcessManager(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
+            : base(serviceUrl, credentials, handler)
+        {
+        }
+
+        public Task<IEnumerable<ProcessInfo>> GetProcessesAsync()
+        {
+            return Client.GetJsonAsync<IEnumerable<ProcessInfo>>(String.Empty);
+        }
+
+        public Task<ProcessInfo> GetCurrentProcessAsync()
+        {
+            return GetProcessAsync(0);
+        }
+
+        public Task<ProcessInfo> GetProcessAsync(int id)
+        {
+            return Client.GetJsonAsync<ProcessInfo>(id.ToString());
+        }
+
+        public async Task KillProcessAsync(int id)
+        {
+            HttpResponseMessage response = await Client.DeleteAsync(id.ToString());
+            response.EnsureSuccessful().Dispose();
+        }
+
+        public async Task<Stream> MiniDump(int id = 0, int dumpType = 0)
+        {
+            string path = id + "/dump";
+            if (dumpType != 0)
+            {
+                path += "?dumpType=" + dumpType;
+            }
+
+            HttpResponseMessage response = await Client.GetAsync(path);
+            return await response.EnsureSuccessful().Content.ReadAsStreamAsync();
+        }
+    }
+}

--- a/Kudu.Client/Kudu.Client.csproj
+++ b/Kudu.Client/Kudu.Client.csproj
@@ -35,6 +35,7 @@
     </Compile>
     <Compile Include="Command\RemoteCommandExecutor.cs" />
     <Compile Include="Deployment\RemoteFetchManager.cs" />
+    <Compile Include="Diagnostics\RemoteProcessManager.cs" />
     <Compile Include="Diagnostics\RemoteLogStreamManager.cs" />
     <Compile Include="Editor\RemoteVfsManager.cs" />
     <Compile Include="Infrastructure\BasicAuthCredentialProvider.cs" />

--- a/Kudu.Contracts/Diagnostics/ProcessInfo.cs
+++ b/Kudu.Contracts/Diagnostics/ProcessInfo.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Kudu.Core.Diagnostics
+{
+    [DebuggerDisplay("{Id} {Name}")]
+    [DataContract(Name = "process")]
+    public class ProcessInfo
+    {
+        [DataMember(Name = "id")]
+        public int Id { get; set; }
+
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "href", EmitDefaultValue = false)]
+        public Uri Href { get; set; }
+
+        [DataMember(Name = "minidump", EmitDefaultValue = false)]
+        public Uri MiniDump { get; set; }
+
+        [DataMember(Name = "parent", EmitDefaultValue = false)]
+        public Uri Parent { get; set; }
+
+        [DataMember(Name = "children", EmitDefaultValue = false)]
+        public IEnumerable<Uri> Children { get; set; }
+
+        [DataMember(Name = "file_name", EmitDefaultValue = false)]
+        public string FileName { get; set; }
+
+        //[DataMember(Name = "arguments", EmitDefaultValue = false)]
+        //public string Arguments { get; set; }
+
+        //[DataMember(Name = "username", EmitDefaultValue = false)]
+        //public string UserName { get; set; }
+
+        [DataMember(Name = "handle_count", EmitDefaultValue = false)]
+        public int HandleCount { get; set; }
+
+        [DataMember(Name = "module_count", EmitDefaultValue = false)]
+        public int ModuleCount { get; set; }
+
+        [DataMember(Name = "thread_count", EmitDefaultValue = false)]
+        public int ThreadCount { get; set; }
+
+        [DataMember(Name = "start_time", EmitDefaultValue = false)]
+        public DateTime StartTime { get; set; }
+
+        [DataMember(Name = "total_cpu_time", EmitDefaultValue = false)]
+        public TimeSpan TotalProcessorTime { get; set; }
+
+        [DataMember(Name = "user_cpu_time", EmitDefaultValue = false)]
+        public TimeSpan UserProcessorTime { get; set; }
+
+        [DataMember(Name = "privileged_cpu_time", EmitDefaultValue = false)]
+        public TimeSpan PrivilegedProcessorTime { get; set; }
+
+        [DataMember(Name = "working_set", EmitDefaultValue = false)]
+        public Int64 WorkingSet64 { get; set; }
+
+        [DataMember(Name = "peak_working_set", EmitDefaultValue = false)]
+        public Int64 PeakWorkingSet64 { get; set; }
+
+        [DataMember(Name = "private_working_set", EmitDefaultValue = false)]
+        public Int64 PrivateWorkingSet64 { get; set; }
+
+        [DataMember(Name = "private_memory", EmitDefaultValue = false)]
+        public Int64 PrivateMemorySize64 { get; set; }
+
+        [DataMember(Name = "virtual_memory", EmitDefaultValue = false)]
+        public Int64 VirtualMemorySize64 { get; set; }
+
+        [DataMember(Name = "peak_virtual_memory", EmitDefaultValue = false)]
+        public Int64 PeakVirtualMemorySize64 { get; set; }
+
+        [DataMember(Name = "paged_system_memory", EmitDefaultValue = false)]
+        public Int64 PagedSystemMemorySize64 { get; set; }
+
+        [DataMember(Name = "non_paged_system_memory", EmitDefaultValue = false)]
+        public Int64 NonpagedSystemMemorySize64 { get; set; }
+
+        [DataMember(Name = "paged_memory", EmitDefaultValue = false)]
+        public Int64 PagedMemorySize64 { get; set; }
+
+        [DataMember(Name = "peak_paged_memory", EmitDefaultValue = false)]
+        public Int64 PeakPagedMemorySize64 { get; set; }
+    }
+}

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -36,6 +36,7 @@
     <Compile Include="Deployment\ILogger.cs" />
     <Compile Include="Deployment\LogEntry.cs" />
     <Compile Include="Deployment\LogEntryType.cs" />
+    <Compile Include="Diagnostics\ProcessInfo.cs" />
     <Compile Include="Dropbox\DropboxDeltaInfo.cs" />
     <Compile Include="Dropbox\DropboxDeployInfo.cs" />
     <Compile Include="Editor\VfsStatEntry.cs" />

--- a/Kudu.Core/Infrastructure/MiniDumpNativeMethods.cs
+++ b/Kudu.Core/Infrastructure/MiniDumpNativeMethods.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Kudu.Core.Infrastructure
+{
+    [SuppressUnmanagedCodeSecurity]
+    internal static class MiniDumpNativeMethods
+    {
+        [DllImport("dbghelp.dll",
+            EntryPoint = "MiniDumpWriteDump",
+            CallingConvention = CallingConvention.StdCall,
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool MiniDumpWriteDump(
+            IntPtr hProcess,
+            uint processId,
+            SafeHandle hFile,
+            MINIDUMP_TYPE dumpType,
+            IntPtr expParam,
+            IntPtr userStreamParam,
+            IntPtr callbackParam);
+    }
+
+    [Flags]
+    [SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue", Justification = "")]
+    [SuppressMessage("Microsoft.Naming", "CA1714:FlagsEnumsShouldHavePluralNames", Justification = "")]
+    public enum MINIDUMP_TYPE : int
+    {
+        // From dbghelp.h:
+        Normal                          = 0x00000000,
+        WithDataSegs                    = 0x00000001,
+        WithFullMemory                  = 0x00000002,
+        WithHandleData                  = 0x00000004,
+        FilterMemory                    = 0x00000008,
+        ScanMemory                      = 0x00000010,
+        WithUnloadedModules             = 0x00000020,
+        WithIndirectlyReferencedMemory  = 0x00000040,
+        FilterModulePaths               = 0x00000080,
+        WithProcessThreadData           = 0x00000100,
+        WithPrivateReadWriteMemory      = 0x00000200,
+        WithoutOptionalData             = 0x00000400,
+        WithFullMemoryInfo              = 0x00000800,
+        WithThreadInfo                  = 0x00001000,
+        WithCodeSegs                    = 0x00002000,
+        WithoutAuxiliaryState           = 0x00004000,
+        WithFullAuxiliaryState          = 0x00008000,
+        WithPrivateWriteCopyMemory      = 0x00010000,
+        IgnoreInaccessibleMemory        = 0x00020000,
+        [SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", Justification = "")]
+        ValidTypeFlags                  = 0x0003ffff,
+    };
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Infrastructure\ExecutableExtensions.cs" />
     <Compile Include="Infrastructure\IExecutable.cs" />
     <Compile Include="Infrastructure\IProcess.cs" />
+    <Compile Include="Infrastructure\MiniDumpNativeMethods.cs" />
     <Compile Include="Infrastructure\ProcessExtensions.cs" />
     <Compile Include="Infrastructure\ProcessWrapper.cs" />
     <Compile Include="Infrastructure\ProgressWriter.cs" />

--- a/Kudu.FunctionalTests/Infrastructure/KuduAssert.cs
+++ b/Kudu.FunctionalTests/Infrastructure/KuduAssert.cs
@@ -29,6 +29,21 @@ namespace Kudu.FunctionalTests.Infrastructure
             return (T)baseEx;
         }
 
+        public static async Task<T> ThrowsUnwrappedAsync<T>(Func<Task> action) where T : Exception
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                Assert.IsAssignableFrom<T>(ex);
+                return (T)ex;
+            }
+
+            throw new Exception("Not throw, expected: " + typeof(T).Name);
+        }
+
         public static Exception ThrowsMessage(string expected, Action action)
         {
             try

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -300,6 +300,12 @@ namespace Kudu.Services.Web.App_Start
 
             // LogStream
             routes.MapHandler<LogStreamHandler>(kernel, "logstream", "logstream/{*path}");
+
+            // Processes
+            routes.MapHttpRoute("all-processes", "diagnostics/processes", new { controller = "Process", action = "GetAllProcesses" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("one-process-get", "diagnostics/processes/{id}", new { controller = "Process", action = "GetProcess" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("one-process-delete", "diagnostics/processes/{id}", new { controller = "Process", action = "KillProcess" }, new { verb = new HttpMethodConstraint("DELETE") });
+            routes.MapHttpRoute("one-process-dump", "diagnostics/processes/{id}/dump", new { controller = "Process", action = "MiniDump" }, new { verb = new HttpMethodConstraint("GET") });
         }
 
         private static ITracer GetTracer(IEnvironment environment, IKernel kernel)

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http;
+using Kudu.Contracts.Tracing;
+using Kudu.Core;
+using Kudu.Core.Diagnostics;
+using Kudu.Core.Infrastructure;
+
+namespace Kudu.Services.Performance
+{
+    public class ProcessController : ApiController
+    {
+        private readonly ITracer _tracer;
+        private readonly IEnvironment _environment;
+
+        public ProcessController(ITracer tracer, IEnvironment environment)
+        {
+            _tracer = tracer;
+            _environment = environment;
+        }
+
+        [HttpGet]
+        public HttpResponseMessage GetAllProcesses()
+        {
+            using (_tracer.Step("ProcessController.GetAllProcesses"))
+            {
+                var results = Process.GetProcesses().Select(p => GetProcessInfo(p, Request.RequestUri.AbsoluteUri.TrimEnd('/') + '/' + p.Id)).OrderBy(p => p.Name.ToLowerInvariant()).ToList();
+                return Request.CreateResponse(HttpStatusCode.OK, results);
+            }
+        }
+
+        [HttpGet]
+        public HttpResponseMessage GetProcess(int id)
+        {
+            using (_tracer.Step("ProcessController.GetProcess"))
+            {
+                var process = GetProcessById(id);
+                return Request.CreateResponse(HttpStatusCode.OK, GetProcessInfo(process, Request.RequestUri.AbsoluteUri, details: true));
+            }
+        }
+
+        [HttpDelete]
+        public void KillProcess(int id)
+        {
+            using (_tracer.Step("ProcessController.KillProcess"))
+            {
+                var process = GetProcessById(id);
+                process.Kill(includesChildren: true, tracer: _tracer);
+            }
+        }
+
+        [HttpGet]
+        public HttpResponseMessage MiniDump(int id, int dumpType = 0)
+        {
+            using (_tracer.Step("ProcessController.MiniDump"))
+            {
+                var process = GetProcessById(id);
+
+                string dumpFile = Path.Combine(_environment.TempPath, "minidump.dmp");
+                FileSystemHelpers.DeleteFileSafe(dumpFile);
+
+                _tracer.Trace("MiniDump pid={0}, name={1}, file={2}", process.Id, process.ProcessName, dumpFile);
+                process.MiniDump(dumpFile, (MINIDUMP_TYPE)dumpType);
+                _tracer.Trace("MiniDump size={0}", new FileInfo(dumpFile).Length);
+
+                HttpResponseMessage response = Request.CreateResponse();
+                response.Content = new StreamContent(File.OpenRead(dumpFile));
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment");
+                response.Content.Headers.ContentDisposition.FileName = String.Format("{0}-{1:MM-dd-H:mm:ss}.dmp", process.ProcessName, DateTime.UtcNow);
+                return response;
+            }
+        }
+
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "")]
+        private ProcessInfo GetProcessInfo(Process process, string href, bool details = false)
+        {
+            href = href.TrimEnd('/');
+            if (href.EndsWith("/0", StringComparison.OrdinalIgnoreCase))
+            {
+                href = href.Substring(0, href.Length - 1) + process.Id;
+            }
+
+            var selfLink = new Uri(href);
+            var info = new ProcessInfo
+            {
+                Id = process.Id,
+                Name = process.ProcessName,
+                Href = selfLink
+            };
+
+            if (details)
+            {
+                // this could fail access denied
+                info.HandleCount = SafeGetValue(() => process.HandleCount, -1);
+                info.ThreadCount = SafeGetValue(() => process.Threads.Count, -1);
+                info.ModuleCount = SafeGetValue(() => process.Modules.Count, -1);
+                info.FileName = SafeGetValue(() => process.MainModule.FileName, "N/A");
+
+                // always return empty
+                //info.Arguments = SafeGetValue(() => process.StartInfo.Arguments, "N/A");
+                //info.UserName = SafeGetValue(() => process.StartInfo.UserName, "N/A");
+
+                info.StartTime = SafeGetValue(() => process.StartTime.ToUniversalTime(), DateTime.MinValue);
+                info.TotalProcessorTime = SafeGetValue(() => process.TotalProcessorTime, TimeSpan.FromSeconds(-1));
+                info.UserProcessorTime = SafeGetValue(() => process.UserProcessorTime, TimeSpan.FromSeconds(-1));
+                info.PrivilegedProcessorTime = SafeGetValue(() => process.PrivilegedProcessorTime, TimeSpan.FromSeconds(-1));
+
+                info.PagedSystemMemorySize64 = SafeGetValue(() => process.PagedSystemMemorySize64, -1);
+                info.NonpagedSystemMemorySize64 = SafeGetValue(() => process.NonpagedSystemMemorySize64, -1);
+                info.PagedMemorySize64 = SafeGetValue(() => process.PagedMemorySize64, -1);
+                info.PeakPagedMemorySize64 = SafeGetValue(() => process.PeakPagedMemorySize64, -1);
+                info.WorkingSet64 = SafeGetValue(() => process.WorkingSet64, -1);
+                info.PeakWorkingSet64 = SafeGetValue(() => process.PeakWorkingSet64, -1);
+                info.VirtualMemorySize64 = SafeGetValue(() => process.VirtualMemorySize64, -1);
+                info.PeakVirtualMemorySize64 = SafeGetValue(() => process.PeakVirtualMemorySize64, -1);
+                info.PrivateMemorySize64 = SafeGetValue(() => process.PrivateMemorySize64, -1);
+                info.PrivateWorkingSet64 = SafeGetValue(() => process.GetPrivateWorkingSet(), -1);
+
+                info.MiniDump = new Uri(selfLink + "/dump");
+                info.Parent = new Uri(selfLink, process.GetParentId().ToString());
+                info.Children = process.GetChildren(recursive: false).Select(c => new Uri(selfLink, c.Id.ToString()));
+            }
+
+            return info;
+        }
+
+        private static Process GetProcessById(int id)
+        {
+            return id <= 0 ? Process.GetCurrentProcess() : Process.GetProcessById(id);
+        }
+
+        private T SafeGetValue<T>(Func<T> func, T defaultValue)
+        {
+            try
+            {
+                return func();
+            }
+            catch (Exception ex)
+            {
+                _tracer.TraceError(ex);
+            }
+
+            return defaultValue;
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Deployment\DeploymentController.cs" />
     <Compile Include="Diagnostics\LogStreamHandler.cs" />
     <Compile Include="Diagnostics\LogStreamManager.cs" />
+    <Compile Include="Diagnostics\ProcessController.cs" />
     <Compile Include="Editor\VfsController.cs" />
     <Compile Include="FetchHelpers\DropboxHelper.cs" />
     <Compile Include="GitServer\CustomGitRepositoryHandler.cs" />

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -4,15 +4,14 @@ using System.IO;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Kudu.Client;
 using Kudu.Client.Deployment;
+using Kudu.Client.Diagnostics;
 using Kudu.Client.Editor;
 using Kudu.Client.Infrastructure;
 using Kudu.Client.SourceControl;
 using Kudu.Client.SSHKey;
 using Kudu.Core.Infrastructure;
 using Kudu.SiteManagement;
-using Kudu.Core.Commands;
 
 namespace Kudu.TestHarness
 {
@@ -99,6 +98,12 @@ namespace Kudu.TestHarness
         }
 
         public RemoteCommandExecutor CommandExecutor
+        {
+            get;
+            private set;
+        }
+
+        public RemoteProcessManager ProcessManager
         {
             get;
             private set;
@@ -374,6 +379,7 @@ namespace Kudu.TestHarness
                 LiveScmVfsManager = new RemoteVfsManager(site.ServiceUrl + "scmvfs"),
                 ZipManager = new RemoteZipManager(site.ServiceUrl + "zip"),
                 CommandExecutor = new RemoteCommandExecutor(site.ServiceUrl + "command"),
+                ProcessManager = new RemoteProcessManager(site.ServiceUrl + "diagnostics/processes"),
                 RepositoryManager = repositoryManager,
             };
 


### PR DESCRIPTION
Instead of synchronizing on marker file exists, creation and deletion, we use a simpler LastWriteTimeUTC.  I ran a simple console app with multiple threads updating and reading this property.  Every works just fine.
