### PR TITLE
support no-repository deployment

### DIFF
--- a/Kudu.Contracts/Deployment/DeployResult.cs
+++ b/Kudu.Contracts/Deployment/DeployResult.cs
@@ -53,6 +53,9 @@ namespace Kudu.Core.Deployment
         [DataMember(Name = "is_temp")]
         public bool IsTemporary { get; set; }
 
+        [DataMember(Name = "is_readonly")]
+        public bool IsReadOnly { get; set; }
+
         [DataMember(Name = "url")]
         public Uri Url { get; set; }
 

--- a/Kudu.Contracts/Deployment/IDeploymentStatusFile.cs
+++ b/Kudu.Contracts/Deployment/IDeploymentStatusFile.cs
@@ -18,6 +18,7 @@ namespace Kudu.Core.Deployment
         DateTime? LastSuccessEndTime { get; set; }
         bool Complete { get; set; }
         bool IsTemporary { get; set; }
+        bool IsReadOnly { get; set; }
 
         void Save();
     }

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -22,6 +22,9 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Common\Constants.cs">
+      <Link>Constants.cs</Link>
+    </Compile>
     <Compile Include="Commands\CommandEvent.cs" />
     <Compile Include="Commands\CommandEventType.cs" />
     <Compile Include="Commands\CommandResult.cs" />

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -10,7 +10,6 @@ namespace Kudu.Contracts.Settings
         public static readonly TimeSpan DefaultCommandIdleTimeout = TimeSpan.FromMinutes(1);
         public static readonly TimeSpan DefaultLogStreamTimeout = TimeSpan.FromMinutes(30);
         public const TraceLevel DefaultTraceLevel = TraceLevel.Error;
-        public const string DefaultRepositoryPath = "repository";
 
         public static string GetValue(this IDeploymentSettingsManager settings, string key)
         {
@@ -112,7 +111,22 @@ namespace Kudu.Contracts.Settings
         public static string GetRepositoryPath(this IDeploymentSettingsManager settings)
         {
             string repositoryPath = settings.GetValue(SettingsKeys.RepositoryPath);
-            return !String.IsNullOrEmpty(repositoryPath) ? repositoryPath : DefaultRepositoryPath;
+            if (!String.IsNullOrEmpty(repositoryPath))
+            {
+                return repositoryPath;
+            }
+
+            if (settings.IsNoneRepository())
+            {
+                return Constants.WebRoot;
+            }
+
+            return Constants.RepositoryPath;
+        }
+
+        public static bool IsNoneRepository(this IDeploymentSettingsManager settings)
+        {
+            return settings.GetValue(SettingsKeys.NoRepository) == "1";
         }
     }
 }

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -21,5 +21,6 @@
         public const string Project = "PROJECT";
         public const string TargetPath = "SCM_TARGET_PATH";
         public const string RepositoryPath = "SCM_REPOSITORY_PATH";
+        public const string NoRepository = "SCM_NO_REPOSITORY";
     }
 }

--- a/Kudu.Contracts/SourceControl/ChangeSet.cs
+++ b/Kudu.Contracts/SourceControl/ChangeSet.cs
@@ -49,6 +49,12 @@ namespace Kudu.Core.SourceControl
             set;
         }
 
+        public bool IsReadOnly
+        {
+            get;
+            set;
+        }
+
         public override string ToString()
         {
             return String.Format("{0} {1} {2} {3}", Id, Timestamp, AuthorName, Message);

--- a/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
@@ -92,6 +92,8 @@ namespace Kudu.Core.Test.Deployment
 
             public bool IsTemporary { get; set; }
 
+            public bool IsReadOnly { get; set; }
+
             public void Save()
             {
                 // Do nothing.

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="XmlSettings, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -77,6 +78,7 @@
     <Compile Include="GitRepositoryTest.cs" />
     <Compile Include="IniFileFacts.cs" />
     <Compile Include="LockFileTests.cs" />
+    <Compile Include="NoneRepositoryFacts.cs" />
     <Compile Include="OperationLockTests.cs" />
     <Compile Include="PathUtilityFacts.cs" />
     <Compile Include="ProcessApiFacts.cs" />

--- a/Kudu.Core.Test/NoneRepositoryFacts.cs
+++ b/Kudu.Core.Test/NoneRepositoryFacts.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Web;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.SourceControl;
+using Kudu.Core.SourceControl.None;
+using Kudu.Core.Tracing;
+using Moq;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Kudu.Core.Test
+{
+    public class NoneRepositoryFacts
+    {
+        [Theory]
+        [InlineData("wwwroot", null, "1")]
+        [InlineData("repository", null, "0")]
+        [InlineData("dummy", "dummy", "1")]
+        [InlineData("dummy", "dummy", null)]
+        public void NoneRepositoryPathTests(string expected, string repositoryPath, string noRepository)
+        {
+            // arrange
+            var settings = MockSettings(repositoryPath, noRepository);
+
+            // Assert
+            Assert.Equal(expected, settings.Object.GetRepositoryPath());
+        }
+
+        [Fact]
+        public void NoneRepositoryCommitTests()
+        {
+            // arrange
+            var settings = MockSettings();
+            var environment = MockEnviroment(@"x:\site", settings.Object);
+            var traceFactory = MockTraceFactory();
+            var httpContext = MockHttpContext();
+
+            // test
+            var repository = new NoneRepository(environment.Object, traceFactory.Object, httpContext.Object);
+
+            // Assert
+            Assert.Equal(RepositoryType.None, repository.RepositoryType);
+            Assert.Equal(environment.Object.RepositoryPath, repository.RepositoryPath);
+            Assert.Null(repository.CurrentId);
+            Assert.Throws<InvalidOperationException>(() => repository.GetChangeSet("dummy"));
+            Assert.Throws<InvalidOperationException>(() => repository.GetChangeSet("master"));
+
+            // Simple commit
+            var message = "this is testing";
+            var author = "john doe";
+            var email = "john.doe@live.com";
+            var success = repository.Commit(message, author + " <" + email + ">");
+
+            // Assert
+            Assert.True(success);
+
+            // Validate changeset
+            var changeSet = repository.GetChangeSet(repository.CurrentId);
+
+            // Assert
+            Assert.NotNull(changeSet);
+            Assert.Equal(message, changeSet.Message);
+            Assert.Equal(author, changeSet.AuthorName);
+            Assert.Equal(email, changeSet.AuthorEmail);
+            Assert.True(changeSet.IsReadOnly);
+            Assert.NotNull(repository.CurrentId);
+            Assert.Equal(repository.CurrentId, changeSet.Id);
+            Assert.Throws<InvalidOperationException>(() => repository.GetChangeSet("dummy"));
+            Assert.Same(changeSet, repository.GetChangeSet("master"));
+            Assert.Same(changeSet, repository.GetChangeSet(repository.CurrentId));
+        }
+
+        private Mock<IDeploymentSettingsManager> MockSettings(string repositoryPath = null, string noRepository = "1")
+        {
+            var settings = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+
+            // setup
+            settings.Setup(s => s.GetValue(SettingsKeys.RepositoryPath, false))
+                    .Returns(repositoryPath);
+            settings.Setup(s => s.GetValue(SettingsKeys.NoRepository, false))
+                    .Returns(noRepository);
+
+            return settings;
+        }
+
+        private Mock<IEnvironment> MockEnviroment(string sitePath, IDeploymentSettingsManager settings)
+        {
+            var environment = new Mock<IEnvironment>(MockBehavior.Strict);
+
+            // setup
+            environment.SetupGet(e => e.RepositoryPath)
+                      .Returns(() => Path.Combine(sitePath, settings.GetRepositoryPath()));
+
+            return environment;
+        }
+
+        private Mock<ITraceFactory> MockTraceFactory()
+        {
+            var traceFactory = new Mock<ITraceFactory>(MockBehavior.Strict);
+
+            // setup
+            traceFactory.Setup(t => t.GetTracer())
+                        .Returns(Mock.Of<ITracer>());
+
+            return traceFactory;
+        }
+
+        private Mock<HttpContextBase> MockHttpContext()
+        {
+            var httpContext = new Mock<HttpContextBase>(MockBehavior.Strict);
+
+            // setup
+            httpContext.SetupGet(c => c.Items)
+                       .Returns(new Hashtable());
+
+            return httpContext;
+        }
+    }
+}

--- a/Kudu.Core.Test/RepositoryFactoryFacts.cs
+++ b/Kudu.Core.Test/RepositoryFactoryFacts.cs
@@ -1,32 +1,42 @@
 ﻿using System;
+using System.Web;
 using Kudu.Contracts.Settings;
 using Kudu.Core.SourceControl;
-using Kudu.Core.SSHKey;
 using Kudu.Core.Tracing;
 using Moq;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Kudu.Core.Test
 {
     public class RepositoryFactoryFacts
     {
-        [Theory]
-        [InlineData(RepositoryType.Git, false, true, "Expected a 'Git' repository but found a 'Mercurial' repository at path ''.")]
-        [InlineData(RepositoryType.Mercurial, true, false, "Expected a 'Mercurial' repository but found a 'Git' repository at path ''.")]
-        public void EnsuringGitRepositoryThrowsIfDifferentRepositoryAlreadyExists(RepositoryType repoType, bool isGit, bool isMercurial, string message)
+        [Fact]
+        public void EnsuringGitRepositoryThrowsIfDifferentRepositoryAlreadyExists()
         {
-            // Arrange
-            var repoFactory = new Mock<RepositoryFactory>(Mock.Of<IEnvironment>(), Mock.Of<IDeploymentSettingsManager>(), Mock.Of<ITraceFactory>()) { CallBase = true };
-            repoFactory.SetupGet(f => f.IsGitRepository)
-                       .Returns(isGit);
-            repoFactory.SetupGet(f => f.IsHgRepository)
-                       .Returns(isMercurial);
-            
-            // Act and Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Object.EnsureRepository(repoType));
+            foreach (RepositoryType repoType in Enum.GetValues(typeof(RepositoryType)))
+            {
+                foreach (RepositoryType currentType in Enum.GetValues(typeof(RepositoryType)))
+                {
+                    if (repoType == currentType)
+                    {
+                        continue;
+                    }
 
-            Assert.Equal(message, ex.Message);
+                    // Arrange
+                    var repoFactory = new Mock<RepositoryFactory>(Mock.Of<IEnvironment>(), Mock.Of<IDeploymentSettingsManager>(), Mock.Of<ITraceFactory>(), Mock.Of<HttpContextBase>()) { CallBase = true };
+                    repoFactory.SetupGet(f => f.IsNoneRepository)
+                               .Returns(currentType == RepositoryType.None);
+                    repoFactory.SetupGet(f => f.IsGitRepository)
+                               .Returns(currentType == RepositoryType.Git);
+                    repoFactory.SetupGet(f => f.IsHgRepository)
+                               .Returns(currentType == RepositoryType.Mercurial);
+
+                    // Act and Assert
+                    var ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Object.EnsureRepository(repoType));
+
+                    Assert.Equal(String.Format("Expected a '{0}' repository but found a '{1}' repository at path ''.", repoType, currentType), ex.Message);
+                }
+            }
         }
     }
 }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -254,6 +254,7 @@ namespace Kudu.Core.Deployment
                 statusFile.Status = DeployStatus.Pending;
                 statusFile.StatusText = statusText;
                 statusFile.IsTemporary = changeSet.IsTemporary;
+                statusFile.IsReadOnly = changeSet.IsReadOnly;
                 statusFile.Save();
             }
 
@@ -411,6 +412,7 @@ namespace Kudu.Core.Deployment
                 statusFile.Author = changeSet.AuthorName;
                 statusFile.Deployer = deployer;
                 statusFile.AuthorEmail = changeSet.AuthorEmail;
+                statusFile.IsReadOnly = changeSet.IsReadOnly;
                 statusFile.Save();
 
                 return statusFile;
@@ -440,6 +442,7 @@ namespace Kudu.Core.Deployment
                 StatusText = file.StatusText,
                 Complete = file.Complete,
                 IsTemporary = file.IsTemporary,
+                IsReadOnly = file.IsReadOnly,
                 Current = file.Id == activeDeploymentId,
                 ReceivedTime = file.ReceivedTime,
                 LastSuccessEndTime = file.LastSuccessEndTime

--- a/Kudu.Core/Deployment/DeploymentStatusFile.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusFile.cs
@@ -96,6 +96,14 @@ namespace Kudu.Core.Deployment
                 Boolean.TryParse(isTemporaryValue, out isTemporary);
             }
 
+            bool isReadOnly = false;
+            string isReadOnlyValue = GetOptionalElementValue(document.Root, "is_readonly");
+
+            if (!String.IsNullOrEmpty(isReadOnlyValue))
+            {
+                Boolean.TryParse(isReadOnlyValue, out isReadOnly);
+            }
+
             Id = document.Root.Element("id").Value;
             Author = GetOptionalElementValue(document.Root, "author");
             Deployer = GetOptionalElementValue(document.Root, "deployer");
@@ -110,6 +118,7 @@ namespace Kudu.Core.Deployment
             LastSuccessEndTime = ParseDateTime(lastSuccessEndTimeValue);
             Complete = complete;
             IsTemporary = isTemporary;
+            IsReadOnly = isReadOnly;
         }
 
         public string Id { get; set; }
@@ -126,6 +135,7 @@ namespace Kudu.Core.Deployment
         public DateTime? LastSuccessEndTime { get; set; }
         public bool Complete { get; set; }
         public bool IsTemporary { get; set; }
+        public bool IsReadOnly { get; set; }
 
         public void Save()
         {
@@ -148,7 +158,8 @@ namespace Kudu.Core.Deployment
                     new XElement("startTime", StartTime),
                     new XElement("endTime", EndTime),
                     new XElement("complete", Complete.ToString()),
-                    new XElement("is_temp", IsTemporary.ToString())
+                    new XElement("is_temp", IsTemporary.ToString()),
+                    new XElement("is_readonly", IsReadOnly.ToString())
                 ));
 
             _statusLock.LockOperation(() =>

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -29,6 +29,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="XmlSettings, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -38,9 +39,6 @@
   <ItemGroup>
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\Common\Constants.cs">
-      <Link>Constants.cs</Link>
     </Compile>
     <Compile Include="Commands\CommandExecutor.cs" />
     <Compile Include="Deployment\CascadeLogger.cs" />
@@ -89,6 +87,7 @@
     <Compile Include="Settings\DeploymentSettingsManager.cs" />
     <Compile Include="Settings\JsonSettings.cs" />
     <Compile Include="Settings\SettingsProvidersPriority.cs" />
+    <Compile Include="SourceControl\None\NoneRepository.cs" />
     <Compile Include="SourceControl\Git\KnownEnvironment.cs" />
     <Compile Include="SourceControl\RepositoryExtensions.cs" />
     <Compile Include="SourceControl\RepositoryFactory.cs" />

--- a/Kudu.Core/SourceControl/None/NoneRepository.cs
+++ b/Kudu.Core/SourceControl/None/NoneRepository.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Tracing;
+
+namespace Kudu.Core.SourceControl.None
+{
+    /// <summary>
+    /// Implementation of a none repository
+    /// </summary>
+    public class NoneRepository : IRepository
+    {
+        private readonly IEnvironment _environment;
+        private readonly ITraceFactory _traceFactory;
+        private readonly HttpContextBase _httpContext;
+        private readonly string _changeSetKey;
+
+        public NoneRepository(IEnvironment environment, ITraceFactory traceFactory, HttpContextBase httpContext)
+        {
+            _environment = environment;
+            _traceFactory = traceFactory;
+            _httpContext = httpContext;
+            _changeSetKey = Path.Combine(_environment.RepositoryPath, "changeset");
+        }
+
+        public string CurrentId
+        {
+            get
+            {
+                var changeSet = (ChangeSet)_httpContext.Items[_changeSetKey];
+                return changeSet == null ? null : changeSet.Id;
+            }
+        }
+
+        public string RepositoryPath
+        {
+            get { return _environment.RepositoryPath; }
+        }
+
+        public RepositoryType RepositoryType
+        {
+            get { return RepositoryType.None; }
+        }
+
+        public bool Exists
+        {
+            get { return true; }
+        }
+
+        public void Initialize()
+        {
+            // no-op
+        }
+
+        public ChangeSet GetChangeSet(string id)
+        {
+            var changeSet = (ChangeSet)_httpContext.Items[_changeSetKey];
+            if (changeSet != null)
+            {
+                if (id == changeSet.Id || id == "master" || id == "HEAD")
+                {
+                    return changeSet;
+                }
+            }
+
+            throw new InvalidOperationException();
+        }
+
+        public void AddFile(string path)
+        {
+            // no-op
+        }
+
+        public bool Commit(string message, string authorName)
+        {
+            var tracer = _traceFactory.GetTracer();
+            using (tracer.Step("None repository commit"))
+            {
+                string[] parts = String.IsNullOrEmpty(authorName) ? new string[0] : authorName.Split(new[] { '<', '>' }, StringSplitOptions.RemoveEmptyEntries);
+
+                var changeSet = new ChangeSet(Guid.NewGuid().ToString("N"),
+                                              parts.Length > 0 ? parts[0].Trim() : Resources.Deployment_UnknownValue,
+                                              parts.Length > 1 ? parts[1].Trim() : Resources.Deployment_UnknownValue,
+                                              message ?? Resources.Deployment_UnknownValue,
+                                              DateTimeOffset.UtcNow);
+
+                // Does not support rollback
+                changeSet.IsReadOnly = true;
+
+                // The lifetime is per request
+                _httpContext.Items[_changeSetKey] = changeSet;
+
+                tracer.Trace("Commit id: " + changeSet.Id, new Dictionary<string, string>
+                {
+                    { "Messsage", changeSet.Message },
+                    { "AuthorName", changeSet.AuthorName },
+                    { "AuthorEmail", changeSet.AuthorEmail }
+                });
+            }
+
+            return true;
+        }
+
+        public void Update(string id)
+        {
+            // no-op
+        }
+
+        public void Update()
+        {
+            // no-op
+        }
+
+        public void Push()
+        {
+            // no-op
+        }
+
+        public void FetchWithoutConflict(string remote, string branchName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clean()
+        {
+            _httpContext.Items.Remove(_changeSetKey);
+        }
+
+        public void UpdateSubmodules()
+        {
+            // no-op
+        }
+
+        public void ClearLock()
+        {
+            // no-op
+        }
+
+        public void CreateOrResetBranch(string branchName, string startPoint)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Rebase(string branchName)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void RebaseAbort()
+        {
+            // no-op
+        }
+
+        public void UpdateRef(string source)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -106,7 +106,8 @@ namespace Kudu.Services.Web.App_Start
                                              .InRequestScope();
 
             // General
-            kernel.Bind<HttpContextBase>().ToMethod(context => new HttpContextWrapper(HttpContext.Current));
+            kernel.Bind<HttpContextBase>().ToMethod(context => new HttpContextWrapper(HttpContext.Current))
+                                             .InRequestScope();
             kernel.Bind<IServerConfiguration>().ToConstant(serverConfiguration);
             kernel.Bind<IFileSystem>().To<FileSystem>().InSingletonScope();
 

--- a/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
@@ -16,12 +16,14 @@ namespace Kudu.Services.ServiceHookHandlers
     public class DropboxHandler : IServiceHookHandler
     {
         private readonly DropboxHelper _dropBoxHelper;
+        private readonly IDeploymentSettingsManager _settings;
 
         public DropboxHandler(ITracer tracer,
                               IDeploymentStatusManager status,
                               IDeploymentSettingsManager settings,
                               IEnvironment environment)
         {
+            _settings = settings;
             _dropBoxHelper = new DropboxHelper(tracer, status, settings, environment);
         }
 
@@ -30,7 +32,7 @@ namespace Kudu.Services.ServiceHookHandlers
             deploymentInfo = null;
             if (!String.IsNullOrEmpty(payload.Value<string>("NewCursor")))
             {
-                var dropboxInfo = new DropboxInfo(payload);
+                var dropboxInfo = new DropboxInfo(payload, _settings.IsNoneRepository() ? RepositoryType.None : RepositoryType.Git); 
                 deploymentInfo = dropboxInfo; 
 
                 // Temporary deployment
@@ -55,12 +57,11 @@ namespace Kudu.Services.ServiceHookHandlers
 
         internal class DropboxInfo : DeploymentInfo
         {
-            public DropboxInfo(JObject payload)
+            public DropboxInfo(JObject payload, RepositoryType repositoryType)
             {
                 Deployer = DropboxHelper.Dropbox;
                 DeployInfo = payload.ToObject<DropboxDeployInfo>();
-                // This ensure that the fetch handler provides an underlying Git repository.
-                RepositoryType = RepositoryType.Git;
+                RepositoryType = repositoryType;
                 IsReusable = false;
             }
 

--- a/Kudu.SiteManagement/Kudu.SiteManagement.csproj
+++ b/Kudu.SiteManagement/Kudu.SiteManagement.csproj
@@ -41,9 +41,6 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\Common\Constants.cs">
-      <Link>Constants.cs</Link>
-    </Compile>
     <Compile Include="..\Kudu.Core\Infrastructure\CommandLineException.cs">
       <Link>CommandLineException.cs</Link>
     </Compile>


### PR DESCRIPTION
This is to support no-repository deployment (no Git nor Hg).   The scenario that we are looking at is Dropbox to Azure as-is deployment.   This allows a fast deployment (no git) trading off with read-only history (cannot rollback).   

TBD: We have yet to figure out the UI gesture on portal to opt in this.  
