### PR TITLE
Changing a few methods to be virtual

### DIFF
--- a/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
+++ b/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
@@ -410,7 +410,7 @@ namespace Kudu.FunctionalTests
                 }
             }
 
-            public void VerifyUrl(ApplicationManager appManager, Setting setting)
+            public virtual void VerifyUrl(ApplicationManager appManager, Setting setting)
             {
                 if (setting.TargetPath == ".")
                 {
@@ -422,12 +422,12 @@ namespace Kudu.FunctionalTests
                 }
             }
 
-            public void VerifyUrl(ApplicationManager appManager, string documentRoot)
+            public virtual void VerifyUrl(ApplicationManager appManager, string documentRoot)
             {
                 KuduAssert.VerifyUrl(appManager.SiteUrl + documentRoot + @"/" + DefaultDocument, Content);
             }
 
-            public void ValidateDeploymentStatus(List<DeployResult> results, Setting setting)
+            public virtual void ValidateDeploymentStatus(List<DeployResult> results, Setting setting)
             {
                 Assert.Equal(1, results.Count);
                 Assert.Equal(setting.DeploymentStatus, results[0].Status);


### PR DESCRIPTION
I need to create a test case in private kudu for an MVCApplication scenario for which I would need to override VerifyUrl. I have changed all the methods in Scenario base to be virtual so there is not much difference between the public and private kudu version of this test case except for the extra scenario. This extra scenario will only work on private kudu since it involves changing document root.
