### PR TITLE
Updated Live SCM controller to always start with the current commit ID

### DIFF
--- a/Kudu.Services/SourceControl/LiveScmEditorController.cs
+++ b/Kudu.Services/SourceControl/LiveScmEditorController.cs
@@ -51,13 +51,12 @@ namespace Kudu.Services.SourceControl
             _deploymentManager = deploymentManager;
             _operationLock = operationLock;
             _repository = repository;
-            _currentEtag = GetCurrentEtag();
         }
 
         public override async Task<HttpResponseMessage> GetItem()
         {
             // Get a lock on the repository
-            await _operationLock.LockAsync();
+            await GetLockAsync();
 
             try
             {
@@ -89,7 +88,7 @@ namespace Kudu.Services.SourceControl
         public override async Task<HttpResponseMessage> PutItem()
         {
             // Get a lock on the repository
-            await _operationLock.LockAsync();
+            await GetLockAsync();
 
             try
             {
@@ -115,7 +114,7 @@ namespace Kudu.Services.SourceControl
         public override async Task<HttpResponseMessage> DeleteItem()
         {
             // Get a lock on the repository
-            await _operationLock.LockAsync();
+            await GetLockAsync();
 
             try
             {
@@ -454,6 +453,14 @@ namespace Kudu.Services.SourceControl
             errorResponse = null;
             return true;
         }
+
+        private async Task GetLockAsync()
+        {
+            await _operationLock.LockAsync();
+
+            // Make sure we have the current commit ID
+            _currentEtag = GetCurrentEtag();
+         }
 
         private EntityTagHeaderValue GetCurrentEtag()
         {


### PR DESCRIPTION
Updated Live SCM controller to always start with the current commit ID when multiple concurrent requests are pending. Before the current commit ID was retrieved in the controller ctor but that could get out of date if the operation was waiting for another concurrent operation to complete.

The impact of not having the most recent commit ID was that it forced a rebase -- now that is no longer the case.
