### PR TITLE
Changes to Kudu functional to work On-Prem

### DIFF
--- a/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
+++ b/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
@@ -492,7 +492,7 @@ project = myproject");
                 ApplicationManager.Run(appName, appManager =>
                 {
                     string url = appManager.SiteUrl + "hostingstart.html";
-                    KuduAssert.VerifyUrl(url, "<h1>This web site has been successfully created</h1>");
+                    KuduAssert.VerifyUrl(url, "This web site has been successfully created");
 
                     // Act
                     appManager.GitDeploy(repo.PhysicalPath);

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -165,7 +165,7 @@ namespace Kudu.TestHarness
             return matches[0].Groups[1].Value;
         }
 
-        public static void Run(string testName, Action<ApplicationManager> action)
+        public static void Run(string testName, Action<ApplicationManager> action, bool randomizeSiteName = true)
         {
             Func<ApplicationManager, Task> asyncAction = (appManager) =>
             {
@@ -176,7 +176,8 @@ namespace Kudu.TestHarness
             RunAsync(testName, asyncAction).Wait();
         }
 
-        public static async Task RunAsync(string testName, Func<ApplicationManager, Task> action)
+        public static async Task RunAsync(
+            string testName, Func<ApplicationManager, Task> action, bool randomizeSiteName = true)
         {
             if (KuduUtils.StopAfterFirstTestFailure && KuduUtils.TestFailureOccurred)
             {
@@ -185,7 +186,7 @@ namespace Kudu.TestHarness
 
             try
             {
-                await RunNoCatch(testName, action);
+                await RunNoCatch(testName, action, randomizeSiteName);
             }
             catch
             {
@@ -194,11 +195,14 @@ namespace Kudu.TestHarness
             }
         }
 
-        public static async Task RunNoCatch(string testName, Func<ApplicationManager, Task> action)
+        public static async Task RunNoCatch(
+            string testName, Func<ApplicationManager, Task> action, bool randomizeSiteName)
         {
             TestTracer.Trace("Running test - {0}", testName);
 
-            var appManager = await CreateApplicationAsync(KuduUtils.GetRandomWebsiteName(testName), testName);
+            var appManager = (randomizeSiteName == true) ?
+                await CreateApplicationAsync(KuduUtils.GetRandomWebsiteName(testName), testName) :
+                await CreateApplicationAsync(testName);
 
             if (KuduUtils.ReuseSameSiteForAllTests)
             {


### PR DESCRIPTION
I made the following changes for our functionals to work on-premise
1) 4 test cases were randomizing site names twice. Now we pass a parameter to Run, if we have already randomized it in the test case itself. 

2) The test case changes to use (1) will be checked into private kudu. The following test cases will be changed
Kudu.FunctionalTests.AntaresWebSiteConfigTests.UpdatingAppSettingsArePropagatedForPHP 
Kudu.FunctionalTests.AntaresWebSiteConfigTests.UpdatingAppSettingsAndConnStringsArePropagatedForMVC
Kudu.FunctionalTests.AntaresWebSiteConfigTests.ExtraBuildArgumentsAreApplied
Kudu.FunctionalTests.LogStreamManagerTests.TestLogStreamAppShutdown 

3) FirstPushDeletesHostingStartHtmlFile  has been changed to work both on-prem and azure. On-prem version of hostingstart.html has no <h1> tags
