### PR TITLE
Updating Kudu test harness to use SitePool

### DIFF
--- a/Kudu.FunctionalTests/DeploymentManagerTests.cs
+++ b/Kudu.FunctionalTests/DeploymentManagerTests.cs
@@ -480,7 +480,7 @@ namespace Kudu.FunctionalTests
         public async Task PullApiTestKilnHgFormat()
         {
             string kilnPayload = @"{ ""commits"": [ { ""author"": ""Brian Surowiec <xtorted@optonline.net>"", ""branch"": ""default"", ""id"": ""0bbefd70c4c4213bba1e91998141f6e861cec24d"", ""message"": ""more fun text"", ""revision"": 20, ""tags"": [ ""tip"" ], ""timestamp"": ""1/16/2013 3:32:04 AM"", ""url"": ""https://13degrees.kilnhg.com/Code/Kudu-Public/Group/Site/History/d2415cbaa78e"" } ], ""pusher"": { ""accesstoken"": false, ""email"": ""xtorted@optonline.net"", ""fullName"": ""Brian Surowiec"" }, ""repository"": { ""central"": true, ""description"": """", ""id"": 113336, ""name"": ""Site"", ""url"": ""https://bitbucket.org/kudutest/hellomercurial/"" } }";
-            string appName = KuduUtils.GetRandomWebsiteName("PullApiTestKilnHgFormat");
+            string appName = "PullApiTestKilnHgFormat";
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {

--- a/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
+++ b/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
@@ -16,7 +16,7 @@ namespace Kudu.FunctionalTests
         [PropertyData("ScenarioSettings")]
         public async Task InPlaceDeploymentBasicTests(Scenario scenario, Setting setting)
         {
-            var appName = KuduUtils.GetRandomWebsiteName(scenario.Name);
+            var appName = scenario.Name;
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
                 KeyValuePair<string, string>[] settings = setting.GetSettings();

--- a/Kudu.Stress/StressTestCases.cs
+++ b/Kudu.Stress/StressTestCases.cs
@@ -1,16 +1,10 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Configuration;
-using System.IO  ;
+using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Kudu.Contracts;
-using Kudu.TestHarness;
 using Kudu.Core.Deployment;
+using Kudu.TestHarness;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 
 namespace Kudu.Stress
 {
@@ -128,13 +122,14 @@ namespace Kudu.Stress
                     if (!testArtifactStore.ContainsKey(testName))
                     {
                         // create site & start w3wp.exe with a request
-                        ApplicationManager stressAppManager = ApplicationManager.CreateApplicationAsync(testName).Result;
+                        ApplicationManager stressAppManager = SitePool.CreateApplicationAsync().Result;
                         Uri siteUri;
                         Uri.TryCreate(new Uri(stressAppManager.SiteUrl), "hostingstart.html", out siteUri);
                         StressUtils.VerifySite(siteUri.AbsoluteUri, "successfully");
 
+                        string appName = stressAppManager.ApplicationName;
                         // create counter objects & do init log
-                        W3wpResourceMonitor counterManager = new W3wpResourceMonitor(testName);
+                        W3wpResourceMonitor counterManager = new W3wpResourceMonitor(appName);
                         counterManager.CheckAndLogResourceUsage();
 
                         TestRepository testRepository = Git.Clone(testName, gitUrl);

--- a/Kudu.TestHarness/Kudu.TestHarness.csproj
+++ b/Kudu.TestHarness/Kudu.TestHarness.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Npm.cs" />
     <Compile Include="Node.cs" />
     <Compile Include="LatencyLogger.cs" />
+    <Compile Include="SitePool.cs" />
     <Compile Include="TestEnvironment.cs" />
     <Compile Include="TestRepositories.cs" />
     <Compile Include="TestTracer.cs" />

--- a/Kudu.TestHarness/KuduUtils.cs
+++ b/Kudu.TestHarness/KuduUtils.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Configuration;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -11,9 +10,6 @@ namespace Kudu.TestHarness
 {
     public class KuduUtils
     {
-        private const int MinSiteNameIndex = 1;
-        private const int DefaultMaxSiteNameIndex = 5;
-
         public static void DownloadDump(string serviceUrl, string zippedLogsPath, NetworkCredential credentials = null)
         {
             try
@@ -61,43 +57,6 @@ namespace Kudu.TestHarness
             return document;
         }
 
-        public static string GetRandomWebsiteName(string name)
-        {
-            if (KuduUtils.ReuseSameSiteForAllTests)
-            {
-                return KuduUtils.SiteReusedForAllTests;
-            }
-            else
-            {
-                int maxLen = Math.Min(name.Length, 25);
-                return name.Substring(0, maxLen) + Guid.NewGuid().ToString("N").Substring(0, 4);
-            }
-        }
-
-        private static int SiteNameIndex = MinSiteNameIndex;
-
-        public static void ReportTestFailure()
-        {
-            if (ReuseSameSiteForAllTests)
-            {
-                TestTracer.Trace("Test failed, name of site used for test is '{0}'", SiteReusedForAllTests);
-            }
-
-            // Make sure no more than max number of sites are created per test run.
-            if (SiteNameIndex < MaxSiteNameIndex)
-            {
-                SiteNameIndex++;
-            }
-        }
-
-        public static bool TestFailureOccurred
-        {
-            get
-            {
-                return SiteNameIndex > MinSiteNameIndex;
-            }
-        }
-
         public static string SiteReusedForAllTests
         {
             get
@@ -105,35 +64,11 @@ namespace Kudu.TestHarness
                 string siteName = GetTestSetting("SiteReusedForAllTests");
                 if (String.IsNullOrEmpty(siteName))
                 {
-                    return null;
+                    return Environment.MachineName;
                 }
 
                 // Append the machine name to the site to avoid conflicting with other users running tests
-                return String.Format("{0}{1}-{2}", siteName, Environment.MachineName, SiteNameIndex);
-            }
-        }
-
-        public static int MaxSiteNameIndex
-        {
-            get
-            {
-                string maxSiteNameIndex = GetTestSetting("MaxSiteNameIndex");
-                try
-                {
-                    return int.Parse(maxSiteNameIndex);
-                }
-                catch
-                {
-                    return DefaultMaxSiteNameIndex;
-                }
-            }
-        }
-
-        public static bool ReuseSameSiteForAllTests
-        {
-            get
-            {
-                return !String.IsNullOrEmpty(SiteReusedForAllTests);
+                return String.Format("{0}{1}", siteName, Environment.MachineName);
             }
         }
 

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Kudu.SiteManagement;
+
+namespace Kudu.TestHarness
+{
+    public static class SitePool
+    {
+        private const int MaxSiteNameIndex = 5;
+        private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(initialCount: 1);
+        private static readonly string _sitePrefix = KuduUtils.SiteReusedForAllTests;
+        private static readonly ConcurrentStack<int> _availableSiteIndex = new ConcurrentStack<int>(Enumerable.Range(1, MaxSiteNameIndex).Reverse());
+        private static ApplicationManager _nextAppManager;
+
+        public static async Task<ApplicationManager> CreateApplicationAsync()
+        {
+            await _semaphore.WaitAsync();
+            ApplicationManager appManager = _nextAppManager;
+            _nextAppManager = null;
+            _semaphore.Release();
+            
+            if (appManager == null)
+            {
+                appManager = await CreateApplicationInternal();
+            }
+
+            EnsureNextApplication();
+            return appManager;
+        }
+
+        private static async void EnsureNextApplication()
+        {
+            await Task.Run(async () => 
+            {
+                await _semaphore.WaitAsync();
+                try
+                {
+                    _nextAppManager = await CreateApplicationInternal();
+                }
+                finally
+                {
+                    _semaphore.Release();
+                }
+            });
+        }
+
+        public static void ReportTestCompletion(ApplicationManager applicationManager, bool success)
+        {
+            if (success)
+            {
+                _availableSiteIndex.Push(applicationManager.SitePoolIndex);
+            }
+            else if (_availableSiteIndex.Count <= 1)
+            {
+                _availableSiteIndex.Push(applicationManager.SitePoolIndex);
+            }
+        }
+
+        private static async Task<ApplicationManager> CreateApplicationInternal()
+        {
+            int siteIndex;
+            _availableSiteIndex.TryPop(out siteIndex);
+            string applicationName = _sitePrefix + siteIndex;
+            var pathResolver = new DefaultPathResolver(PathHelper.ServiceSitePath, PathHelper.SitesPath);
+            var settingsResolver = new DefaultSettingsResolver();
+
+            var siteManager = GetSiteManager(pathResolver, settingsResolver);
+
+            Site site = siteManager.GetSite(applicationName);
+            if (site != null)
+            {
+                var appManager = new ApplicationManager(siteManager, site, applicationName, settingsResolver)
+                {
+                    SitePoolIndex = siteIndex
+                };
+
+                // In site reuse mode, clean out the existing site so we start clean
+                await appManager.RepositoryManager.Delete(deleteWebRoot: true, ignoreErrors: true);
+
+                // Make sure we start with the correct default file as some tests expect it
+                WriteIndexHtml(appManager);
+
+                return appManager;
+            }
+            else
+            {
+                site = await siteManager.CreateSiteAsync(applicationName);
+                return new ApplicationManager(siteManager, site, applicationName, settingsResolver)
+                {
+                    SitePoolIndex = siteIndex
+                };
+            }
+        }
+
+        private static ISiteManager GetSiteManager(DefaultPathResolver pathResolver, DefaultSettingsResolver settingsResolver)
+        {
+            return new SiteManager(pathResolver, traceFailedRequests: true, logPath: PathHelper.TestResultsPath, settingsResolver: settingsResolver);
+        }
+
+        // Try to write index.html.  In case of failure with 502, we will include
+        // UpTime information with the exception.  This info will be used for furthur
+        // investigation of Bad Gateway issue.
+        private static void WriteIndexHtml(ApplicationManager appManager)
+        {
+            try
+            {
+                appManager.VfsWebRootManager.WriteAllText("hostingstart.html", "<h1>This web site has been successfully created</h1>");
+            }
+            catch (HttpRequestException ex)
+            {
+                if (ex.Message.Contains("502 (Bad Gateway)"))
+                {
+                    string upTime = null;
+                    try
+                    {
+                        upTime = appManager.GetKuduUpTime();
+                    }
+                    catch (Exception exception)
+                    {
+                        TestTracer.Trace("GetKuduUpTime failed with exception\n{0}", exception);
+                    }
+
+                    if (!String.IsNullOrEmpty(upTime))
+                    {
+                        throw new HttpRequestException(ex.Message + " Kudu Up Time: " + upTime, ex);
+                    }
+                }
+
+                throw;
+            }
+        }
+    }
+}


### PR DESCRIPTION
In public Kudu, deleting and recreating websites is much slower than site re-use. Consequently, all this code change is some refactoring to make it similar to how private Kudu's code looks like.
