### PR TITLE
Fix #731: don't call String.Format in Command Controller scenario

### DIFF
--- a/Kudu.Core/Commands/CommandExecutor.cs
+++ b/Kudu.Core/Commands/CommandExecutor.cs
@@ -92,7 +92,7 @@ namespace Kudu.Core.Commands
             }
 
             Executable exe = _externalCommandFactory.BuildExternalCommandExecutable(workingDirectory, _environment.WebRootPath, NullLogger.Instance);
-            _executingProcess = exe.CreateProcess(command, new object[0]);
+            _executingProcess = exe.CreateProcess(command);
 
             var commandEvent = CommandEvent;
 

--- a/Kudu.Core/Infrastructure/Executable.cs
+++ b/Kudu.Core/Infrastructure/Executable.cs
@@ -382,8 +382,13 @@ namespace Kudu.Core.Infrastructure
         }
 #endif
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Method is used, misdiagnosed due to linking of this file")]
         internal Process CreateProcess(string arguments, object[] args)
+        {
+            return CreateProcess(String.Format(arguments, args));
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Method is used, misdiagnosed due to linking of this file")]
+        internal Process CreateProcess(string arguments)
         {
             var psi = new ProcessStartInfo
             {
@@ -396,7 +401,7 @@ namespace Kudu.Core.Infrastructure
                 WindowStyle = ProcessWindowStyle.Hidden,
                 UseShellExecute = false,
                 ErrorDialog = false,
-                Arguments = String.Format(arguments, args)
+                Arguments = arguments
             };
 
             if (Encoding != null)


### PR DESCRIPTION
We don't want the String.Format call at all here.
