### PR TITLE
Check "sha" is not empty as well as checking for null

### DIFF
--- a/Kudu.Services.Web/Default.aspx
+++ b/Kudu.Services.Web/Default.aspx
@@ -90,7 +90,7 @@
         %>
         
         <h1>Kudu - Build <%= version %>
-        <% if (sha != null) { %>
+        <% if (!String.IsNullOrEmpty(sha)) { %>
         (<a id="sha" href="https://github.com/projectkudu/kudu/commit/<%= sha %>"><%= sha.Substring(0, 10) %></a>)
         <% } %>
         </h1>


### PR DESCRIPTION
In my working copy the "sha" var was empty, not null and was throwing an exception.
