### PR TITLE
Redirect non-POST /deploy requests to the Kudu root

### DIFF
--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -73,7 +73,7 @@ namespace Kudu.Services
             {
                 if (!String.Equals(context.Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase))
                 {
-                    context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                    context.Response.Redirect("~/");
                     context.ApplicationInstance.CompleteRequest();
                     return;
                 }


### PR DESCRIPTION
This makes it easy for users to just paste the /deploy URL from the portal as is.
