### PR TITLE
Support gcdump and diagsession

### DIFF
--- a/Kudu.Client/Diagnostics/RemoteProcessManager.cs
+++ b/Kudu.Client/Diagnostics/RemoteProcessManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Kudu.Client.Infrastructure;
 using Kudu.Core.Diagnostics;
@@ -37,15 +38,45 @@ namespace Kudu.Client.Diagnostics
             response.EnsureSuccessful().Dispose();
         }
 
-        public async Task<Stream> MiniDump(int id = 0, int dumpType = 0)
+        public async Task<Stream> MiniDump(int id = 0, int dumpType = 0, string format = null)
         {
-            string path = id + "/dump";
-            if (dumpType != 0)
+            var path = new StringBuilder();
+            path.AppendFormat("{0}/dump", id);
+
+            var separator = '?';
+            if (dumpType > 0)
             {
-                path += "?dumpType=" + dumpType;
+                path.AppendFormat("{0}dumpType={1}", separator, dumpType);
+                separator = '&';
+            }
+            if (!String.IsNullOrEmpty(format))
+            {
+                path.AppendFormat("{0}format={1}", separator, format);
+                separator = '&';
             }
 
-            HttpResponseMessage response = await Client.GetAsync(path);
+            HttpResponseMessage response = await Client.GetAsync(path.ToString());
+            return await response.EnsureSuccessful().Content.ReadAsStreamAsync();
+        }
+
+        public async Task<Stream> GCDump(int id = 0, int maxDumpCountK = 0, string format = null)
+        {
+            var path = new StringBuilder();
+            path.AppendFormat("{0}/gcdump", id);
+
+            var separator = '?';
+            if (maxDumpCountK > 0)
+            {
+                path.AppendFormat("{0}maxDumpCountK={1}", separator, maxDumpCountK);
+                separator = '&';
+            }
+            if (!String.IsNullOrEmpty(format))
+            {
+                path.AppendFormat("{0}format={1}", separator, format);
+                separator = '&';
+            }
+
+            HttpResponseMessage response = await Client.GetAsync(path.ToString());
             return await response.EnsureSuccessful().Content.ReadAsStreamAsync();
         }
     }

--- a/Kudu.Contracts/Diagnostics/ProcessInfo.cs
+++ b/Kudu.Contracts/Diagnostics/ProcessInfo.cs
@@ -21,6 +21,9 @@ namespace Kudu.Core.Diagnostics
         [DataMember(Name = "minidump", EmitDefaultValue = false)]
         public Uri MiniDump { get; set; }
 
+        [DataMember(Name = "gcdump", EmitDefaultValue = false)]
+        public Uri GCDump { get; set; }
+
         [DataMember(Name = "parent", EmitDefaultValue = false)]
         public Uri Parent { get; set; }
 

--- a/Kudu.Core.Test/ProcessApiFacts.cs
+++ b/Kudu.Core.Test/ProcessApiFacts.cs
@@ -33,7 +33,7 @@ namespace Kudu.Core.Test
                       .Returns(() => new MemoryStream());
 
             // Test
-            using (var stream = ProcessController.MiniDumpStream.OpenRead(path, fileSystem.Object))
+            using (var stream = ProcessController.FileStreamWrapper.OpenRead(path, fileSystem.Object))
             {
             }
 
@@ -58,7 +58,7 @@ namespace Kudu.Core.Test
                       .Returns(() => new MemoryStream());
 
             // Test
-            var stream = ProcessController.MiniDumpStream.OpenRead(path, fileSystem.Object);
+            var stream = ProcessController.FileStreamWrapper.OpenRead(path, fileSystem.Object);
             stream.Close();
 
             // Assert

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -329,6 +329,10 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRoute("one-process-get", "diagnostics/processes/{id}", new { controller = "Process", action = "GetProcess" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("one-process-delete", "diagnostics/processes/{id}", new { controller = "Process", action = "KillProcess" }, new { verb = new HttpMethodConstraint("DELETE") });
             routes.MapHttpRoute("one-process-dump", "diagnostics/processes/{id}/dump", new { controller = "Process", action = "MiniDump" }, new { verb = new HttpMethodConstraint("GET") });
+            if (ProcessExtensions.SupportGCDump)
+            {
+                routes.MapHttpRoute("one-process-gcdump", "diagnostics/processes/{id}/gcdump", new { controller = "Process", action = "GCDump" }, new { verb = new HttpMethodConstraint("GET") });
+            }
             routes.MapHttpRoute("all-threads", "diagnostics/processes/{id}/threads", new { controller = "Process", action = "GetAllThreads" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("one-process-thread", "diagnostics/processes/{processId}/threads/{threadId}", new { controller = "Process", action = "GetThread" }, new { verb = new HttpMethodConstraint("GET") });
 

--- a/Kudu.Services/Infrastructure/ZipStreamContent.cs
+++ b/Kudu.Services/Infrastructure/ZipStreamContent.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Kudu.Contracts.Tracing;
+
+namespace Kudu.Services.Infrastructure
+{
+    public static class ZipStreamContent
+    {
+        public static PushStreamContent Create(string fileName, ITracer tracer, Action<ZipArchive> onZip)
+        {
+            var content = new PushStreamContent((outputStream, httpContent, transportContext) =>
+            {
+                using (tracer.Step("ZipStreamContent.OnZip"))
+                {
+                    try
+                    {
+                        using (var zip = new ZipArchive(new StreamWrapper(outputStream), ZipArchiveMode.Create, leaveOpen: false))
+                        {
+                            onZip(zip);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        tracer.TraceError(ex);
+                        throw;
+                    }
+                }
+            });
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+            content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment");
+            content.Headers.ContentDisposition.FileName = fileName;
+            return content;
+        }
+
+        // this wraps the read-only HttpResponseStream to support ZipArchive Position getter.
+        public class StreamWrapper : DelegatingStream
+        {
+            private long _position = 0;
+
+            public StreamWrapper(Stream stream)
+                : base(stream)
+            {
+            }
+
+            public override long Position
+            {
+                get { return _position; }
+                set { throw new NotSupportedException(); }
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                _position += count;
+                base.Write(buffer, offset, count);
+            }
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            {
+                _position += count;
+                return base.BeginWrite(buffer, offset, count, callback, state);
+            }
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Infrastructure\LockExtensions.cs" />
     <Compile Include="Infrastructure\MemoryStreamExtensions.cs" />
     <Compile Include="Infrastructure\UriHelper.cs" />
+    <Compile Include="Infrastructure\ZipStreamContent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/Kudu.Services/Resources.Designer.cs
+++ b/Kudu.Services/Resources.Designer.cs
@@ -241,6 +241,15 @@ namespace Kudu.Services {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dump format ({0}) is not supported..
+        /// </summary>
+        internal static string Error_DumpFormatNotSupported {
+            get {
+                return ResourceManager.GetString("Error_DumpFormatNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The json payload is empty..
         /// </summary>
         internal static string Error_EmptyPayload {

--- a/Kudu.Services/Resources.resx
+++ b/Kudu.Services/Resources.resx
@@ -225,6 +225,9 @@
   <data name="Error_FullMiniDumpNotSupported" xml:space="preserve">
     <value>Site mode ({0}) does not support full minidump.</value>
   </data>
+  <data name="Error_DumpFormatNotSupported" xml:space="preserve">
+    <value>Dump format ({0}) is not supported.</value>
+  </data>
   <data name="Dropbox_Synchronized" xml:space="preserve">
     <value>Synchronized {0} change(s) from Dropbox.</value>
   </data>


### PR DESCRIPTION
In addition to minidump, we will support the gcdump and diagsession format.  The benefit is for C# leak investigation which has a much smaller foot print than a full minidump.

Minidump = /diagnostics/processes/{id}/dump?dumptype=(0|1|2)&format=(zip|raw)
Note: zip format will also package matching sos and mscordacwks dls

GCdump = /diagnostics/processes/{id}/gcdump?format=(zip|raw|diagsession)&maxDumpCountK=(0)
Note: this only lights up if vsdiagagent binaries are installed.

I also make zip related stream more efficient.
