### PR TITLE
Site extension logging for Kudu

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -21,6 +21,7 @@ namespace Kudu
         public const string DeploymentToolsPath = "tools";
         public const string LogFilesPath = @"LogFiles";
         public const string TracePath = LogFilesPath + @"\Git\trace";
+        public const string SiteExtensionLogsDirectory = "siteExtLogs";
         public const string DeploySettingsPath = "settings.xml";
         public const string ActiveDeploymentFile = "active";
         public const string TraceFile = "trace.xml";

--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -70,6 +70,7 @@ namespace Kudu.Console
             string deploymentLockPath = Path.Combine(lockPath, Constants.DeploymentLockFile);
             string statusLockPath = Path.Combine(lockPath, Constants.StatusLockFile);
             string hooksLockPath = Path.Combine(lockPath, Constants.HooksLockFile);
+            string analyticsPath = env.AnalyticsPath;
 
             IOperationLock deploymentLock = new LockFile(deploymentLockPath, traceFactory, fileSystem);
             IOperationLock statusLock = new LockFile(statusLockPath, traceFactory, fileSystem);
@@ -80,12 +81,15 @@ namespace Kudu.Console
 
             IRepository gitRepository = new GitExeRepository(env, settingsManager, traceFactory);
 
+            IAnalytics analytics = new Analytics(settingsManager, fileSystem, tracer, analyticsPath);
+
             IWebHooksManager hooksManager = new WebHooksManager(tracer, env, hooksLock, fileSystem);
             var logger = new ConsoleLogger();
             IDeploymentManager deploymentManager = new DeploymentManager(builderFactory,
                                                           env,
                                                           fileSystem,
                                                           traceFactory,
+                                                          analytics,
                                                           settingsManager,
                                                           new DeploymentStatusManager(env, fileSystem, statusLock),
                                                           deploymentLock,

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -15,6 +15,7 @@
         string NodeModulesPath { get; }
         string LogFilesPath { get; }            // e.g. /logfiles
         string TracePath { get; }               // e.g. /logfiles/git/trace
+        string AnalyticsPath { get; }           // e.g. %temp%/siteExtLogs
         string DeploymentTracePath { get; }     // e.g. /logfiles/git/deployment
     }
 }

--- a/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
@@ -101,6 +101,7 @@ namespace Kudu.Core.Test.Deployment
                                  IEnvironment environment = null,
                                  IFileSystem fileSystem = null,
                                  ITraceFactory traceFactory = null,
+                                 IAnalytics analytics = null,
                                  IDeploymentSettingsManager settings = null,
                                  IDeploymentStatusManager status = null,
                                  IOperationLock deploymentLock = null,
@@ -111,12 +112,13 @@ namespace Kudu.Core.Test.Deployment
             environment = environment ?? Mock.Of<IEnvironment>();
             fileSystem = fileSystem ?? Mock.Of<IFileSystem>();
             traceFactory = traceFactory ?? Mock.Of<ITraceFactory>();
+            analytics = analytics ?? Mock.Of<IAnalytics>();
             settings = settings ?? Mock.Of<IDeploymentSettingsManager>();
             status = status ?? Mock.Of<IDeploymentStatusManager>();
             deploymentLock = deploymentLock ?? Mock.Of<IOperationLock>();
             globalLogger = globalLogger ?? Mock.Of<ILogger>();
 
-            return new DeploymentManager(builderFactory, environment, fileSystem, traceFactory, settings, status, deploymentLock, globalLogger, hooksManager);
+            return new DeploymentManager(builderFactory, environment, fileSystem, traceFactory, analytics, settings, status, deploymentLock, globalLogger, hooksManager);
         }
     }
 }

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Settings\SettingsProvidersTests.cs" />
     <Compile Include="SSHKeyManagerFacts.cs" />
     <Compile Include="TracerTests.cs" />
+    <Compile Include="Tracing\SiteExtensionLogManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kudu.Contracts\Kudu.Contracts.csproj">

--- a/Kudu.Core.Test/PurgeDeploymentsTests.cs
+++ b/Kudu.Core.Test/PurgeDeploymentsTests.cs
@@ -57,7 +57,7 @@ namespace Kudu.Core.Test
             var status = new Mock<IDeploymentStatusManager>();
             var trace = new Mock<ITraceFactory>();
             var tracer = new Mock<ITracer>();
-            var manager = new DeploymentManager(null, null, null, trace.Object, null, status.Object, null, null, null);
+            var manager = new DeploymentManager(null, null, null, trace.Object, null, null, status.Object, null, null, null);
 
             // Setup
             status.Setup(s => s.ActiveDeploymentId)

--- a/Kudu.Core.Test/Tracing/SiteExtensionLogManagerTests.cs
+++ b/Kudu.Core.Test/Tracing/SiteExtensionLogManagerTests.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Tracing;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Kudu.Core.Test.Tracing
+{
+    public class SiteExtensionLogManagerTests
+    {
+        private const string DirectoryPath = "directoryPath";
+
+        private readonly SiteExtensionLogManager _siteExtensionLogManager;
+        private readonly byte[] _buffer = new byte[1024];
+        private readonly List<FileInfoBase> _mockLogFiles = new List<FileInfoBase>();
+        private readonly List<IDictionary<string, object>> _logEvents = new List<IDictionary<string, object>>();
+        private bool _deleteCalled;
+
+        public SiteExtensionLogManagerTests()
+        {
+            _siteExtensionLogManager = BuildSiteExtensionLogManager();
+        }
+
+        [Fact]
+        public void SiteExtensionLogManagerShouldLogOneEventToFile()
+        {
+            LogEvent("val1", 2);
+
+            ValidateLogFileContent();
+        }
+
+        [Fact]
+        public void SiteExtensionLogManagerShouldLogSeveralEventsToFile()
+        {
+            LogEvent("val1", 2);
+            LogEvent("val2", 3);
+            LogEvent("val3", 4);
+            LogEvent("val4", 5);
+
+            ValidateLogFileContent();
+        }
+
+        [Fact]
+        public void SiteExtensionLogManagerShouldCleanupLogIfNeeded()
+        {
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, -2, true);
+            AddFileInfoBaseToFilesList(1024 * 1024, 2, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 4, false);
+
+            LogEvent("val1", 2);
+
+            Assert.True(_deleteCalled, "Delete should have been called");
+
+            ValidateLogFileContent();
+        }
+
+        [Fact]
+        public void SiteExtensionLogManagerShouldNotCleanupLogIfNotNeeded()
+        {
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 2, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 1, false);
+            AddFileInfoBaseToFilesList(1024 * 1024, 4, false);
+
+            LogEvent("val1", 2);
+
+            Assert.False(_deleteCalled, "Delete should not have been called");
+
+            ValidateLogFileContent();
+        }
+
+        private void AddFileInfoBaseToFilesList(long length, int addHours, bool expectDelete)
+        {
+            var fileInfoBaseMock = new Mock<FileInfoBase>();
+
+            fileInfoBaseMock.SetupGet(fs => fs.Length)
+                            .Returns(length);
+
+            fileInfoBaseMock.SetupGet(fs => fs.LastWriteTimeUtc)
+                            .Returns(DateTime.Now.AddHours(addHours));
+
+            fileInfoBaseMock.Setup(f => f.Delete())
+                            .Callback(() =>
+                            {
+                                if (!expectDelete)
+                                {
+                                    throw new AssertException("Delete not expected");
+                                }
+
+                                _deleteCalled = true;
+                            });
+
+            _mockLogFiles.Add(fileInfoBaseMock.Object);
+        }
+
+        private void LogEvent(string val1, Int64 val2)
+        {
+            IDictionary<string, object> logEvent = new Dictionary<string, object>();
+            logEvent["key1"] = val1;
+            logEvent["key2"] = val2;
+
+            _siteExtensionLogManager.Log(logEvent);
+
+            _logEvents.Add(logEvent);
+        }
+
+        private void ValidateLogFileContent()
+        {
+            using (var reader = new StreamReader(new MemoryStream(_buffer)))
+            {
+                var logFileContent = reader.ReadToEnd();
+                var lines = logFileContent.Split('\n');
+
+                Assert.Equal(_logEvents.Count, lines.Length - 1);
+
+                for (int i = 0; i < lines.Length - 1; i++)
+                {
+                    var logLine = JsonConvert.DeserializeObject<Dictionary<string, object>>(lines[i]);
+
+                    foreach (var property in _logEvents[i])
+                    {
+                        Assert.Equal(property.Value, logLine[property.Key]);
+                    }
+                }
+            }
+        }
+
+        private Mock<IFileSystem> BuildFileSystemMock()
+        {
+            var fileSystemMock = new Mock<IFileSystem>();
+            var fileBaseMock = new Mock<FileBase>();
+            var directoryInfoFactoryMock = new Mock<IDirectoryInfoFactory>();
+            var directoryInfoMock = new Mock<DirectoryInfoBase>();
+
+            fileSystemMock.SetupGet(fs => fs.File)
+                      .Returns(fileBaseMock.Object);
+
+            fileSystemMock.SetupGet(fs => fs.DirectoryInfo)
+                      .Returns(directoryInfoFactoryMock.Object);
+
+            fileBaseMock.Setup(f => f.Open(It.IsAny<string>(), FileMode.Append, FileAccess.Write, FileShare.Read))
+                        .Returns(() =>
+                        {
+                            int index = _buffer.Length;
+                            for (int i = 0; i < _buffer.Length; i++)
+                            {
+                                if (_buffer[i] == 0)
+                                {
+                                    index = i;
+                                    break;
+                                }
+                            }
+                            return new MemoryStream(_buffer, index, _buffer.Length - index);
+                        });
+
+            directoryInfoFactoryMock.Setup(d => d.FromDirectoryName(It.IsAny<string>()))
+                        .Returns(directoryInfoMock.Object);
+
+            directoryInfoFactoryMock.Setup(d => d.FromDirectoryName(It.IsAny<string>()))
+                        .Returns(directoryInfoMock.Object);
+
+            directoryInfoMock.Setup(d => d.GetFiles(It.IsAny<string>()))
+                             .Returns(() => _mockLogFiles.ToArray());
+
+            return fileSystemMock;
+        }
+
+        private SiteExtensionLogManager BuildSiteExtensionLogManager()
+        {
+            var fileSystemMock = BuildFileSystemMock();
+            var tracer = Mock.Of<ITracer>();
+
+            return new SiteExtensionLogManager(fileSystemMock.Object, tracer, DirectoryPath);
+        }
+    }
+}

--- a/Kudu.Core/Deployment/Generator/BasicBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/BasicBuilder.cs
@@ -1,6 +1,4 @@
 ﻿using Kudu.Contracts.Settings;
-using System;
-using System.Globalization;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -9,6 +7,11 @@ namespace Kudu.Core.Deployment.Generator
         public BasicBuilder(IEnvironment environment, IDeploymentSettingsManager settings, IBuildPropertyProvider propertyProvider, string repositoryPath, string projectPath)
             : base(environment, settings, propertyProvider, repositoryPath, projectPath, "--basic")
         {
+        }
+
+        public override string ProjectType
+        {
+            get { return "BASIC"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/Generator/CustomBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/CustomBuilder.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.IO;
 using System.Threading.Tasks;
-using Kudu.Contracts.Tracing;
-using Kudu.Core.Infrastructure;
 using Kudu.Contracts.Settings;
-using System.IO.Abstractions;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -35,6 +31,11 @@ namespace Kudu.Core.Deployment.Generator
             }
 
             return tcs.Task;
+        }
+
+        public override string ProjectType
+        {
+            get { return "CUSTOM DEPLOYMENT"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/Generator/CustomGeneratorCommandSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/CustomGeneratorCommandSiteBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Kudu.Contracts.Settings;
+﻿using Kudu.Contracts.Settings;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -19,6 +18,11 @@ namespace Kudu.Core.Deployment.Generator
             {
                 return _scriptGeneratorArgs;
             }
+        }
+
+        public override string ProjectType
+        {
+            get { return "CustomGeneratorCommand"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
@@ -34,6 +34,8 @@ namespace Kudu.Core.Deployment.Generator
             ExternalCommandFactory = new ExternalCommandFactory(environment, settings, repositoryPath);
         }
 
+        public abstract string ProjectType { get; }
+
         protected IEnvironment Environment { get; private set; }
 
         protected IDeploymentSettingsManager DeploymentSettings { get; private set; }

--- a/Kudu.Core/Deployment/Generator/NodeSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/NodeSiteBuilder.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Threading.Tasks;
-using Kudu.Contracts.Settings;
-using Kudu.Contracts.Tracing;
-using Kudu.Core.SourceControl.Git;
+﻿using Kudu.Contracts.Settings;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -14,9 +9,9 @@ namespace Kudu.Core.Deployment.Generator
         {
         }
 
-        public override Task Build(DeploymentContext context)
+        public override string ProjectType
         {
-            return base.Build(context);
+            get { return "NODE.JS"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/Generator/WapBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/WapBuilder.cs
@@ -1,8 +1,6 @@
-﻿using Kudu.Contracts.Settings;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System;
 using System.Text;
+using Kudu.Contracts.Settings;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -36,6 +34,11 @@ namespace Kudu.Core.Deployment.Generator
 
                 return commandArguments.ToString();
             }
+        }
+
+        public override string ProjectType
+        {
+            get { return "ASP.NET WAP"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/Generator/WebSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/WebSiteBuilder.cs
@@ -1,8 +1,7 @@
-﻿using Kudu.Contracts.Settings;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Globalization;
 using System.Text;
+using Kudu.Contracts.Settings;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -36,6 +35,11 @@ namespace Kudu.Core.Deployment.Generator
 
                 return commandArguments.ToString();
             }
+        }
+
+        public override string ProjectType
+        {
+            get { return "ASP.NET WEBSITE"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/ISiteBuilder.cs
+++ b/Kudu.Core/Deployment/ISiteBuilder.cs
@@ -5,5 +5,6 @@ namespace Kudu.Core.Deployment
     public interface ISiteBuilder
     {
         Task Build(DeploymentContext context);
+        string ProjectType { get; }
     }
 }

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -19,6 +19,7 @@ namespace Kudu.Core
         private string _repositoryPath;
         private readonly string _logFilesPath;
         private readonly string _tracePath;
+        private readonly string _analyticsPath;
         private readonly string _deploymentTracePath;
 
         public Environment(
@@ -57,6 +58,7 @@ namespace Kudu.Core
             _nodeModulesPath = nodeModulesPath;
             _logFilesPath = Path.Combine(rootPath, Constants.LogFilesPath);
             _tracePath = Path.Combine(rootPath, Constants.TracePath);
+            _analyticsPath = Path.Combine(tempPath ?? _logFilesPath, Constants.SiteExtensionLogsDirectory);
             _deploymentTracePath = Path.Combine(rootPath, Constants.DeploymentTracePath);
         }
 
@@ -162,6 +164,14 @@ namespace Kudu.Core
             get
             {
                 return FileSystemHelpers.EnsureDirectory(_fileSystem, _tracePath);
+            }
+        }
+
+        public string AnalyticsPath
+        {
+            get
+            {
+                return FileSystemHelpers.EnsureDirectory(_fileSystem, _analyticsPath);
             }
         }
 

--- a/Kudu.Core/Infrastructure/StringExtensions.cs
+++ b/Kudu.Core/Infrastructure/StringExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using Kudu.Core.SourceControl;
 
 namespace Kudu.Core
 {

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Deployment\Generator\NodeSiteEnabler.cs" />
     <Compile Include="Deployment\Generator\SiteBuilderFactory.cs" />
     <Compile Include="Hooks\WebHooksManager.cs" />
+    <Compile Include="Tracing\SiteExtensionLogEvent.cs" />
+    <Compile Include="Tracing\ISiteExtensionLogEvent.cs" />
     <Compile Include="Infrastructure\StringExtensions.cs" />
     <Compile Include="Settings\DeploymentSettingsProvider.cs" />
     <Compile Include="Deployment\DeploymentContext.cs" />
@@ -95,7 +97,10 @@
     <Compile Include="SSHKey\PEMEncoder.cs" />
     <Compile Include="SSHKey\SSHEncoding.cs" />
     <Compile Include="SSHKey\SSHKeyManager.cs" />
+    <Compile Include="Tracing\Analytics.cs" />
     <Compile Include="Tracing\CascadeTracer.cs" />
+    <Compile Include="Tracing\SiteExtensionLogManager.cs" />
+    <Compile Include="Tracing\IAnalytics.cs" />
     <Compile Include="Tracing\ITraceFactory.cs" />
     <Compile Include="Tracing\TextLogger.cs" />
     <Compile Include="Tracing\NullTracer.cs" />

--- a/Kudu.Core/Tracing/Analytics.cs
+++ b/Kudu.Core/Tracing/Analytics.cs
@@ -1,0 +1,65 @@
+﻿using System.IO.Abstractions;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.Tracing;
+
+namespace Kudu.Core.Tracing
+{
+    public class Analytics : IAnalytics
+    {
+        private readonly SiteExtensionLogManager _siteExtensionLogManager;
+        private readonly IDeploymentSettingsManager _settings;
+
+        public Analytics(IDeploymentSettingsManager settings, IFileSystem fileSystem, ITracer tracer, string directoryPath)
+        {
+            _settings = settings;
+            _siteExtensionLogManager = new SiteExtensionLogManager(fileSystem, tracer, directoryPath);
+        }
+
+        public void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds)
+        {
+            var o = new SiteDeployedSiteExtensionLogEvent()
+            {
+                SiteType = projectType,
+                ScmType = _settings.GetValue(SettingsKeys.ScmType),
+                Result = result,
+                Error = error,
+                Latency = deploymentDurationInMilliseconds
+            };
+
+            _siteExtensionLogManager.Log(o);
+        }
+
+        private class SiteDeployedSiteExtensionLogEvent : SiteExtensionLogEvent
+        {
+            public string SiteType
+            {
+                set { this["SiteType"] = value; }
+            }
+
+            public string ScmType
+            {
+                set { this["ScmType"] = value; }
+            }
+
+            public string Result
+            {
+                set { this["Result"] = value; }
+            }
+
+            public string Error
+            {
+                set { this["Error"] = value; }
+            }
+
+            public long? Latency
+            {
+                set { this["Latency"] = value; }
+            }
+
+            public SiteDeployedSiteExtensionLogEvent()
+                : base("Kudu", "SiteDeployed")
+            {
+            }
+        }
+    }
+}

--- a/Kudu.Core/Tracing/IAnalytics.cs
+++ b/Kudu.Core/Tracing/IAnalytics.cs
@@ -1,0 +1,7 @@
+﻿namespace Kudu.Core.Tracing
+{
+    public interface IAnalytics
+    {
+        void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds);
+    }
+}

--- a/Kudu.Core/Tracing/ISiteExtensionLogEvent.cs
+++ b/Kudu.Core/Tracing/ISiteExtensionLogEvent.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Kudu.Core.Tracing
+{
+    public interface ISiteExtensionLogEvent
+    {
+        IDictionary<string, object> ToDictionary();
+    }
+}

--- a/Kudu.Core/Tracing/SiteExtensionLogEvent.cs
+++ b/Kudu.Core/Tracing/SiteExtensionLogEvent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kudu.Core.Tracing
+{
+    public class SiteExtensionLogEvent : Dictionary<string, object>
+    {
+        public SiteExtensionLogEvent(string siteExtension, string eventType)
+        {
+            this["SiteExtension"] = siteExtension;
+            this["EventDate"] = DateTime.UtcNow;
+            this["EventName"] = eventType;
+        }
+    }
+}

--- a/Kudu.Core/Tracing/SiteExtensionLogManager.cs
+++ b/Kudu.Core/Tracing/SiteExtensionLogManager.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Infrastructure;
+using Newtonsoft.Json;
+
+namespace Kudu.Core.Tracing
+{
+    public class SiteExtensionLogManager
+    {
+        private const string DefaultFileNameFormat = "kudu_{0}.log";
+        private const int MaxFileSize = 1024 * 1024; // 1 MB
+        private const int MaxTotalFilesSize = MaxFileSize * 10;
+
+        private static readonly string SiteExtensionLogSearchPattern = DefaultFileNameFormat.FormatInvariant("*");
+
+        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings()
+        {
+            CheckAdditionalContent = false,
+            DefaultValueHandling = DefaultValueHandling.Ignore,
+            MissingMemberHandling = MissingMemberHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore,
+            MaxDepth = 1,
+            PreserveReferencesHandling = PreserveReferencesHandling.None,
+            ReferenceLoopHandling = ReferenceLoopHandling.Error
+        };
+
+        private readonly IFileSystem _fileSystem;
+        private readonly ITracer _tracer;
+        private readonly string _directoryPath;
+        private string _currentFileName;
+        private string _currentPath;
+
+        public SiteExtensionLogManager(IFileSystem fileSystem, ITracer tracer, string directoryPath)
+        {
+            _fileSystem = fileSystem;
+            _tracer = tracer;
+            _directoryPath = directoryPath;
+
+            UpdateCurrentPath();
+        }
+
+        public void Log(IDictionary<string, object> siteExtensionLogEvent)
+        {
+            using (_tracer.Step("Site Extension Log"))
+            {
+                try
+                {
+                    // TODO: Consider doing cleanup only once per X minutes
+                    HandleCleanup();
+
+                    string message = JsonConvert.SerializeObject(siteExtensionLogEvent, JsonSerializerSettings);
+
+                    _tracer.Trace("{0}", message);
+
+                    OperationManager.Attempt(() =>
+                    {
+                        using (var streamWriter = new StreamWriter(_fileSystem.File.Open(_currentPath, FileMode.Append, FileAccess.Write, FileShare.Read)))
+                        {
+                            streamWriter.WriteLine(message);
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    _tracer.TraceError(ex);
+                }
+            }
+        }
+
+        private void HandleCleanup()
+        {
+            FileInfoBase[] extentionLogFiles = ListLogFiles();
+
+            if (extentionLogFiles.Sum(file => file.Length) > MaxTotalFilesSize)
+            {
+                extentionLogFiles.OrderBy(file => file.LastWriteTimeUtc).First().Delete();
+            }
+
+            FileInfoBase currentFileInfo = extentionLogFiles.FirstOrDefault(file => String.Equals(file.Name, _currentFileName, StringComparison.OrdinalIgnoreCase));
+            if (currentFileInfo != null && currentFileInfo.Length > MaxFileSize)
+            {
+                UpdateCurrentPath();
+            }
+        }
+
+        private void UpdateCurrentPath()
+        {
+            string filePostfix = DateTime.UtcNow.ToString("yyyyMMddHHMM");
+            _currentFileName = DefaultFileNameFormat.FormatInvariant(filePostfix);
+            _currentPath = Path.Combine(_directoryPath, _currentFileName);
+        }
+
+        private FileInfoBase[] ListLogFiles()
+        {
+            try
+            {
+                return _fileSystem.DirectoryInfo.FromDirectoryName(_directoryPath).GetFiles(SiteExtensionLogSearchPattern);
+            }
+            catch
+            {
+                return new FileInfoBase[0];
+            }
+        }
+    }
+}

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -153,6 +153,11 @@ namespace Kudu.Services.Web.App_Start
             kernel.Bind<IOperationLock>().ToConstant(hooksLock).WhenInjectedInto<WebHooksManager>();
             kernel.Bind<IOperationLock>().ToConstant(_deploymentLock);
 
+            kernel.Bind<IAnalytics>().ToMethod(context => new Analytics(context.Kernel.Get<IDeploymentSettingsManager>(),
+                                                                        fileSystem,
+                                                                        context.Kernel.Get<ITracer>(),
+                                                                        environment.AnalyticsPath));
+
             var shutdownDetector = new ShutdownDetector();
             shutdownDetector.Initialize();
 

--- a/Kudu.TestHarness/TestEnvironment.cs
+++ b/Kudu.TestHarness/TestEnvironment.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Kudu.Core;
+﻿using Kudu.Core;
 
 namespace Kudu.TestHarness
 {
@@ -78,6 +77,12 @@ namespace Kudu.TestHarness
         }
 
         public string TracePath
+        {
+            get;
+            set;
+        }
+
+        public string AnalyticsPath
         {
             get;
             set;


### PR DESCRIPTION
This is the kudu implementation to get its logs to Azure,
The contract it uses is using a file where each line is a json serialized log event, the file is named `extension_*.log` and is stored under `%temp%\siteExtLogs`.
