### PR TITLE
Adding IIS Pipeline Info to Kudu

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -39,6 +39,10 @@ namespace Kudu
 
         public const string HostingStartHtml = "hostingstart.html";
 
+        public const string TotalRequestCountHeader = "HTTP_X_TOTAL_REQUESTS_COUNT";
+        public const string ActiveRequestsCountHeader = "HTTP_X_ACTIVE_REQUESTS_COUNT";
+        public const string ListActiveRequestsHeader = "HTTP_X_LIST_ACTIVE_REQUESTS";
+
         private static readonly TimeSpan _maxAllowedExectionTime = TimeSpan.FromMinutes(30);
 
         public static TimeSpan MaxAllowedExecutionTime

--- a/Kudu.Contracts/Diagnostics/IISPipelineInfo.cs
+++ b/Kudu.Contracts/Diagnostics/IISPipelineInfo.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+
+namespace Kudu.Core.Diagnostics
+{
+    [DebuggerDisplay("{TotalServedRequestsCount} {ActiveRequestsCount}")]
+    [DataContract(Name = "iispipeline")]
+    public class IISPipelineInfo
+    {
+        [DataMember(Name = "total_requests_count", EmitDefaultValue = true)]
+        public int TotalServedRequestsCount { get; set; }
+
+        [DataMember(Name = "active_requests_count", EmitDefaultValue = true)]
+        public int ActiveRequestsCount { get; set; }
+
+        [DataMember(Name = "list_active_requests", EmitDefaultValue = true)]
+        public IEnumerable<string> ListActiveRequests { get; set; }
+    }
+}

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Deployment\ILogger.cs" />
     <Compile Include="Deployment\LogEntry.cs" />
     <Compile Include="Deployment\LogEntryType.cs" />
+    <Compile Include="Diagnostics\IISPipelineInfo.cs" />
     <Compile Include="Diagnostics\ProcessInfo.cs" />
     <Compile Include="Diagnostics\ProcessThreadInfo.cs" />
     <Compile Include="Editor\VfsStatEntry.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -338,6 +338,9 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRoute("publish-hooks", "hooks/publish/{hookEventType}", new { controller = "WebHooks", action = "PublishEvent" }, new { verb = new HttpMethodConstraint("POST") });
             routes.MapHttpRoute("get-hooks", "hooks", new { controller = "WebHooks", action = "GetWebHooks" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("subscribe-hook", "hooks", new { controller = "WebHooks", action = "Subscribe" }, new { verb = new HttpMethodConstraint("POST") });
+
+            // IISPipeline
+            routes.MapHttpRoute("iis-pipeline", "diagnostics/iispipeline", new { controller = "IISPipeline", action = "GetIISPipelineInfo" }, new { verb = new HttpMethodConstraint("GET") });
         }
 
         private static ITracer GetTracer(IEnvironment environment, IKernel kernel)

--- a/Kudu.Services.Web/Default.aspx
+++ b/Kudu.Services.Web/Default.aspx
@@ -157,6 +157,10 @@
             <td><a href="diagnostics/processes">Browse</a></td>
         </tr>
         <tr>
+            <td><strong>IIS Pipeline Info</strong></td>
+            <td><a href="diagnostics/iispipeline">Browse</a></td>
+        </tr>
+        <tr>
             <td><strong>Source control info</strong></td>
             <td><a href="scm/info">Browse</a></td>
         </tr>

--- a/Kudu.Services/Diagnostics/IISPipelineController.cs
+++ b/Kudu.Services/Diagnostics/IISPipelineController.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Diagnostics;
+
+
+namespace Kudu.Services.Performance
+{
+    public class IISPipelineController : ApiController
+    {
+        private readonly ITracer _tracer;
+
+        public IISPipelineController(ITracer tracer)
+        {
+            _tracer = tracer;
+        }
+
+        [HttpGet]
+        public HttpResponseMessage GetIISPipelineInfo()
+        {
+            using (_tracer.Step("IISPipelineController.GetIISPipelineInfo"))
+            {
+                var serverVariables = System.Web.HttpContext.Current.Request.ServerVariables;
+                var info = new IISPipelineInfo
+                {
+                    TotalServedRequestsCount = ValueOrDefault(() => Int32.Parse(serverVariables[Constants.TotalRequestCountHeader]), -1),
+                    ActiveRequestsCount = ValueOrDefault(() => Int32.Parse(serverVariables[Constants.ActiveRequestsCountHeader]), -1),
+                    ListActiveRequests = ValueOrDefault(() => serverVariables[Constants.ListActiveRequestsHeader].Split(';').Select(s => s.Trim()).Where(s => !String.IsNullOrEmpty(s)).ToList(), new List<string>())
+                };
+
+                return Request.CreateResponse(HttpStatusCode.OK, info);
+            }
+        }
+
+        private static T ValueOrDefault<T>(Func<T> value, T Default)
+        {
+            try
+            {
+                return value.Invoke();
+            }
+            catch (Exception)
+            {
+            }
+
+            return Default;
+        }
+
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ByteRanges\InvalidByteRangeException.cs" />
     <Compile Include="Commands\CommandController.cs" />
     <Compile Include="Deployment\DeploymentController.cs" />
+    <Compile Include="Diagnostics\IISPipelineController.cs" />
     <Compile Include="Diagnostics\LogStreamHandler.cs" />
     <Compile Include="Diagnostics\LogStreamManager.cs" />
     <Compile Include="Diagnostics\ProcessController.cs" />


### PR DESCRIPTION
A native module would populate request headers X_TOTAL_REQUESTS_COUNT, X_TOTAL_REQUESTS_COUNT, and X_LIST_ACTIVE_REQUESTS with information from inside IIS pipeline.
it adds them only for requests made to /diagnostics/iispipeline
