### PR TITLE
Fix #785: Fetch scenario blows up when branch name matches folder name

### DIFF
--- a/Kudu.Core/SourceControl/Git/GitExeRepository.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeRepository.cs
@@ -192,11 +192,11 @@ echo $i > pushinfo
             string output = null;
             try
             {
-                output = Execute("log -n 1 {0}", id);
+                output = Execute("log -n 1 {0} --", id);
             }
             catch (CommandLineException ex)
             {
-                if (!String.IsNullOrEmpty(ex.Message) && ex.Message.IndexOf("unknown revision ", StringComparison.OrdinalIgnoreCase) != -1)
+                if (!String.IsNullOrEmpty(ex.Message) && ex.Message.IndexOf("bad revision ", StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     // Indicates the changeset does not exist in the repo.
                     return null;

--- a/Kudu.FunctionalTests/DeploymentManagerTests.cs
+++ b/Kudu.FunctionalTests/DeploymentManagerTests.cs
@@ -543,7 +543,7 @@ namespace Kudu.FunctionalTests
         [Fact]
         public async Task PullApiTestGenericFormatCustomBranch()
         {
-            string payload = @"{ ""oldRef"": ""0000000000000000000"", ""newRef"": ""ad21595c668f3de813463df17c04a3b23065fedc"", ""url"": ""https://github.com/KuduApps/RepoWithMultipleBranches.git"", ""deployer"" : ""CodePlex"", branch: ""test"" }";
+            string payload = @"{ ""oldRef"": ""0000000000000000000"", ""newRef"": ""b4bd5b73ec4c15019d41d16e418c3017b70b3796"", ""url"": ""https://github.com/KuduApps/RepoWithMultipleBranches.git"", ""deployer"" : ""CodePlex"", branch: ""test"" }";
             string appName = "PullApiTestGenericCustomBranch";
 
             await ApplicationManager.RunAsync(appName, async appManager =>


### PR DESCRIPTION
I changed the branch test to have this condition, such that it is broken without this change (https://github.com/KuduApps/RepoWithMultipleBranches/commit/b4bd5b73ec4c15019d41d16e418c3017b70b3796).
