### PR TITLE
Fix #866: Zip controller and Kudu dump don't preserve file timestamps

### DIFF
--- a/Kudu.Services/Infrastructure/ZipArchiveExtensions.cs
+++ b/Kudu.Services/Infrastructure/ZipArchiveExtensions.cs
@@ -65,6 +65,7 @@ namespace Kudu.Services
             {
                 string fileName = Path.Combine(directoryNameInArchive, file.Name);
                 ZipArchiveEntry entry = zipArchive.CreateEntry(fileName, CompressionLevel.Fastest);
+                entry.LastWriteTime = file.LastWriteTime;
 
                 using (Stream zipStream = entry.Open())
                 {


### PR DESCRIPTION
This solves it for files, but not folders. Folders are much trickier because most get created as a result of creating files, and there is no obvious way of setting the timestamp.
