### PR TITLE
Fix #837

### DIFF
--- a/Kudu.Core/Jobs/ContinuousJobLogger.cs
+++ b/Kudu.Core/Jobs/ContinuousJobLogger.cs
@@ -9,7 +9,7 @@ namespace Kudu.Core.Jobs
     public class ContinuousJobLogger : JobLogger
     {
         public const string JobLogFileName = "job.log";
-        public const string JobPrevLogFileName = "job_1.log";
+        public const string JobPrevLogFileName = "job_prev.log";
         public const int MaxContinuousLogFileSize = 1 * 1024 * 1024;
 
         private readonly string _historyPath;


### PR DESCRIPTION
WebJob: prevent job log files from growing too large
We'll roll the log file once when it reaches 1 MB keeping only up to 2 log files per continuous job
