### PR TITLE
fix test to use cached repo

### DIFF
--- a/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
+++ b/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
@@ -25,7 +25,7 @@ namespace Kudu.FunctionalTests
                     await appManager.SettingsManager.SetValues(settings);
                 }
 
-                using (TestRepository testRepository = Git.Clone(scenario.Name, scenario.CloneUrl))
+                using (TestRepository testRepository = Git.Clone(scenario.Name))
                 {
                     var result = appManager.GitDeploy(testRepository.PhysicalPath);
                     setting.Verify(appManager);
@@ -44,7 +44,7 @@ namespace Kudu.FunctionalTests
             get
             {
                 yield return new object[] { new NodeJsAppScenario(), new InPlaceDefaultProjectTargetPathSetting() };
-                                
+
                 var scenario = new HelloKuduWithSubFolders();
                 foreach (Setting setting in Settings)
                 {
@@ -143,7 +143,7 @@ namespace Kudu.FunctionalTests
             {
                 get { return DeployStatus.Failed; }
             }
-            
+
             public override void Verify(ApplicationManager appManager)
             {
                 Assert.False(appManager.VfsManager.Exists(@"site\repository\.git"), @"Should not have site\repository\.git folder");
@@ -390,7 +390,6 @@ namespace Kudu.FunctionalTests
         public abstract class Scenario
         {
             public abstract string Name { get; }
-            public abstract string CloneUrl { get; }
             public abstract string BuilderTrace { get; }
             public abstract string Content { get; }
             public abstract string DefaultDocument { get; }
@@ -441,11 +440,6 @@ namespace Kudu.FunctionalTests
                 get { return "NodeHelloWorldNoConfig"; }
             }
 
-            public override string CloneUrl
-            {
-                get { return "https://github.com/KuduApps/NodeHelloWorldNoConfig.git"; }
-            }
-
             public override string Content
             {
                 get { return "Hello, world"; }
@@ -467,11 +461,6 @@ namespace Kudu.FunctionalTests
             public override string Name
             {
                 get { return "HelloKuduWithSubFolders"; }
-            }
-
-            public override string CloneUrl
-            {
-                get { return "https://github.com/KuduApps/HelloKuduWithSubFolders.git"; }
             }
 
             public override string Content

--- a/Kudu.TestHarness/TestRepositories.cs
+++ b/Kudu.TestHarness/TestRepositories.cs
@@ -50,6 +50,7 @@ namespace Kudu.TestHarness
             new TestRepositoryInfo("https://github.com/KuduApps/MvcApplicationWithNuGetAutoRestore","1e269b5"),
             new TestRepositoryInfo("https://github.com/KuduApps/ConsoleWorker",                     "50c6cf5"),
             new TestRepositoryInfo("https://github.com/KuduApps/BasicConsoleWorker",                "ce1ec74"),
+            new TestRepositoryInfo("https://github.com/KuduApps/HelloKuduWithSubFolders.git",       "617fe07"),
         };
 
         private static Dictionary<string, TestRepositoryInfo> _repos;


### PR DESCRIPTION
this is a trivial fix to have test using the cached test repo.   another issue is Git.Clone() api if passing the CloneUrl arg, it will not honor the commitid set in TestRepositories.   I have not fixed that.
