### PR TITLE
use true async stdio streams for process executable

### DIFF
--- a/Build/Build.proj
+++ b/Build/Build.proj
@@ -39,10 +39,10 @@
         <RegexTransform Items="@(RegexTransform)" />
     </Target>
     
-    <Target Name="RunAll" DependsOnTargets="UpdateVersion; RestorePackages; Build; ReportFxCopResults; RunTests; BuildSites; BuildZips" />
+    <Target Name="RunAll" DependsOnTargets="UpdateVersion; RestorePackages; Build; ReportFxCopResults; RunTests; BuildSites; BuildZips; CopySymbols" />
 
     <Target Name="CreateOutputPath">
-        <MakeDir Directories="$(ArtifactsPath)" Condition="!Exists('$(ArtifactsPath)')" />
+        <MakeDir Directories="$(ArtifactsPath)\symbols" Condition="!Exists('$(ArtifactsPath)\symbols')" />
         <MakeDir Directories="$(TestResultsPath)" Condition="!Exists('$(TestResultsPath)')" />
     </Target>
 
@@ -129,5 +129,13 @@
           </Code>
         </Task>
       </UsingTask>
+      
+      <Target Name="CopySymbols">
+        <ItemGroup>
+          <SymbolFilesToCopy Include="$(ProjectRoot)\Kudu.*\obj\$(Configuration)\Kudu*.pdb" />
+          <SymbolFilesToCopy Include="$(ProjectRoot)\Kudu.*\obj\x86\$(Configuration)\Kudu*.pdb" />
+        </ItemGroup>
+        <Copy SourceFiles="%(SymbolFilesToCopy.FullPath)" DestinationFiles="$(ArtifactsPath)\symbols\%(Filename)%(Extension)" SkipUnchangedFiles="true" />
+      </Target>
       
 </Project>


### PR DESCRIPTION
Introduce a consistent Process start routine utilizing true async stdio streams read/write.   This routine is consumed by 3 executable's execution patterns.
1. simple commands such as git init.   these type of commands are only interested in output string.
2. stdio e2e commands.  these is used specifically for git server exe (info/ref, receive-pack, upload-pack).
3. long running commands such as deployment script.  these commands receive an ongoing progress during its execution lifetime.

Although it may not address #880 directly, at the minimum it should recover for infinite thread blocks. 
