### PR TITLE
Fix #813 Blacklist uninteresting attributes.

### DIFF
--- a/Kudu.Contracts/Tracing/TraceExtensions.cs
+++ b/Kudu.Contracts/Tracing/TraceExtensions.cs
@@ -11,6 +11,21 @@ namespace Kudu.Contracts.Tracing
 
         private static readonly Dictionary<string, string> _empty = new Dictionary<string, string>();
 
+        // These are the set of attributes/headers that will be filtered out from trace.xml.
+        private static readonly HashSet<string> _blackList = new HashSet<string>(new[]
+        {
+            AlwaysTrace,
+            TraceLevelKey,
+            "Max-Forwards",
+            "X-LiveUpgrade",
+            "X-ARR-LOG-ID",
+            "DISGUISED-HOST",
+            "X-Original-URL",
+            "X-Forwarded-For",
+            "X-ARR-SSL"
+        },
+        StringComparer.OrdinalIgnoreCase);
+
         public static IDisposable Step(this ITracer tracer, string message)
         {
             return tracer.Step(message, _empty);
@@ -80,7 +95,7 @@ namespace Kudu.Contracts.Tracing
         // Some attributes only carry control information and are not meant for display
         public static bool IsNonDisplayableAttribute(string key)
         {
-            return key == AlwaysTrace || key == TraceLevelKey;
+            return _blackList.Contains(key);
         }
 
         private static TraceLevel GetTraceLevel(IDictionary<string, string> attributes)
@@ -109,6 +124,5 @@ namespace Kudu.Contracts.Tracing
 
             return TraceLevel.Verbose;
         }
-
     }
 }

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Settings\SettingsProvidersTests.cs" />
     <Compile Include="SSHKeyManagerFacts.cs" />
     <Compile Include="TracerTests.cs" />
+    <Compile Include="Tracing\TracingTests.cs" />
     <Compile Include="Tracing\SiteExtensionLogManagerTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Kudu.Core.Test/Tracing/TracingTests.cs
+++ b/Kudu.Core.Test/Tracing/TracingTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Kudu.Contracts.Tracing;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Kudu.Core.Test.Tracing
+{
+    public class TracingTests
+    {
+        [Theory]
+        [InlineData(true, TraceExtensions.AlwaysTrace)]
+        [InlineData(true, TraceExtensions.TraceLevelKey)]
+        [InlineData(true, "Max-Forwards")]
+        [InlineData(true, "X-ARR-LOG-ID")]
+        [InlineData(false, "url")]
+        [InlineData(false, "method")]
+        [InlineData(false, "type")]
+        [InlineData(false, "Host")]
+        public void TracingAttributeBlacklistTests(bool expected, string header)
+        {
+            Assert.Equal(expected, TraceExtensions.IsNonDisplayableAttribute(header));
+        }
+    }
+}

--- a/Kudu.Core/Tracing/Tracer.cs
+++ b/Kudu.Core/Tracing/Tracer.cs
@@ -31,7 +31,6 @@ namespace Kudu.Core.Tracing
         public Tracer(string path, TraceLevel level, IOperationLock traceLock)
             : this(new FileSystem(), path, level, traceLock)
         {
-
         }
 
         public Tracer(IFileSystem fileSystem, string path, TraceLevel level, IOperationLock traceLock)


### PR DESCRIPTION
Old trace.xml with minimal filtering:

```
<step title="Incoming Request" 
    date="12/17 22:51:56" 
    url="/diagnostics/settings" 
    method="GET" type="request" 
    instance="3b789f" pid="1260,2,6" 
    Connection="Keep-Alive" 
    Accept="application/json" 
    Accept-Language="en-US" 
    Host="****" 
    Max-Forwards="9" 
    User-Agent="Azure-Portal/3.14.00296.29" 
    x-ms-client-request-id="****" 
    x-ms-client-session-id="ed199787-89b9-405e-9c79-3726b4604a04" 
    x-ms-principal-id="0003BFFDC3F88AB0" 
    x-ms-principal-liveid="****" 
    X-LiveUpgrade="1" 
    X-ARR-LOG-ID="7c4caefb-109d-4b27-9dd2-8ff1b3fd5af1" 
    DISGUISED-HOST="****" 
    X-Original-URL="/diagnostics/settings" 
    X-Forwarded-For="131.107.147.234:58186, 131.107.147.234" 
    X-ARR-SSL="1024|128|CN=*.kudu1.antares-test.windows-int.net|CN=*.kudu1.antares-test.windows-int.net"     
    elapsed="556">
```

New trace.xml with added filtering:

```
<step title="Incoming Request" 
    date="12/17 22:55:27" 
    url="/deploy" 
    method="GET" 
    type="request" 
    instance="3b789f" 
    pid="3848,2,6" 
    Connection="Keep-Alive" 
    Accept="text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8" 
    Accept-Encoding="gzip,deflate,sdch" 
    Accept-Language="en-US,en;q=0.8" 
    Cookie="WAWebSiteSID=c33e7cf2ce374d05a4e5cdface4bc009; ARRAffinity=3b789f785018ddd1d5e0dc7bd5555fa3c719565bb93d7c53a29acd231df7493e" 
    Host="testheader01.scm.kudu1.antares-test.windows-int.net" 
    User-Agent="Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36" 
    elapsed="82">
```
