### PR TITLE
Fixes GitHub payload DateTimeOffset conversion issue

### DIFF
--- a/Kudu.Services/ServiceHookHandlers/GitHubCompatHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/GitHubCompatHandler.cs
@@ -88,7 +88,7 @@ namespace Kudu.Services.ServiceHookHandlers
                     commitAuthor.Value<string>("name"),
                     commitAuthor.Value<string>("email"),
                     latestCommit.Value<string>("message"),
-                    DateTimeOffset.Parse(latestCommit.Value<string>("timestamp"))
+                    latestCommit.Value<DateTime>("timestamp")
             );
         }
 


### PR DESCRIPTION
Fixes 'String was not recognized as a valid DateTime' when processing payload from GitHub.
