### PR TITLE
fix #894 console hang with large number of files

### DIFF
--- a/Kudu.Core/Infrastructure/ProcessExtensions.cs
+++ b/Kudu.Core/Infrastructure/ProcessExtensions.cs
@@ -252,25 +252,14 @@ namespace Kudu.Core.Infrastructure
 
                 try
                 {
-                    // in happy path, stdio task will complete in timely manner and
-                    // delay task is canceled.  we observe the delay.Exception
-                    // explicitly to avoid first chance exception.
-                    if (delay.IsCanceled && delay.Exception == null)
-                    {
-                        await stdio;
-                    }
-                    else
-                    {
-                        // observe all tasks to avoid process crashes
-                        await Task.WhenAll(stdio, delay);
-                    }
+                    // to get the result of stdio flush
+                    await stdio;
 
-                    // in case tasks completion races with cancellation
                     break;
                 }
                 catch (TaskCanceledException)
                 {
-                    // expected since we cancelled all task
+                    // expected since we cancelled all tasks
                 }
 
                 // this means no activity within given time

--- a/Kudu.Services.Web/DebugConsole/Default.aspx
+++ b/Kudu.Services.Web/DebugConsole/Default.aspx
@@ -50,7 +50,7 @@
                                 <th scope="col">Size</th>
                             </tr>
                         </thead>
-                        <tbody data-bind="foreach: sort(selected().children())">
+                        <tbody data-bind="foreach: selected().children()">
                             <tr>
                                 <td class="actions">
                                     <div data-bind="visible: !editing()">

--- a/Kudu.Services/Commands/PersistentCommandController.cs
+++ b/Kudu.Services/Commands/PersistentCommandController.cs
@@ -109,7 +109,12 @@ namespace Kudu.Services
                 startInfo.EnvironmentVariables[environmentVariable.Key] = environmentVariable.Value;
             }
 
+            // add '>' to distinguish PROMPT from other output
             startInfo.EnvironmentVariables["PROMPT"] = "$P$G";
+
+            // dir cmd would list folders then files alpabetically
+            // consistent with FileBrowser ui.
+            startInfo.EnvironmentVariables["DIRCMD"] = "/OG /ON";
 
             var process = new Process
             {


### PR DESCRIPTION
There are two issues causing the browser to hang (busy).   

First, items are push one-by-one to ko.observable, this causes the UI to update for each inserted item (slow).  I fixed by pushing range of items instead of one-by-one - UI will be updated once.   Even with this, after a few hundred items, the UI perf will again degrade.  I introduce maxViewItems (default is 100) and one could override via localStorage.

Second, the sort function is slow for large array.  I fixed by ensuring the order in ko.observableArray to have folders before files (as a result, display folders before files).  Within folders and files, the server always returns in alphabetical order (no extra sort needed).

As unrelated fix, I cleanup the wait for Task complexity.  In 4.5, default .NET policy on unobserved faulted task is ignored (unlike 4.0, where the process will crash).
