### PR TITLE
Fixes #634: Clears git locks when the deployment lock is acquired.

### DIFF
--- a/Kudu.Core.Test/LockFileTests.cs
+++ b/Kudu.Core.Test/LockFileTests.cs
@@ -4,7 +4,9 @@ using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Kudu.Contracts.Infrastructure;
+using Kudu.Contracts.SourceControl;
 using Kudu.Core.Infrastructure;
+using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 using Moq;
 using Xunit;
@@ -61,6 +63,40 @@ namespace Kudu.Core.Test
 
             // Assert
             Assert.Equal(count * threads, totals);
+        }
+
+        [Fact]
+        public void LockFileRepositoryClearLockTest()
+        {
+            // Mock
+            var path = @"x:\temp";
+            var lockFileName = Path.Combine(path, "deployment.lock");
+            var fileSystem = new Mock<IFileSystem>();
+            var file = new Mock<FileBase>();
+            var directory = new Mock<DirectoryBase>();
+            var repository = new Mock<IRepository>();
+            var repositoryFactory = new Mock<IRepositoryFactory>();
+            var lockFile = new DeploymentLockFile(lockFileName, Mock.Of<ITraceFactory>(), fileSystem.Object);
+
+            // Setup
+            fileSystem.SetupGet(f => f.Directory)
+                      .Returns(directory.Object);
+            directory.Setup(d => d.Exists(path))
+                     .Returns(true);
+            fileSystem.SetupGet(f => f.File)
+                      .Returns(file.Object);
+            file.Setup(f => f.Open(lockFileName, FileMode.Create, FileAccess.Write, FileShare.None))
+                .Returns(Mock.Of<Stream>());
+            repositoryFactory.Setup(f => f.GetRepository())
+                             .Returns(repository.Object);
+
+            // Test
+            lockFile.RepositoryFactory = repositoryFactory.Object;
+            var locked = lockFile.Lock();
+
+            // Assert
+            Assert.True(locked, "lock should be successfule!");
+            repository.Verify(r => r.ClearLock(), Times.Once);
         }
 
         private LockFile MockLockFile(string path, ITraceFactory traceFactory = null, IFileSystem fileSystem = null)

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -184,8 +184,6 @@ namespace Kudu.Core.Deployment
 
                     ILogger logger = GetLogger(changeSet.Id);
 
-                    repository.ClearLock();
-
                     if (needFileUpdate)
                     {
                         using (tracer.Step("Updating to specific changeset"))

--- a/Kudu.Core/Infrastructure/DeploymentLockFile.cs
+++ b/Kudu.Core/Infrastructure/DeploymentLockFile.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO.Abstractions;
+using Kudu.Contracts.SourceControl;
+using Kudu.Core.SourceControl;
+using Kudu.Core.Tracing;
+
+namespace Kudu.Core.Infrastructure
+{
+    /// <summary>
+    /// Specific to deployment lock.
+    /// </summary>
+    public class DeploymentLockFile : LockFile
+    {
+        public DeploymentLockFile(string path, ITraceFactory traceFactory, IFileSystem fileSystem)
+            : base(path, traceFactory, fileSystem)
+        {
+        }
+
+        // This is set when IRepositoryFactory is created in Ninject.
+        public IRepositoryFactory RepositoryFactory
+        {
+            get;
+            set;
+        }
+
+        protected override void OnLockAcquired()
+        {
+            IRepositoryFactory repositoryFactory = RepositoryFactory;
+            if (repositoryFactory != null)
+            {
+                IRepository repository = repositoryFactory.GetRepository();
+                if (repository != null)
+                {
+                    // Clear any left over repository-related lock since we have the actual lock
+                    repository.ClearLock();
+                }
+            }
+        }
+    }
+}

--- a/Kudu.Core/Infrastructure/LockFile.cs
+++ b/Kudu.Core/Infrastructure/LockFile.cs
@@ -105,6 +105,8 @@ namespace Kudu.Core.Infrastructure
 
                 _lockStream = _fileSystem.File.Open(_path, FileMode.Create, FileAccess.Write, FileShare.None);
 
+                OnLockAcquired();
+
                 return true;
             }
             catch (Exception ex)
@@ -113,6 +115,11 @@ namespace Kudu.Core.Infrastructure
 
                 return false;
             }
+        }
+
+        protected virtual void OnLockAcquired()
+        {
+            // no-op
         }
 
         /// <summary>

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Infrastructure\DisposableAction.cs" />
     <Compile Include="Infrastructure\IniFile.cs" />
     <Compile Include="Infrastructure\LockFile.cs" />
+    <Compile Include="Infrastructure\DeploymentLockFile.cs" />
     <Compile Include="Infrastructure\OperationManager.cs" />
     <Compile Include="Infrastructure\VsHelper.cs" />
     <Compile Include="Infrastructure\XmlUtility.cs" />

--- a/Kudu.Core/SourceControl/Git/GitExeRepository.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeRepository.cs
@@ -366,7 +366,14 @@ echo $i > pushinfo
         public void ClearLock()
         {
             // Delete the lock file from the .git folder
-            var lockFiles = Directory.EnumerateFiles(Path.Combine(_gitExe.WorkingDirectory, ".git"), "*.lock", SearchOption.AllDirectories)
+            var lockFilesPath = Path.Combine(_gitExe.WorkingDirectory, ".git");
+            
+            if (!Directory.Exists(lockFilesPath))
+            {
+                return;
+            }
+
+            var lockFiles = Directory.EnumerateFiles(lockFilesPath, "*.lock", SearchOption.AllDirectories)
                                      .Where(fullPath => _lockFileNames.Contains(Path.GetFileName(fullPath), StringComparer.OrdinalIgnoreCase))
                                      .ToList();
             if (lockFiles.Count > 0)

--- a/Kudu.Services/FetchHelpers/DropboxHelper.cs
+++ b/Kudu.Services/FetchHelpers/DropboxHelper.cs
@@ -146,7 +146,6 @@ namespace Kudu.Services
             if (!repository.IsEmpty())
             {
                 // git checkout --force <branch>
-                repository.ClearLock();
                 repository.Update(branch);
             }
 

--- a/Kudu.Services/ServiceHookHandlers/ServiceHookHandlerBase.cs
+++ b/Kudu.Services/ServiceHookHandlers/ServiceHookHandlerBase.cs
@@ -14,7 +14,6 @@ namespace Kudu.Services.ServiceHookHandlers
 
         public Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger)
         {
-            repository.ClearLock();
             repository.FetchWithoutConflict(deploymentInfo.RepositoryUrl, targetBranch);
             return _completed;
         }


### PR DESCRIPTION
Fixes #634: Clears git locks when the deployment lock is acquired.

Added ClearLock() when DeploymentLock is acquired to prevent deadlock in more scenarios.

For example, the scenario below will return an error. 
1. Run Kudu. Assume $KUDU_DIR$ is .../kudu/apps/<app name>/site/repository
2. To simulate git crashing during an operation, create the index.lock file in .git folder. In msys git, run 
    touch $KUDU_DIR$/.git/index.lock
3. Try the api in LiveScmEditorController, which will fail.
    curl -X PUT --data " cool page" %KUDU_URL%/scmvfs/cool.txt
An error will be returned.

The idea is that index.lock may be left over from a previous failed git operation, which can be cleared for users.
