### PR TITLE
add test harness xunit attribute to support retry and others

### DIFF
--- a/Kudu.FunctionalTests/App.config
+++ b/Kudu.FunctionalTests/App.config
@@ -5,6 +5,12 @@
         <add key="SiteReusedForAllTests" value="TestRunnerSite"/>
         <!-- Update to change the maximum number of sites created on failure in reuse site mode -->
         <add key="MaxSiteNameIndex" value="1"/>
+        <!-- number of repeated runs -->
+        <add key="TestHarness.Runs" value="1"/>
+        <!-- number of retries if failed -->
+        <add key="TestHarness.Retries" value="1"/>
+        <!-- whether to suppress error if retry succeeds. -->
+        <add key="TestHarness.SuppressError" value="false"/>
     </appSettings>
     <system.net>
         <connectionManagement>

--- a/Kudu.FunctionalTests/CommandExecutorTests.cs
+++ b/Kudu.FunctionalTests/CommandExecutorTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class CommandExecutorTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/CustomGitTests.cs
+++ b/Kudu.FunctionalTests/CustomGitTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class CustomGitTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/DeploymentActionsTests.cs
+++ b/Kudu.FunctionalTests/DeploymentActionsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class DeploymentActionsTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/DeploymentManagerTests.cs
+++ b/Kudu.FunctionalTests/DeploymentManagerTests.cs
@@ -21,6 +21,7 @@ using Xunit.Extensions;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class DeploymentManagerTests
     {
         [Fact]
@@ -807,7 +808,7 @@ namespace Kudu.FunctionalTests
             yield return new RepoInvalidInfo("InvalidUrl", "Repository url 'InvalidUrl' is invalid.", null);
             yield return new RepoInvalidInfo("InvalidUrl", "Repository url 'InvalidUrl' is invalid.", null);
             yield return new RepoInvalidInfo(".", "Repository url '.' is invalid.", null);
-            yield return new RepoInvalidInfo("http://google.com/", "fatal:.*http://google.com.* not found", null);
+            yield return new RepoInvalidInfo("http://google.com/", "fatal:.*http://.*google.com.* not found", null);
             yield return new RepoInvalidInfo("http://google.com/", "abort: 'http://www.google.com/' does not appear to be an hg repository", "hg");
             yield return new RepoInvalidInfo("InvalidScheme://abcdefghigkl.com/", "fatal: Unable to find remote helper for 'InvalidScheme'", null);
             yield return new RepoInvalidInfo("InvalidScheme://abcdefghigkl.com/", "abort: repository InvalidScheme://abcdefghigkl.com/ not found", "hg");

--- a/Kudu.FunctionalTests/DiagnosticsApiFacts.cs
+++ b/Kudu.FunctionalTests/DiagnosticsApiFacts.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class DiagnosticsApiFacts
     {
         [Fact]

--- a/Kudu.FunctionalTests/DropboxTests.cs
+++ b/Kudu.FunctionalTests/DropboxTests.cs
@@ -25,6 +25,7 @@ using Xunit.Extensions;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class DropboxTests
     {
         private const string OAuth20Token = "";

--- a/Kudu.FunctionalTests/GitDeploymentTests.cs
+++ b/Kudu.FunctionalTests/GitDeploymentTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class GitDeploymentTests
     {
         // ASP.NET apps

--- a/Kudu.FunctionalTests/GitRepositoryFacts.cs
+++ b/Kudu.FunctionalTests/GitRepositoryFacts.cs
@@ -12,6 +12,7 @@ using Xunit.Extensions;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class GitRepositoryFacts
     {
         [Fact]

--- a/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
+++ b/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class GitRepositoryManagementTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/GitStabilityTests.cs
+++ b/Kudu.FunctionalTests/GitStabilityTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class GitStabilityTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/HgRepositoryFacts.cs
+++ b/Kudu.FunctionalTests/HgRepositoryFacts.cs
@@ -12,6 +12,7 @@ using Xunit.Extensions;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class HgRepositoryFacts
     {
         [Fact]

--- a/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
+++ b/Kudu.FunctionalTests/InPlaceDeploymentTests.cs
@@ -10,6 +10,7 @@ using Xunit.Extensions;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class InPlaceDeploymentTest
     {
         [Theory]

--- a/Kudu.FunctionalTests/InitialCloneTests.cs
+++ b/Kudu.FunctionalTests/InitialCloneTests.cs
@@ -12,6 +12,7 @@ using Xunit.Extensions;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class InitialCloneTest
     {
         [Theory]

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests.Jobs
 {
+    [TestHarnessClassCommand]
     public class WebJobsTests
     {
         private const string VerificationFilePath = "LogFiles/verification.txt";

--- a/Kudu.FunctionalTests/LargeRepoTests.cs
+++ b/Kudu.FunctionalTests/LargeRepoTests.cs
@@ -14,6 +14,7 @@ using TimeoutException = System.TimeoutException;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class LargeRepoTests
     {
         private static readonly bool shouldRunLargeRepoTests = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("RUN_LARGE_REPO_TESTS"));

--- a/Kudu.FunctionalTests/LogStreamManagerTests.cs
+++ b/Kudu.FunctionalTests/LogStreamManagerTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class LogStreamManagerTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/SelectNodeVersionFacts.cs
+++ b/Kudu.FunctionalTests/SelectNodeVersionFacts.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class SelectNodeVersionFacts
     {
         [Fact]

--- a/Kudu.FunctionalTests/SettingsApiFacts.cs
+++ b/Kudu.FunctionalTests/SettingsApiFacts.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class SettingsApiFacts
     {
         [Fact]

--- a/Kudu.FunctionalTests/Vfs/LiveScmEditorControllerTest.cs
+++ b/Kudu.FunctionalTests/Vfs/LiveScmEditorControllerTest.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class LiveScmEditorControllerTest
     {
         [Fact]

--- a/Kudu.FunctionalTests/Vfs/VfsControllerTest.cs
+++ b/Kudu.FunctionalTests/Vfs/VfsControllerTest.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class VfsControllerTest
     {
         [Fact]

--- a/Kudu.FunctionalTests/WebHooksTests.cs
+++ b/Kudu.FunctionalTests/WebHooksTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class WebHooksTests
     {
         [Fact]

--- a/Kudu.FunctionalTests/ZipTests.cs
+++ b/Kudu.FunctionalTests/ZipTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Kudu.FunctionalTests
 {
+    [TestHarnessClassCommand]
     public class ZipTests
     {
         [Fact]

--- a/Kudu.TestHarness/Kudu.TestHarness.csproj
+++ b/Kudu.TestHarness/Kudu.TestHarness.csproj
@@ -17,6 +17,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.extensions, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -38,6 +46,7 @@
   <ItemGroup>
     <Compile Include="ApplicationManager.cs" />
     <Compile Include="ApplicationManagerExtensions.cs" />
+    <Compile Include="TestHarnessClassCommandAttribute.cs" />
     <Compile Include="MockDeploymentSettingsManager.cs" />
     <Compile Include="Npm.cs" />
     <Compile Include="Node.cs" />

--- a/Kudu.TestHarness/TestHarnessClassCommandAttribute.cs
+++ b/Kudu.TestHarness/TestHarnessClassCommandAttribute.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using Kudu.Core;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Kudu.TestHarness
+{
+    public class TestHarnessClassCommandAttribute : RunWithAttribute
+    {
+        // Number of retries.  When test failed, it will be re-tried
+        // based on this value.  Default 0 means never retry.
+        public const int DefaultRetries = 0;
+
+        // If retry successful, suppress any error and report as success result.
+        // Default is false means always report as error.
+        public const bool DefaultSuppressError = false;
+
+        // Number of run iterations. this is used when you want to stress 
+        // the test and running it in a loop.  Default is 1 means run only once.
+        // Regardless of this settings, it will always stop on first failure.
+        public const int DefaultRuns = 1;
+
+        // Override via Test assembly's appSettings 
+        public const string RunsSettingKey = "TestHarness.Runs";
+        public const string RetriesSettingKey = "TestHarness.Retries";
+        public const string SuppressErrorSettingKey = "TestHarness.SuppressError";
+
+        public TestHarnessClassCommandAttribute()
+            : base(typeof(TestHarnessClassCommand))
+        {
+            Retries = DefaultRetries;
+            SuppressError = DefaultSuppressError;
+            Runs = DefaultRuns;
+        }
+
+        public int Retries
+        {
+            get;
+            set;
+        }
+
+        public bool SuppressError
+        {
+            get;
+            set;
+        }
+
+        public int Runs
+        {
+            get;
+            set;
+        }
+
+        class TestHarnessClassCommand : TestClassCommand
+        {
+            public override IEnumerable<ITestCommand> EnumerateTestCommands(IMethodInfo testMethod)
+            {
+                var attribute = (TestHarnessClassCommandAttribute)this.TypeUnderTest.Type.GetCustomAttributes(typeof(TestHarnessClassCommandAttribute), true)[0];
+                foreach (ITestCommand testCommand in base.EnumerateTestCommands(testMethod))
+                {
+                    if (testCommand is SkipCommand)
+                    {
+                        yield return testCommand;
+                    }
+                    else
+                    {
+                        yield return new TestHarnessCommand(attribute, testCommand);
+                    }
+                }
+            }
+
+            class TestHarnessCommand : DelegatingTestCommand
+            {
+                private readonly int _runs;
+                private readonly int _retries;
+                private readonly bool _suppressError;
+
+                public TestHarnessCommand(TestHarnessClassCommandAttribute attribute, ITestCommand inner)
+                    : base(inner)
+                {
+                    if (!Int32.TryParse(ConfigurationManager.AppSettings[RunsSettingKey], out _runs))
+                    {
+                        _runs = attribute.Runs;
+                    }
+                    _runs = Math.Max(DefaultRuns, _runs);
+
+                    if (!Int32.TryParse(ConfigurationManager.AppSettings[RetriesSettingKey], out _retries))
+                    {
+                        _retries = attribute.Retries;
+                    }
+                    _retries = Math.Max(DefaultRetries, _retries);
+
+                    if (!Boolean.TryParse(ConfigurationManager.AppSettings[SuppressErrorSettingKey], out _suppressError))
+                    {
+                        _suppressError = attribute.SuppressError;
+                    }
+                }
+
+                public override MethodResult Execute(object testClass)
+                {
+                    MethodResult result = null;
+                    for (int i = 0; i < _runs; ++i)
+                    {
+                        result = ExecuteInternal(testClass);
+                        if (result is FailedResult)
+                        {
+                            break;
+                        }
+
+                        TraceIf(_runs > 1, "Run {0}/{1} passed successfully.", i + 1, _runs);
+                    }
+
+                    return result;
+                }
+
+                private MethodResult ExecuteInternal(object testClass)
+                {
+                    Exception exception = null;
+                    MethodResult result = null;
+                    MethodResult failedResult = null;
+                    for (int i = 0; i < _retries + 1; ++i)
+                    {
+                        try
+                        {
+                            result = InnerCommand.Execute(testClass);
+                            if (result is FailedResult)
+                            {
+                                TraceIf(_retries > 0, "Retry {0}/{1} failed.", i, _retries);
+                                failedResult = (FailedResult)result;
+                            }
+                            else
+                            {
+                                TraceIf(_retries > 0 && i > 0, "Retry {0}/{1} passed successfully.", i, _retries);
+                                break;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            TraceIf(_retries > 0, "Retry {0}/{1} failed with {2}", i, _retries, ex);
+
+                            // optimize to preserve stacktrace
+                            if (i >= _retries)
+                            {
+                                throw;
+                            }
+                            exception = ex;
+                        }
+                    }
+
+                    if (_suppressError && result is PassedResult)
+                    {
+                        return result;
+                    }
+
+                    if (exception != null)
+                    {
+                        ExceptionUtility.RethrowWithNoStackTraceLoss(exception);
+                    }
+
+                    return failedResult ?? result;
+                }
+            }
+        }
+
+        public static void TraceIf(bool condition, string messageFormat, params object[] args)
+        {
+            if (condition)
+            {
+                TestTracer.Trace(messageFormat, args);
+                TestTracer.Trace("====================================================================================\r\n");
+            }
+        }
+    }
+}

--- a/Kudu.TestHarness/packages.config
+++ b/Kudu.TestHarness/packages.config
@@ -6,4 +6,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.15" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
the motivation is to allow auto retry when test failed (this is often what we do when investigate error).   there are 3 test settings below (commented in codes).

```
     // Number of retries.  When test failed, it will be re-tried
     // based on this value.  Default 0 means never retry.
     public const int DefaultRetries = 0;

     // If retry successful, suppress any error and report as success result.
     // Default is false means always report as error.
     public const bool DefaultSuppressError = false;

     // Number of iterations. this is used when you want to stress 
     // the test and running it in a loop.  Default is 1 means run only once.
     // Regardless of this settings, it will always stop on first failures.
     public const int DefaultRuns = 1;

     // Override via Test assembly's appSettings 
     public const string RunsSettingKey = "TestHarness.Runs";
     public const string RetriesSettingKey = "TestHarness.Retries";
     public const string SuppressErrorSettingKey = "TestHarness.SuppressError";
```

@gissues:{"order":54.80769230769212,"status":"backlog"}
