### PR TITLE
fix #998 to close the stream when deadlock

### DIFF
--- a/Kudu.Core.Test/ProcessApiFacts.cs
+++ b/Kudu.Core.Test/ProcessApiFacts.cs
@@ -120,8 +120,9 @@ namespace Kudu.Core.Test
         [Fact]
         public async Task ProcesStartBasicTests()
         {
+            var tracer = Mock.Of<ITracer>();
             var process = new Mock<IProcess>();
-            var idleManager = new IdleManager(TimeSpan.MaxValue, Mock.Of<ITracer>());
+            var idleManager = new IdleManager(TimeSpan.MaxValue, tracer);
 
             var expectedExitCode = 10;
             var input = "this is input";
@@ -161,7 +162,7 @@ namespace Kudu.Core.Test
                    .Returns(true);
 
             // Test
-            int actualExitCode = await process.Object.Start(actualOutput, actualError, expectedInput, idleManager);
+            int actualExitCode = await process.Object.Start(tracer, actualOutput, actualError, expectedInput, idleManager);
 
             // Assert
             Assert.Equal(expectedExitCode, actualExitCode);
@@ -174,8 +175,9 @@ namespace Kudu.Core.Test
         [Fact]
         public async Task ProcesOutputBlockedTests()
         {
+            var tracer = Mock.Of<ITracer>();
             var process = new Mock<IProcess>();
-            var idleManager = new IdleManager(TimeSpan.MaxValue, Mock.Of<ITracer>());
+            var idleManager = new IdleManager(TimeSpan.MaxValue, tracer);
             var output = new Mock<Stream>(MockBehavior.Strict);
             CancellationToken cancellationToken;
 
@@ -205,7 +207,7 @@ namespace Kudu.Core.Test
                 ProcessExtensions.StandardOutputDrainTimeout = TimeSpan.FromSeconds(1);
 
                 // Test
-                await process.Object.Start(new MemoryStream(), new MemoryStream(), null, idleManager);
+                await process.Object.Start(tracer, new MemoryStream(), new MemoryStream(), null, idleManager);
 
                 throw new InvalidOperationException("Should not reach here!");
             }

--- a/Kudu.Core/Infrastructure/Executable.cs
+++ b/Kudu.Core/Infrastructure/Executable.cs
@@ -263,7 +263,7 @@ namespace Kudu.Core.Infrastructure
                 {
                     var wrapper = new ProcessWrapper(process);
 
-                    int exitCode = await wrapper.Start(output, error, input, idleManager ?? new IdleManager(IdleTimeout, tracer));
+                    int exitCode = await wrapper.Start(tracer, output, error, input, idleManager ?? new IdleManager(IdleTimeout, tracer));
 
                     tracer.TraceProcessExitCode(process);
 


### PR DESCRIPTION
In the past we did cancel the async stdout/err operations and wait for it to complete (canceled).   However, this still deadlock.   This fix simply close/dispose the stdout/err.  This should force the stream to abort all operations.
