### PR TITLE
Fixes #833: Use FileSystemHelpers.Instance for FileSystem singleton.

### DIFF
--- a/Kudu.Core.Test/AsyncLockFileTests.cs
+++ b/Kudu.Core.Test/AsyncLockFileTests.cs
@@ -22,7 +22,7 @@ namespace Kudu.Core.Test
         public AsyncLockFileTests()
         {
             _lockFilePath = Path.Combine(PathHelper.TestLockPath, "file.lock");
-            _lockFile = new DeploymentLockFile(_lockFilePath, NullTracerFactory.Instance, new FileSystem());
+            _lockFile = new DeploymentLockFile(_lockFilePath, NullTracerFactory.Instance);
             _lockFile.InitializeAsyncLocks();
         }
 
@@ -30,7 +30,7 @@ namespace Kudu.Core.Test
         public void AsyncLock_ThrowsIfNotInitialized()
         {
             string lockFilePath = Path.Combine(PathHelper.TestLockPath, "uninitialized.lock");
-            LockFile uninitialized = new LockFile(lockFilePath, NullTracerFactory.Instance, new FileSystem());
+            LockFile uninitialized = new LockFile(lockFilePath, NullTracerFactory.Instance);
             Assert.Throws<InvalidOperationException>(() => uninitialized.LockAsync());
         }
 

--- a/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
@@ -5,6 +5,7 @@ using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment;
 using Kudu.Core.Hooks;
+using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 using Moq;
@@ -112,7 +113,7 @@ namespace Kudu.Core.Test.Deployment
         {
             builderFactory = builderFactory ?? Mock.Of<ISiteBuilderFactory>();
             environment = environment ?? Mock.Of<IEnvironment>();
-            fileSystem = fileSystem ?? Mock.Of<IFileSystem>();
+            FileSystemHelpers.Instance = fileSystem ?? Mock.Of<IFileSystem>();
             traceFactory = traceFactory ?? Mock.Of<ITraceFactory>();
             analytics = analytics ?? Mock.Of<IAnalytics>();
             settings = settings ?? Mock.Of<IDeploymentSettingsManager>();
@@ -120,7 +121,7 @@ namespace Kudu.Core.Test.Deployment
             deploymentLock = deploymentLock ?? Mock.Of<IOperationLock>();
             globalLogger = globalLogger ?? Mock.Of<ILogger>();
 
-            return new DeploymentManager(builderFactory, environment, fileSystem, traceFactory, analytics, settings, status, deploymentLock, globalLogger, hooksManager);
+            return new DeploymentManager(builderFactory, environment, traceFactory, analytics, settings, status, deploymentLock, globalLogger, hooksManager);
         }
     }
 }

--- a/Kudu.Core.Test/Deployment/NodeSiteEnablerTests.cs
+++ b/Kudu.Core.Test/Deployment/NodeSiteEnablerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO.Abstractions;
+using Kudu.Core.Infrastructure;
 using Moq;
 using Xunit;
 using Xunit.Extensions;
@@ -42,8 +43,9 @@ namespace Kudu.Core.Deployment.Generator.Test
             }
 
             fileSystemMock.Setup(f => f.File).Returns(fileMock.Object);
+            FileSystemHelpers.Instance = fileSystemMock.Object;
 
-            bool looksLikeNodeResult = NodeSiteEnabler.LooksLikeNode(fileSystemMock.Object, "site");
+            bool looksLikeNodeResult = NodeSiteEnabler.LooksLikeNode("site");
             Assert.Equal(looksLikeNodeExpectedResult, looksLikeNodeResult);
         }
     }

--- a/Kudu.Core.Test/FileSystemHelpersTest.cs
+++ b/Kudu.Core.Test/FileSystemHelpersTest.cs
@@ -20,8 +20,9 @@ namespace Kudu.Core.Test
             var directory = new Mock<DirectoryBase>();
             fileSystem.Setup(m => m.Directory).Returns(directory.Object);
             directory.Setup(m => m.Exists("foo")).Returns(false);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
-            string path = FileSystemHelpers.EnsureDirectory(fileSystem.Object, "foo");
+            string path = FileSystemHelpers.EnsureDirectory("foo");
 
             Assert.Equal("foo", path);
             directory.Verify(m => m.CreateDirectory("foo"), Times.Once());
@@ -34,8 +35,9 @@ namespace Kudu.Core.Test
             var directory = new Mock<DirectoryBase>();
             fileSystem.Setup(m => m.Directory).Returns(directory.Object);
             directory.Setup(m => m.Exists("foo")).Returns(true);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
-            string path = FileSystemHelpers.EnsureDirectory(fileSystem.Object, "foo");
+            string path = FileSystemHelpers.EnsureDirectory("foo");
 
             Assert.Equal("foo", path);
             directory.Verify(m => m.CreateDirectory("foo"), Times.Never());

--- a/Kudu.Core.Test/Hooks/WebHooksManagerTests.cs
+++ b/Kudu.Core.Test/Hooks/WebHooksManagerTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Hooks;
+using Kudu.Core.Infrastructure;
 using Moq;
 using Xunit;
 
@@ -224,6 +225,8 @@ namespace Kudu.Core.Test.Deployment
                             _hooksFileContent = contents;
                         });
 
+            FileSystemHelpers.Instance = fileSystemMock.Object;
+
             return fileSystemMock;
         }
 
@@ -233,8 +236,9 @@ namespace Kudu.Core.Test.Deployment
             var environmentMock = BuildEnvironmentMock();
             var fileSystemMock = BuildFileSystemMock();
             var tracer = Mock.Of<ITracer>();
+            FileSystemHelpers.Instance = fileSystemMock.Object;
 
-            return new WebHooksManager(tracer, environmentMock.Object, hooksLockMock.Object, fileSystemMock.Object);
+            return new WebHooksManager(tracer, environmentMock.Object, hooksLockMock.Object);
         }
     }
 }

--- a/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
+++ b/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO.Abstractions;
+using Kudu.Core.Infrastructure;
 using Moq;
 using Xunit;
 
@@ -8,21 +9,13 @@ namespace Kudu.Core.Test
     public class EnvironmentFacts
     {
         [Fact]
-        public void ConstructorThrowsIfFileSystemIsNull()
-        {
-            // Act and Assert
-            var ex = Assert.Throws<ArgumentNullException>(() =>
-                new Environment(null, null, null, null, null, null, null, null, null, null, null, null));
-
-            Assert.Equal("fileSystem", ex.ParamName);
-        }
-
-        [Fact]
         public void ConstructorThrowsIfRepositoryPathResolverIsNull()
         {
+            FileSystemHelpers.Instance = Mock.Of<IFileSystem>();
+
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() =>
-                new Environment(Mock.Of<IFileSystem>(), null, null, null, null, null, null, null, null, null, null, null));
+                new Environment(null, null, null, null, null, null, null, null, null, null, null));
 
             Assert.Equal("repositoryPath", ex.ParamName);
         }
@@ -38,6 +31,7 @@ namespace Kudu.Core.Test
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem.Setup(s => s.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = mockFileSystem.Object;
 
             var environment = CreateEnvironment(mockFileSystem.Object, repositoryPath: repositoryPath);
 
@@ -60,6 +54,7 @@ namespace Kudu.Core.Test
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem.Setup(s => s.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = mockFileSystem.Object;
 
             var environment = CreateEnvironment(mockFileSystem.Object, webRootPath: webRootPath);
 
@@ -82,6 +77,7 @@ namespace Kudu.Core.Test
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem.Setup(s => s.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = mockFileSystem.Object;
 
             var environment = CreateEnvironment(mockFileSystem.Object, deploymentsPath: deployCachePath);
 
@@ -104,6 +100,7 @@ namespace Kudu.Core.Test
 
             var mockFileSystem = new Mock<IFileSystem>();
             mockFileSystem.Setup(s => s.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = mockFileSystem.Object;
 
             var environment = CreateEnvironment(mockFileSystem.Object, sshKeyPath: sshPath);
 
@@ -133,9 +130,9 @@ namespace Kudu.Core.Test
             repositoryPath = repositoryPath ?? "";
             rootPath = rootPath ?? "";
             dataPath = dataPath ?? "";
+            FileSystemHelpers.Instance = fileSystem;
 
-            return new Environment(fileSystem,
-                    rootPath,
+            return new Environment(rootPath,
                     siteRootPath,
                     tempPath,
                     repositoryPath,

--- a/Kudu.Core.Test/JsonSettingsFacts.cs
+++ b/Kudu.Core.Test/JsonSettingsFacts.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using Kudu.Core.Infrastructure;
 using Kudu.Core.Settings;
 using Moq;
 using Newtonsoft.Json;
@@ -20,7 +21,7 @@ namespace Kudu.Core.Test
         {
             IFileSystem fileSystem = GetMockFileSystem(SettingsPath);
 
-            var settings = new JsonSettings(fileSystem, SettingsPath);
+            var settings = new JsonSettings(SettingsPath);
 
             Assert.Equal(null, settings.GetValue("non_existing"));
 
@@ -28,7 +29,7 @@ namespace Kudu.Core.Test
 
             Assert.False(settings.DeleteValue("non_existing"));
 
-            Assert.False(fileSystem.File.Exists(SettingsPath));
+            Assert.False(FileSystemHelpers.FileExists(SettingsPath));
         }
 
         [Fact]
@@ -40,7 +41,9 @@ namespace Kudu.Core.Test
                 new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString())
             };
 
-            var settings = new JsonSettings(GetMockFileSystem(SettingsPath, values), SettingsPath);
+            FileSystemHelpers.Instance = GetMockFileSystem(SettingsPath, values);
+
+            var settings = new JsonSettings(SettingsPath);
 
             foreach (KeyValuePair<string, string> value in values)
             {
@@ -63,7 +66,9 @@ namespace Kudu.Core.Test
                 { Guid.NewGuid().ToString(), random.Next() % 2 == 0 }
             };
 
-            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+            FileSystemHelpers.Instance = GetMockFileSystem(SettingsPath);
+
+            var settings = new JsonSettings(SettingsPath);
 
             foreach (KeyValuePair<string, JToken> value in values)
             {
@@ -86,7 +91,9 @@ namespace Kudu.Core.Test
                 { Guid.NewGuid().ToString(), random.Next() % 2 == 0 }
             };
 
-            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+            FileSystemHelpers.Instance = GetMockFileSystem(SettingsPath);
+
+            var settings = new JsonSettings(SettingsPath);
 
             Assert.Equal(0, settings.GetValues().Count());
 
@@ -126,7 +133,9 @@ namespace Kudu.Core.Test
                 json[value.Key] = value.Value;
             }
 
-            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+            FileSystemHelpers.Instance = GetMockFileSystem(SettingsPath);
+
+            var settings = new JsonSettings(SettingsPath);
 
             Assert.Equal(0, settings.GetValues().Count());
 
@@ -144,7 +153,8 @@ namespace Kudu.Core.Test
         public void NullOrEmptyTest()
         {
             var key = Guid.NewGuid().ToString();
-            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+            FileSystemHelpers.Instance = GetMockFileSystem(SettingsPath);
+            var settings = new JsonSettings(SettingsPath);
 
             Assert.Equal(null, settings.GetValue(key));
 
@@ -159,7 +169,9 @@ namespace Kudu.Core.Test
         public void DeleteValueTest()
         {
             var value = new KeyValuePair<string, string>(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
-            var settings = new JsonSettings(GetMockFileSystem(SettingsPath), SettingsPath);
+            FileSystemHelpers.Instance = GetMockFileSystem(SettingsPath);
+
+            var settings = new JsonSettings(SettingsPath);
 
             Assert.Equal(null, settings.GetValue(value.Key));
 
@@ -219,6 +231,8 @@ namespace Kudu.Core.Test
 
             fileSystem.Setup(fs => fs.File).Returns(file.Object);
             fileSystem.Setup(fs => fs.Directory).Returns(directory.Object);
+
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             return fileSystem.Object;
         }

--- a/Kudu.Core.Test/LockFileTests.cs
+++ b/Kudu.Core.Test/LockFileTests.cs
@@ -76,7 +76,7 @@ namespace Kudu.Core.Test
             var directory = new Mock<DirectoryBase>();
             var repository = new Mock<IRepository>();
             var repositoryFactory = new Mock<IRepositoryFactory>();
-            var lockFile = new DeploymentLockFile(lockFileName, Mock.Of<ITraceFactory>(), fileSystem.Object);
+            var lockFile = new DeploymentLockFile(lockFileName, Mock.Of<ITraceFactory>());
 
             // Setup
             fileSystem.SetupGet(f => f.Directory)
@@ -89,6 +89,7 @@ namespace Kudu.Core.Test
                 .Returns(Mock.Of<Stream>());
             repositoryFactory.Setup(f => f.GetRepository())
                              .Returns(repository.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
             lockFile.RepositoryFactory = repositoryFactory.Object;
@@ -135,7 +136,9 @@ namespace Kudu.Core.Test
                 fileSystem = fs.Object;
             }
 
-            return new LockFile(path, traceFactory, fileSystem);
+            FileSystemHelpers.Instance = fileSystem;
+
+            return new LockFile(path, traceFactory);
         }
     }
 }

--- a/Kudu.Core.Test/ProcessApiFacts.cs
+++ b/Kudu.Core.Test/ProcessApiFacts.cs
@@ -34,9 +34,10 @@ namespace Kudu.Core.Test
                       .Returns(true);
             file.Setup(f => f.OpenRead(path))
                       .Returns(() => new MemoryStream());
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
-            using (var stream = ProcessController.FileStreamWrapper.OpenRead(path, fileSystem.Object))
+            using (var stream = ProcessController.FileStreamWrapper.OpenRead(path))
             {
             }
 
@@ -59,9 +60,10 @@ namespace Kudu.Core.Test
                       .Returns(true);
             file.Setup(f => f.OpenRead(path))
                       .Returns(() => new MemoryStream());
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
-            var stream = ProcessController.FileStreamWrapper.OpenRead(path, fileSystem.Object);
+            var stream = ProcessController.FileStreamWrapper.OpenRead(path);
             stream.Close();
 
             // Assert
@@ -72,7 +74,7 @@ namespace Kudu.Core.Test
         public void MiniDumpFreeModeTests()
         {
             var settings = new Mock<IDeploymentSettingsManager>();
-            var controller = new Mock<ProcessController>(Mock.Of<ITracer>(), null, settings.Object, null);
+            var controller = new Mock<ProcessController>(Mock.Of<ITracer>(), null, settings.Object);
 
             // Setup
             controller.Object.Request = new HttpRequestMessage();

--- a/Kudu.Core.Test/PurgeDeploymentsTests.cs
+++ b/Kudu.Core.Test/PurgeDeploymentsTests.cs
@@ -57,7 +57,7 @@ namespace Kudu.Core.Test
             var status = new Mock<IDeploymentStatusManager>();
             var trace = new Mock<ITraceFactory>();
             var tracer = new Mock<ITracer>();
-            var manager = new DeploymentManager(null, null, null, trace.Object, null, null, status.Object, null, null, null);
+            var manager = new DeploymentManager(null, null, trace.Object, null, null, status.Object, null, null, null);
 
             // Setup
             status.Setup(s => s.ActiveDeploymentId)

--- a/Kudu.Core.Test/SSHKeyManagerFacts.cs
+++ b/Kudu.Core.Test/SSHKeyManagerFacts.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Security.Cryptography;
 using System.Text;
+using Kudu.Core.Infrastructure;
 using Moq;
 using Xunit;
 using Xunit.Extensions;
@@ -33,20 +34,8 @@ namespace Kudu.Core.SSHKey.Test
             IEnvironment env = null;
 
             // Act and Assert
-            var ex = Assert.Throws<ArgumentNullException>(() => new SSHKeyManager(env, fileSystem: null, traceFactory: null));
+            var ex = Assert.Throws<ArgumentNullException>(() => new SSHKeyManager(env, traceFactory: null));
             Assert.Equal("environment", ex.ParamName);
-        }
-
-        [Fact]
-        public void ConstructorThrowsIfFileSystemIsNull()
-        {
-            // Arrange
-            IEnvironment env = Mock.Of<IEnvironment>();
-            IFileSystem fileSystem = null;
-
-            // Act and Assert
-            var ex = Assert.Throws<ArgumentNullException>(() => new SSHKeyManager(env, fileSystem, traceFactory: null));
-            Assert.Equal("fileSystem", ex.ParamName);
         }
 
         [Fact]
@@ -68,11 +57,12 @@ namespace Kudu.Core.SSHKey.Test
             var fileSystem = new Mock<IFileSystem>();
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
             fileSystem.SetupGet(f => f.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act
             sshKeyManager.SetPrivateKey(_privateKey);
@@ -97,11 +87,12 @@ namespace Kudu.Core.SSHKey.Test
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
             fileSystem.SetupGet(f => f.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act
             sshKeyManager.SetPrivateKey(_privateKey);
@@ -121,18 +112,19 @@ namespace Kudu.Core.SSHKey.Test
             fileBase.Setup(s => s.WriteAllText(sshPath + @"\config", "HOST *\r\n  StrictHostKeyChecking no"));
             fileBase.Setup(s => s.WriteAllText(sshPath + @"\id_rsa", It.IsAny<string>()));
             fileBase.Setup(s => s.Exists(sshPath + @"\id_rsa.pub"))
-                    .Returns(() => ++invoked == 1);
+                    .Returns(() => ++invoked <= 2);
 
             var directory = new Mock<DirectoryBase>();
             directory.Setup(d => d.Exists(sshPath)).Returns(true);
             var fileSystem = new Mock<IFileSystem>();
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
             fileSystem.SetupGet(f => f.Directory).Returns(directory.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act
             sshKeyManager.SetPrivateKey(key1);
@@ -157,11 +149,12 @@ namespace Kudu.Core.SSHKey.Test
 
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act 
             var actual = sshKeyManager.GetPublicKey(ensurePublicKey);
@@ -181,11 +174,12 @@ namespace Kudu.Core.SSHKey.Test
 
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act 
             var actual = sshKeyManager.GetPublicKey(ensurePublicKey: false);
@@ -214,11 +208,12 @@ namespace Kudu.Core.SSHKey.Test
 
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act 
             var actual = sshKeyManager.GetPublicKey(ensurePublicKey: true);
@@ -244,11 +239,12 @@ namespace Kudu.Core.SSHKey.Test
 
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
             environment.SetupGet(e => e.SSHKeyPath).Returns(sshPath);
 
-            var sshKeyManager = new SSHKeyManager(environment.Object, fileSystem.Object, traceFactory: null);
+            var sshKeyManager = new SSHKeyManager(environment.Object, traceFactory: null);
 
             // Act 
             var actual = sshKeyManager.GetPublicKey(ensurePublicKey);

--- a/Kudu.Core.Test/Tracing/SiteExtensionLogManagerTests.cs
+++ b/Kudu.Core.Test/Tracing/SiteExtensionLogManagerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
 using Moq;
 using Newtonsoft.Json;
@@ -181,15 +182,17 @@ namespace Kudu.Core.Test.Tracing
             directoryInfoMock.Setup(d => d.GetFiles(It.IsAny<string>()))
                              .Returns(() => _mockLogFiles.ToArray());
 
+            FileSystemHelpers.Instance = fileSystemMock.Object;
+
             return fileSystemMock;
         }
 
         private SiteExtensionLogManager BuildSiteExtensionLogManager()
         {
-            var fileSystemMock = BuildFileSystemMock();
+            FileSystemHelpers.Instance = BuildFileSystemMock().Object;
             var tracer = Mock.Of<ITracer>();
 
-            return new SiteExtensionLogManager(fileSystemMock.Object, tracer, DirectoryPath);
+            return new SiteExtensionLogManager(tracer, DirectoryPath);
         }
     }
 }

--- a/Kudu.Core.Test/XmlLoggerFacts.cs
+++ b/Kudu.Core.Test/XmlLoggerFacts.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
 using Moq;
 using Xunit;
@@ -22,9 +23,10 @@ namespace Kudu.Core.Test
             // Setup
             fileSystem.SetupGet(f => f.File)
                       .Returns(Mock.Of<FileBase>());
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
-            var logger = new XmlLogger(fileSystem.Object, path, Mock.Of<IAnalytics>());
+            var logger = new XmlLogger(path, Mock.Of<IAnalytics>());
             var entries = logger.GetLogEntries();
             
             // Assert
@@ -57,9 +59,10 @@ namespace Kudu.Core.Test
                 .Returns(true);
             file.Setup(f => f.OpenRead(path))
                 .Returns(() => { mem.Position = 0; return mem; });
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
-            var logger = new XmlLogger(fileSystem.Object, path, Mock.Of<IAnalytics>());
+            var logger = new XmlLogger(path, Mock.Of<IAnalytics>());
             var entries = logger.GetLogEntries();
 
             // Assert
@@ -86,9 +89,10 @@ namespace Kudu.Core.Test
                 .Returns(true);
             file.Setup(f => f.OpenRead(path))
                 .Returns(() => { mem.Position = 0; return mem; });
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
-            var logger = new XmlLogger(fileSystem.Object, path, analytics.Object);
+            var logger = new XmlLogger(path, analytics.Object);
             var entries = logger.GetLogEntries();
 
             // Assert

--- a/Kudu.Core/Deployment/DeploymentHelper.cs
+++ b/Kudu.Core/Deployment/DeploymentHelper.cs
@@ -31,22 +31,22 @@ namespace Kudu.Core.Deployment
                    (VsHelper.IsWap(path) || VsHelper.IsExecutableProject(path));
         }
 
-        public static bool IsDefaultWebRootContent(string webroot, IFileSystem fileSystem)
+        public static bool IsDefaultWebRootContent(string webroot)
         {
-            if (!fileSystem.Directory.Exists(webroot))
+            if (!FileSystemHelpers.DirectoryExists(webroot))
             {
                 // degenerated
                 return true;
             }
 
-            var entries = fileSystem.Directory.GetFileSystemEntries(webroot);
+            var entries = FileSystemHelpers.GetFileSystemEntries(webroot);
             if (entries.Length == 0)
             {
                 // degenerated
                 return true;
             }
 
-            if (entries.Length == 1 && fileSystem.File.Exists(entries[0]))
+            if (entries.Length == 1 && FileSystemHelpers.FileExists(entries[0]))
             {
                 string hoststarthtml = Path.Combine(webroot, Constants.HostingStartHtml);
                 return String.Equals(entries[0], hoststarthtml, StringComparison.OrdinalIgnoreCase);

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -24,7 +24,6 @@ namespace Kudu.Core.Deployment
 
         private readonly ISiteBuilderFactory _builderFactory;
         private readonly IEnvironment _environment;
-        private readonly IFileSystem _fileSystem;
         private readonly ITraceFactory _traceFactory;
         private readonly IAnalytics _analytics;
         private readonly IOperationLock _deploymentLock;
@@ -40,7 +39,6 @@ namespace Kudu.Core.Deployment
 
         public DeploymentManager(ISiteBuilderFactory builderFactory,
                                  IEnvironment environment,
-                                 IFileSystem fileSystem,
                                  ITraceFactory traceFactory,
                                  IAnalytics analytics,
                                  IDeploymentSettingsManager settings,
@@ -51,7 +49,6 @@ namespace Kudu.Core.Deployment
         {
             _builderFactory = builderFactory;
             _environment = environment;
-            _fileSystem = fileSystem;
             _traceFactory = traceFactory;
             _analytics = analytics;
             _deploymentLock = deploymentLock;
@@ -90,14 +87,14 @@ namespace Kudu.Core.Deployment
             {
                 string path = GetLogPath(id, ensureDirectory: false);
 
-                if (!_fileSystem.File.Exists(path))
+                if (!FileSystemHelpers.FileExists(path))
                 {
                     throw new FileNotFoundException(String.Format(CultureInfo.CurrentCulture, Resources.Error_NoLogFound, id));
                 }
 
                 VerifyDeployment(id, IsDeploying);
 
-                var logger = new XmlLogger(_fileSystem, path, _analytics);
+                var logger = new XmlLogger(path, _analytics);
                 List<LogEntry> entries = logger.GetLogEntries().ToList();
 
                 // Determine if there's details to show at all
@@ -117,14 +114,14 @@ namespace Kudu.Core.Deployment
             {
                 string path = GetLogPath(id, ensureDirectory: false);
 
-                if (!_fileSystem.File.Exists(path))
+                if (!FileSystemHelpers.FileExists(path))
                 {
                     throw new FileNotFoundException(String.Format(CultureInfo.CurrentCulture, Resources.Error_NoLogFound, id));
                 }
 
                 VerifyDeployment(id, IsDeploying);
 
-                var logger = new XmlLogger(_fileSystem, path, _analytics);
+                var logger = new XmlLogger(path, _analytics);
 
                 return logger.GetLogEntryDetails(entryId).ToList();
             }
@@ -137,7 +134,7 @@ namespace Kudu.Core.Deployment
             {
                 string path = GetRoot(id, ensureDirectory: false);
 
-                if (!_fileSystem.Directory.Exists(path))
+                if (!FileSystemHelpers.DirectoryExists(path))
                 {
                     throw new DirectoryNotFoundException(String.Format(CultureInfo.CurrentCulture, Resources.Error_UnableToDeleteNoDeploymentFound, id));
                 }
@@ -666,7 +663,7 @@ namespace Kudu.Core.Deployment
 
         private IEnumerable<DeployResult> EnumerateResults()
         {
-            if (!_fileSystem.Directory.Exists(_environment.DeploymentsPath))
+            if (!FileSystemHelpers.DirectoryExists(_environment.DeploymentsPath))
             {
                 yield break;
             }
@@ -674,7 +671,7 @@ namespace Kudu.Core.Deployment
             string activeDeploymentId = _status.ActiveDeploymentId;
             bool isDeploying = IsDeploying;
 
-            foreach (var id in _fileSystem.Directory.GetDirectories(_environment.DeploymentsPath))
+            foreach (var id in FileSystemHelpers.GetDirectories(_environment.DeploymentsPath))
             {
                 DeployResult result = GetResult(id, activeDeploymentId, isDeploying);
 
@@ -759,7 +756,7 @@ namespace Kudu.Core.Deployment
         public ILogger GetLogger(string id)
         {
             var path = GetLogPath(id);
-            var xmlLogger = new XmlLogger(_fileSystem, path, _analytics);
+            var xmlLogger = new XmlLogger(path, _analytics);
             return new ProgressLogger(id, _status, new CascadeLogger(xmlLogger, _globalLogger));
         }
 
@@ -791,7 +788,7 @@ namespace Kudu.Core.Deployment
 
             if (ensureDirectory)
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, path);
+                return FileSystemHelpers.EnsureDirectory(path);
             }
 
             return path;

--- a/Kudu.Core/Deployment/DeploymentStatusManager.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusManager.cs
@@ -10,30 +10,26 @@ namespace Kudu.Core.Deployment
     public class DeploymentStatusManager : IDeploymentStatusManager
     {
         public static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(60);
-
         private readonly IEnvironment _environment;
         private readonly IOperationLock _statusLock;
-        private readonly IFileSystem _fileSystem;
         private readonly string _activeFile;
 
         public DeploymentStatusManager(IEnvironment environment,
-                                       IFileSystem fileSystem,
                                        IOperationLock statusLock)
         {
             _environment = environment;
-            _fileSystem = fileSystem;
             _statusLock = statusLock;
             _activeFile = Path.Combine(environment.DeploymentsPath, Constants.ActiveDeploymentFile);
         }
 
         public IDeploymentStatusFile Create(string id)
         {
-            return DeploymentStatusFile.Create(id, _fileSystem, _environment, _statusLock);
+            return DeploymentStatusFile.Create(id, _environment, _statusLock);
         }
 
         public IDeploymentStatusFile Open(string id)
         {
-            return DeploymentStatusFile.Open(id, _fileSystem, _environment, _statusLock);
+            return DeploymentStatusFile.Open(id, _environment, _statusLock);
         }
 
         public void Delete(string id)
@@ -45,13 +41,13 @@ namespace Kudu.Core.Deployment
                 FileSystemHelpers.DeleteDirectorySafe(path, ignoreErrors: true);
 
                 // Used for ETAG
-                if (_fileSystem.File.Exists(_activeFile))
+                if (FileSystemHelpers.FileExists(_activeFile))
                 {
-                    _fileSystem.File.SetLastWriteTimeUtc(_activeFile, DateTime.UtcNow);
+                    FileSystemHelpers.SetLastWriteTimeUtc(_activeFile, DateTime.UtcNow);
                 }
                 else
                 {
-                    _fileSystem.File.WriteAllText(_activeFile, String.Empty);
+                    FileSystemHelpers.WriteAllText(_activeFile, String.Empty);
                 }
             }, LockTimeout);
         }
@@ -67,9 +63,9 @@ namespace Kudu.Core.Deployment
             {
                 return _statusLock.LockOperation(() =>
                 {
-                    if (_fileSystem.File.Exists(_activeFile))
+                    if (FileSystemHelpers.FileExists(_activeFile))
                     {
-                        return _fileSystem.File.ReadAllText(_activeFile);
+                        return FileSystemHelpers.ReadAllText(_activeFile);
                     }
 
                     return null;
@@ -77,10 +73,7 @@ namespace Kudu.Core.Deployment
             }
             set
             {
-                _statusLock.LockOperation(() =>
-                {
-                    _fileSystem.File.WriteAllText(_activeFile, value);
-                }, LockTimeout);
+                _statusLock.LockOperation(() => FileSystemHelpers.WriteAllText(_activeFile, value), LockTimeout);
             }
         }
 
@@ -91,9 +84,9 @@ namespace Kudu.Core.Deployment
             {
                 return _statusLock.LockOperation(() =>
                 {
-                    if (_fileSystem.File.Exists(_activeFile))
+                    if (FileSystemHelpers.FileExists(_activeFile))
                     {
-                        return _fileSystem.File.GetLastWriteTimeUtc(_activeFile);
+                        return FileSystemHelpers.GetLastWriteTimeUtc(_activeFile);
                     }
                     else
                     {

--- a/Kudu.Core/Deployment/Generator/NodeSiteEnabler.cs
+++ b/Kudu.Core/Deployment/Generator/NodeSiteEnabler.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.IO.Abstractions;
+using Kudu.Core.Infrastructure;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -14,7 +15,7 @@ namespace Kudu.Core.Deployment.Generator
 
         private static readonly string[] PotentialNodeDetectionFiles = new[] { "server.js", "app.js" };
 
-        public static bool LooksLikeNode(IFileSystem fileSystem, string siteFolder)
+        public static bool LooksLikeNode(string siteFolder)
         {
             bool potentiallyLooksLikeNode = false;
 
@@ -23,7 +24,7 @@ namespace Kudu.Core.Deployment.Generator
             foreach (var nodeDetectionFile in NodeDetectionFiles)
             {
                 string fullPath = Path.Combine(siteFolder, nodeDetectionFile);
-                if (fileSystem.File.Exists(fullPath))
+                if (FileSystemHelpers.FileExists(fullPath))
                 {
                     return true;
                 }
@@ -34,7 +35,7 @@ namespace Kudu.Core.Deployment.Generator
             foreach (var nodeDetectionFile in PotentialNodeDetectionFiles)
             {
                 string fullPath = Path.Combine(siteFolder, nodeDetectionFile);
-                if (fileSystem.File.Exists(fullPath))
+                if (FileSystemHelpers.FileExists(fullPath))
                 {
                     potentiallyLooksLikeNode = true;
                     break;
@@ -49,7 +50,7 @@ namespace Kudu.Core.Deployment.Generator
                 foreach (var iisStartupFile in IisStartupFiles)
                 {
                     string fullPath = Path.Combine(siteFolder, iisStartupFile);
-                    if (fileSystem.File.Exists(fullPath))
+                    if (FileSystemHelpers.FileExists(fullPath))
                     {
                         return false;
                     }

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -137,7 +137,7 @@ namespace Kudu.Core.Deployment.Generator
 
         private static bool IsNodeSite(string projectPath)
         {
-            return NodeSiteEnabler.LooksLikeNode(new FileSystem(), projectPath);
+            return NodeSiteEnabler.LooksLikeNode(projectPath);
         }
 
         private ISiteBuilder ResolveProject(string repositoryRoot, IDeploymentSettingsManager perDeploymentSettings, IFileFinder fileFinder, bool tryWebSiteProject = false, SearchOption searchOption = SearchOption.AllDirectories)

--- a/Kudu.Core/Deployment/XmlLogger.cs
+++ b/Kudu.Core/Deployment/XmlLogger.cs
@@ -10,14 +10,12 @@ namespace Kudu.Core.Deployment
 {
     public class XmlLogger : ILogger
     {
-        private readonly string _path;
-        private readonly IFileSystem _fileSystem;
-        private readonly IAnalytics _analytics;
         private readonly static object LogLock = new object();
+        private readonly string _path;
+        private readonly IAnalytics _analytics;
 
-        public XmlLogger(IFileSystem fileSystem, string path, IAnalytics analytics)
+        public XmlLogger(string path, IAnalytics analytics)
         {
-            _fileSystem = fileSystem;
             _path = path;
             _analytics = analytics;
         }
@@ -90,9 +88,9 @@ namespace Kudu.Core.Deployment
         {
             try
             {
-                if (_fileSystem.File.Exists(_path))
+                if (FileSystemHelpers.FileExists(_path))
                 {
-                    using (var stream = _fileSystem.File.OpenRead(_path))
+                    using (var stream = FileSystemHelpers.OpenRead(_path))
                     {
                         return XDocument.Load(stream);
                     }

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -7,7 +7,6 @@ namespace Kudu.Core
 {
     public class Environment : IEnvironment
     {
-        private readonly IFileSystem _fileSystem;
         private readonly string _webRootPath;
         private readonly string _deploymentsPath;
         private readonly string _deploymentToolsPath;
@@ -28,7 +27,6 @@ namespace Kudu.Core
 
         // This ctor is used only in unit tests
         public Environment(
-                IFileSystem fileSystem,
                 string rootPath,
                 string siteRootPath,
                 string tempPath,
@@ -41,16 +39,11 @@ namespace Kudu.Core
                 string nodeModulesPath,
                 string dataPath)
         {
-            if (fileSystem == null)
-            {
-                throw new ArgumentNullException("fileSystem");
-            }
             if (repositoryPath == null)
             {
                 throw new ArgumentNullException("repositoryPath");
             }
 
-            _fileSystem = fileSystem;
             RootPath = rootPath;
             SiteRootPath = siteRootPath;
             _tempPath = tempPath;
@@ -76,12 +69,10 @@ namespace Kudu.Core
         }
 
         public Environment(
-                IFileSystem fileSystem,
                 string rootPath,
                 string binPath,
                 string repositoryPath)
         {
-            _fileSystem = fileSystem;
             RootPath = rootPath;
 
             SiteRootPath = Path.Combine(rootPath, Constants.SiteFolder);
@@ -109,7 +100,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _repositoryPath);
+                return FileSystemHelpers.EnsureDirectory(_repositoryPath);
             }
             set
             {
@@ -122,7 +113,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _webRootPath);
+                return FileSystemHelpers.EnsureDirectory(_webRootPath);
             }
         }
 
@@ -130,7 +121,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentsPath);
+                return FileSystemHelpers.EnsureDirectory(_deploymentsPath);
             }
         }
 
@@ -138,7 +129,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentToolsPath);
+                return FileSystemHelpers.EnsureDirectory(_deploymentToolsPath);
             }
         }
 
@@ -146,7 +137,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _diagnosticsPath);
+                return FileSystemHelpers.EnsureDirectory(_diagnosticsPath);
             }
         }
 
@@ -154,7 +145,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _sshKeyPath);
+                return FileSystemHelpers.EnsureDirectory(_sshKeyPath);
             }
         }
 
@@ -214,7 +205,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _tracePath);
+                return FileSystemHelpers.EnsureDirectory(_tracePath);
             }
         }
 
@@ -222,7 +213,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _analyticsPath);
+                return FileSystemHelpers.EnsureDirectory(_analyticsPath);
             }
         }
 
@@ -230,7 +221,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_fileSystem, _deploymentTracePath);
+                return FileSystemHelpers.EnsureDirectory(_deploymentTracePath);
             }
         }
 

--- a/Kudu.Core/Hooks/WebHooksManager.cs
+++ b/Kudu.Core/Hooks/WebHooksManager.cs
@@ -32,7 +32,6 @@ namespace Kudu.Core.Hooks
         private readonly IEnvironment _environment;
         private readonly string _hooksFilePath;
         private readonly IOperationLock _hooksLock;
-        private readonly IFileSystem _fileSystem;
         private readonly ITracer _tracer;
 
         static WebHooksManager()
@@ -40,12 +39,11 @@ namespace Kudu.Core.Hooks
             JsonSerializerSettings.Converters.Add(new StringEnumConverter() { CamelCaseText = true });
         }
 
-        public WebHooksManager(ITracer tracer, IEnvironment environment, IOperationLock hooksLock, IFileSystem fileSystem)
+        public WebHooksManager(ITracer tracer, IEnvironment environment, IOperationLock hooksLock)
         {
             _tracer = tracer;
             _environment = environment;
             _hooksLock = hooksLock;
-            _fileSystem = fileSystem;
 
             _hooksFilePath = Path.Combine(_environment.DeploymentsPath, HooksFileName);
         }
@@ -254,12 +252,12 @@ namespace Kudu.Core.Hooks
         {
             string fileContent = null;
 
-            if (!_fileSystem.File.Exists(_hooksFilePath))
+            if (!FileSystemHelpers.FileExists(_hooksFilePath))
             {
                 return Enumerable.Empty<WebHook>();
             }
 
-            OperationManager.Attempt(() => fileContent = _fileSystem.File.ReadAllText(_hooksFilePath));
+            OperationManager.Attempt(() => fileContent = FileSystemHelpers.ReadAllText(_hooksFilePath));
 
             if (!String.IsNullOrEmpty(fileContent))
             {
@@ -279,7 +277,7 @@ namespace Kudu.Core.Hooks
         private void SaveHooksToFile(IEnumerable<WebHook> hooks)
         {
             string hooksFileContent = JsonConvert.SerializeObject(hooks, JsonSerializerSettings);
-            OperationManager.Attempt(() => _fileSystem.File.WriteAllText(_hooksFilePath, hooksFileContent));
+            OperationManager.Attempt(() => FileSystemHelpers.WriteAllText(_hooksFilePath, hooksFileContent));
         }
     }
 }

--- a/Kudu.Core/Infrastructure/DeploymentLockFile.cs
+++ b/Kudu.Core/Infrastructure/DeploymentLockFile.cs
@@ -11,8 +11,8 @@ namespace Kudu.Core.Infrastructure
     /// </summary>
     public class DeploymentLockFile : LockFile
     {
-        public DeploymentLockFile(string path, ITraceFactory traceFactory, IFileSystem fileSystem)
-            : base(path, traceFactory, fileSystem)
+        public DeploymentLockFile(string path, ITraceFactory traceFactory)
+            : base(path, traceFactory)
         {
         }
 

--- a/Kudu.Core/Infrastructure/DisposableAction.cs
+++ b/Kudu.Core/Infrastructure/DisposableAction.cs
@@ -5,7 +5,6 @@ namespace Kudu.Core.Infrastructure
 {
     internal class DisposableAction : IDisposable
     {
-        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Method is used, misdiagnosed due to linking of this file")]
         internal static readonly IDisposable Noop = new DisposableAction(() => { });
 
         private readonly Action _action;

--- a/Kudu.Core/Infrastructure/OperationManager.cs
+++ b/Kudu.Core/Infrastructure/OperationManager.cs
@@ -9,6 +9,7 @@ namespace Kudu.Core.Infrastructure
         private const int DefaultRetries = 3;
         private const int DefaultDelayBeforeRetry = 250; // 250 ms
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public static void Attempt(Action action, int retries = DefaultRetries, int delayBeforeRetry = DefaultDelayBeforeRetry)
         {
             OperationManager.Attempt<object>(() =>
@@ -18,6 +19,7 @@ namespace Kudu.Core.Infrastructure
             }, retries, delayBeforeRetry);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public static T Attempt<T>(Func<T> action, int retries = DefaultRetries, int delayBeforeRetry = DefaultDelayBeforeRetry, Func<Exception, bool> shouldRetry = null)
         {
             T result = default(T);

--- a/Kudu.Core/Infrastructure/ZipArchiveExtensions.cs
+++ b/Kudu.Core/Infrastructure/ZipArchiveExtensions.cs
@@ -77,7 +77,7 @@ namespace Kudu.Core.Infrastructure
             }
         }
 
-        public static void Extract(this ZipArchive archive, FileSystem fileSystem, string directoryName)
+        public static void Extract(this ZipArchive archive, string directoryName)
         {
             foreach (ZipArchiveEntry entry in archive.Entries)
             {
@@ -85,11 +85,11 @@ namespace Kudu.Core.Infrastructure
                 if (entry.Length == 0 && (path.EndsWith("/", StringComparison.Ordinal) || path.EndsWith("\\", StringComparison.Ordinal)))
                 {
                     // Extract directory
-                    fileSystem.Directory.CreateDirectory(path);
+                    FileSystemHelpers.CreateDirectory(path);
                 }
                 else
                 {
-                    FileInfoBase fileInfo = fileSystem.FileInfo.FromFileName(path);
+                    FileInfoBase fileInfo = FileSystemHelpers.FileInfoFromFileName(path);
 
                     if (!fileInfo.Directory.Exists)
                     {

--- a/Kudu.Core/Jobs/ContinuousJobLogger.cs
+++ b/Kudu.Core/Jobs/ContinuousJobLogger.cs
@@ -21,8 +21,8 @@ namespace Kudu.Core.Jobs
 
         private int _consoleLogLinesCount;
 
-        public ContinuousJobLogger(string jobName, IEnvironment environment, IFileSystem fileSystem, ITraceFactory traceFactory)
-            : base(GetStatusFileName(), environment, fileSystem, traceFactory)
+        public ContinuousJobLogger(string jobName, IEnvironment environment, ITraceFactory traceFactory)
+            : base(GetStatusFileName(), environment, traceFactory)
         {
             _historyPath = Path.Combine(Environment.JobsDataPath, Constants.ContinuousPath, jobName);
             FileSystemHelpers.EnsureDirectory(_historyPath);
@@ -108,7 +108,7 @@ namespace Kudu.Core.Jobs
         {
             try
             {
-                FileInfoBase logFile = FileSystem.FileInfo.FromFileName(_logFilePath);
+                FileInfoBase logFile = FileSystemHelpers.FileInfoFromFileName(_logFilePath);
 
                 if (logFile.Length > MaxContinuousLogFileSize)
                 {
@@ -118,7 +118,7 @@ namespace Kudu.Core.Jobs
                     {
                         // roll log file, currently allow only 2 log files to exist at the same time
                         string prevLogFilePath = GetLogFilePath(JobPrevLogFileName);
-                        FileSystem.File.Delete(prevLogFilePath);
+                        FileSystemHelpers.DeleteFileSafe(prevLogFilePath);
                         logFile.MoveTo(prevLogFilePath);
                     }
                 }

--- a/Kudu.Core/Jobs/JobLogger.cs
+++ b/Kudu.Core/Jobs/JobLogger.cs
@@ -21,8 +21,6 @@ namespace Kudu.Core.Jobs
 
         protected IEnvironment Environment { get; private set; }
 
-        protected IFileSystem FileSystem { get; private set; }
-
         protected ITraceFactory TraceFactory { get; private set; }
 
         protected string InstanceId { get; private set; }
@@ -31,11 +29,10 @@ namespace Kudu.Core.Jobs
 
         private readonly string _statusFileName;
 
-        protected JobLogger(string statusFileName, IEnvironment environment, IFileSystem fileSystem, ITraceFactory traceFactory)
+        protected JobLogger(string statusFileName, IEnvironment environment, ITraceFactory traceFactory)
         {
             _statusFileName = statusFileName;
             TraceFactory = traceFactory;
-            FileSystem = fileSystem;
             Environment = environment;
 
             InstanceId = InstanceIdUtility.GetShortInstanceId();
@@ -65,7 +62,7 @@ namespace Kudu.Core.Jobs
 
         public TJobStatus GetStatus<TJobStatus>() where TJobStatus : class, IJobStatus
         {
-            return ReadJobStatusFromFile<TJobStatus>(TraceFactory, FileSystem, GetStatusFilePath());
+            return ReadJobStatusFromFile<TJobStatus>(TraceFactory, GetStatusFilePath());
         }
 
         public void ReportStatus<TJobStatus>(TJobStatus status) where TJobStatus : class, IJobStatus
@@ -90,11 +87,11 @@ namespace Kudu.Core.Jobs
             }
         }
 
-        public static TJobStatus ReadJobStatusFromFile<TJobStatus>(ITraceFactory traceFactory, IFileSystem fileSystem, string statusFilePath) where TJobStatus : class, IJobStatus
+        public static TJobStatus ReadJobStatusFromFile<TJobStatus>(ITraceFactory traceFactory, string statusFilePath) where TJobStatus : class, IJobStatus
         {
             try
             {
-                if (!fileSystem.File.Exists(statusFilePath))
+                if (!FileSystemHelpers.FileExists(statusFilePath))
                 {
                     return null;
                 }

--- a/Kudu.Core/Jobs/TriggeredJobRunner.cs
+++ b/Kudu.Core/Jobs/TriggeredJobRunner.cs
@@ -15,15 +15,15 @@ namespace Kudu.Core.Jobs
     {
         private readonly LockFile _lockFile;
 
-        public TriggeredJobRunner(string jobName, IEnvironment environment, IFileSystem fileSystem, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
-            : base(jobName, Constants.TriggeredPath, environment, fileSystem, settings, traceFactory, analytics)
+        public TriggeredJobRunner(string jobName, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
+            : base(jobName, Constants.TriggeredPath, environment, settings, traceFactory, analytics)
         {
-            _lockFile = BuildTriggeredJobRunnerLockFile(JobDataPath, TraceFactory, FileSystem);
+            _lockFile = BuildTriggeredJobRunnerLockFile(JobDataPath, TraceFactory);
         }
 
-        public static LockFile BuildTriggeredJobRunnerLockFile(string jobDataPath, ITraceFactory traceFactory, IFileSystem fileSystem)
+        public static LockFile BuildTriggeredJobRunnerLockFile(string jobDataPath, ITraceFactory traceFactory)
         {
-            return new LockFile(Path.Combine(jobDataPath, "triggeredJob.lock"), traceFactory, fileSystem);
+            return new LockFile(Path.Combine(jobDataPath, "triggeredJob.lock"), traceFactory);
         }
 
         protected override string JobEnvironmentKeyPrefix
@@ -43,7 +43,7 @@ namespace Kudu.Core.Jobs
                 throw new ConflictException();
             }
 
-            TriggeredJobRunLogger logger = TriggeredJobRunLogger.LogNewRun(triggeredJob, Environment, FileSystem, TraceFactory, Settings);
+            TriggeredJobRunLogger logger = TriggeredJobRunLogger.LogNewRun(triggeredJob, Environment, TraceFactory, Settings);
             Debug.Assert(logger != null);
 
             try

--- a/Kudu.Core/Settings/JsonSettings.cs
+++ b/Kudu.Core/Settings/JsonSettings.cs
@@ -19,16 +19,9 @@ namespace Kudu.Core.Settings
     public class JsonSettings
     {
         private string _path;
-        private IFileSystem _fileSystem;
 
         public JsonSettings(string path)
-            : this(new FileSystem(), path)
         {
-        }
-
-        public JsonSettings(IFileSystem fileSystem, string path)
-        {
-            _fileSystem = fileSystem;
             _path = path;
         }
 
@@ -86,14 +79,14 @@ namespace Kudu.Core.Settings
 
         private JObject Read()
         {
-            if (!_fileSystem.File.Exists(_path))
+            if (!FileSystemHelpers.FileExists(_path))
             {
                 return new JObject();
             }
 
             // opens file for FileAccess.Read but does allow other read/write (FileShare.ReadWrite).   
             // it is the most optimal where write is infrequent and dirty read is acceptable.
-            using (var reader = new JsonTextReader(new StreamReader(_fileSystem.File.Open(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))))
+            using (var reader = new JsonTextReader(new StreamReader(FileSystemHelpers.OpenFile(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))))
             {
                 return JObject.Load(reader);
             }
@@ -101,14 +94,14 @@ namespace Kudu.Core.Settings
 
         private void Save(JObject json)
         {
-            if (!_fileSystem.File.Exists(_path))
+            if (!FileSystemHelpers.FileExists(_path))
             {
-                FileSystemHelpers.EnsureDirectory(_fileSystem, Path.GetDirectoryName(_path));
+                FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(_path));
             }
 
             // opens file for FileAccess.Write but does allow other dirty read (FileShare.Read).   
             // it is the most optimal where write is infrequent and dirty read is acceptable.
-            using (var writer = new JsonTextWriter(new StreamWriter(_fileSystem.File.Open(_path, FileMode.Create, FileAccess.Write, FileShare.Read))))
+            using (var writer = new JsonTextWriter(new StreamWriter(FileSystemHelpers.OpenFile(_path, FileMode.Create, FileAccess.Write, FileShare.Read))))
             {
                 // prefer indented-readable format
                 writer.Formatting = Formatting.Indented;

--- a/Kudu.Core/Tracing/Analytics.cs
+++ b/Kudu.Core/Tracing/Analytics.cs
@@ -11,10 +11,10 @@ namespace Kudu.Core.Tracing
         private readonly SiteExtensionLogManager _siteExtensionLogManager;
         private readonly IDeploymentSettingsManager _settings;
 
-        public Analytics(IDeploymentSettingsManager settings, IFileSystem fileSystem, ITracer tracer, string directoryPath)
+        public Analytics(IDeploymentSettingsManager settings, ITracer tracer, string directoryPath)
         {
             _settings = settings;
-            _siteExtensionLogManager = new SiteExtensionLogManager(fileSystem, tracer, directoryPath);
+            _siteExtensionLogManager = new SiteExtensionLogManager(tracer, directoryPath);
         }
 
         public void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode)

--- a/Kudu.Core/Tracing/SiteExtensionLogManager.cs
+++ b/Kudu.Core/Tracing/SiteExtensionLogManager.cs
@@ -28,15 +28,13 @@ namespace Kudu.Core.Tracing
             ReferenceLoopHandling = ReferenceLoopHandling.Error
         };
 
-        private readonly IFileSystem _fileSystem;
         private readonly ITracer _tracer;
         private readonly string _directoryPath;
         private string _currentFileName;
         private string _currentPath;
 
-        public SiteExtensionLogManager(IFileSystem fileSystem, ITracer tracer, string directoryPath)
+        public SiteExtensionLogManager(ITracer tracer, string directoryPath)
         {
-            _fileSystem = fileSystem;
             _tracer = tracer;
             _directoryPath = directoryPath;
 
@@ -58,7 +56,7 @@ namespace Kudu.Core.Tracing
 
                     OperationManager.Attempt(() =>
                     {
-                        using (var streamWriter = new StreamWriter(_fileSystem.File.Open(_currentPath, FileMode.Append, FileAccess.Write, FileShare.Read)))
+                        using (var streamWriter = new StreamWriter(FileSystemHelpers.OpenFile(_currentPath, FileMode.Append, FileAccess.Write, FileShare.Read)))
                         {
                             streamWriter.WriteLine(message);
                         }
@@ -98,7 +96,7 @@ namespace Kudu.Core.Tracing
         {
             try
             {
-                return _fileSystem.DirectoryInfo.FromDirectoryName(_directoryPath).GetFiles(SiteExtensionLogSearchPattern);
+                return FileSystemHelpers.DirectoryInfoFromDirectoryName(_directoryPath).GetFiles(SiteExtensionLogSearchPattern);
             }
             catch
             {

--- a/Kudu.Core/Tracing/TextLogger.cs
+++ b/Kudu.Core/Tracing/TextLogger.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
 
 namespace Kudu.Core.Tracing
 {
@@ -11,12 +12,7 @@ namespace Kudu.Core.Tracing
         private readonly int _depth;
 
         public TextLogger(string path)
-            : this(new FileSystem(), path)
-        {
-        }
-
-        public TextLogger(IFileSystem fileSystem, string path)
-            : this(new LogFileHelper(fileSystem, path), 0)
+            : this(new LogFileHelper(path), 0)
         {
         }
 
@@ -34,12 +30,10 @@ namespace Kudu.Core.Tracing
 
         private class LogFileHelper
         {
-            private readonly IFileSystem _fileSystem;
             private readonly string _logFile;
 
-            public LogFileHelper(IFileSystem fileSystem, string logFile)
+            public LogFileHelper(string logFile)
             {
-                _fileSystem = fileSystem;
                 _logFile = logFile;
             }
 
@@ -50,7 +44,7 @@ namespace Kudu.Core.Tracing
                 strb.Append(GetIndentation(depth + 1));
                 strb.Append(value);
 
-                using (StreamWriter writer = new StreamWriter(_fileSystem.File.Open(_logFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite)))
+                using (StreamWriter writer = new StreamWriter(FileSystemHelpers.OpenFile(_logFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite)))
                 {
                     writer.WriteLine(strb.ToString());
                 }

--- a/Kudu.Core/Tracing/TextTracer.cs
+++ b/Kudu.Core/Tracing/TextTracer.cs
@@ -15,14 +15,9 @@ namespace Kudu.Core.Tracing
         private readonly TraceLevel _level;
         private int _depth;
 
-        public TextTracer(string path, TraceLevel level)
-            : this(new FileSystem(), path, level)
+        public TextTracer(string path, TraceLevel level, int depth = 0)
         {
-        }
-
-        public TextTracer(IFileSystem fileSystem, string path, TraceLevel level, int depth = 0)
-        {
-            _logFile = new LogFileHelper(this, fileSystem, path);
+            _logFile = new LogFileHelper(this, path);
             _level = level;
             _depth = depth;
 
@@ -62,14 +57,12 @@ namespace Kudu.Core.Tracing
         private class LogFileHelper
         {
             private readonly ITracer _tracer;
-            private readonly IFileSystem _fileSystem;
             private readonly string _logFile;
             private Stopwatch _stopWatch;
 
-            public LogFileHelper(ITracer tracer, IFileSystem fileSystem, string logFile)
+            public LogFileHelper(ITracer tracer, string logFile)
             {
                 _tracer = tracer;
-                _fileSystem = fileSystem;
                 _logFile = logFile;
             }
 
@@ -141,7 +134,7 @@ namespace Kudu.Core.Tracing
                     }
                 }
 
-                using (StreamWriter writer = new StreamWriter(_fileSystem.File.Open(_logFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite)))
+                using (StreamWriter writer = new StreamWriter(FileSystemHelpers.OpenFile(_logFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite)))
                 {
                     writer.WriteLine(strb.ToString());
                 }

--- a/Kudu.FunctionalTests/SettingsApiFacts.cs
+++ b/Kudu.FunctionalTests/SettingsApiFacts.cs
@@ -146,7 +146,7 @@ namespace Kudu.FunctionalTests
                 string clientId = await client.GetStringAsync("commit.txt");
 
                 // Assert
-                Assert.Equal(id, clientId.TrimEnd());
+                 Assert.Equal(id, clientId.TrimEnd());
             });
         }
     }

--- a/Kudu.Services.Test/FetchHandlerFacts.cs
+++ b/Kudu.Services.Test/FetchHandlerFacts.cs
@@ -10,6 +10,7 @@ using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core;
 using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
 using Kudu.Services.ServiceHookHandlers;
 using Moq;
@@ -97,6 +98,7 @@ namespace Kudu.Services.Test
                                                 IRepositoryFactory repositoryFactory = null,
                                                 IFileSystem fileSystem = null)
         {
+            FileSystemHelpers.Instance = fileSystem ?? Mock.Of<IFileSystem>();
             return new FetchHandler(tracer ?? Mock.Of<ITracer>(),
                                     deploymentManager ?? Mock.Of<IDeploymentManager>(),
                                     settings ?? Mock.Of<IDeploymentSettingsManager>(),
@@ -104,8 +106,7 @@ namespace Kudu.Services.Test
                                     deploymentLock ?? Mock.Of<IOperationLock>(),
                                     environment ?? Mock.Of<IEnvironment>(),
                                     new[] { serviceHookHandler ?? Mock.Of<IServiceHookHandler>() },
-                                    repositoryFactory ?? Mock.Of<IRepositoryFactory>(),
-                                    fileSystem ?? Mock.Of<IFileSystem>());
+                                    repositoryFactory ?? Mock.Of<IRepositoryFactory>());
         }
 
         private Mock<IFileSystem> GetFileSystem(string siteRoot, params DateTime[] writeTimeUtcs)

--- a/Kudu.Services.Test/InfoRefsControllerFacts.cs
+++ b/Kudu.Services.Test/InfoRefsControllerFacts.cs
@@ -10,6 +10,7 @@ using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core;
 using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
 using Kudu.Core.SourceControl.Git;
 using Kudu.Services.GitServer;
@@ -216,9 +217,10 @@ namespace Kudu.Services.Test
             fileSystem.SetupGet(fs => fs.Directory)
                       .Returns(directoryBase.Object);
             scenario.Setup(fileBase, directoryBase, webroot);
+            FileSystemHelpers.Instance = fileSystem.Object;
 
             // Act
-            bool result = DeploymentHelper.IsDefaultWebRootContent(webroot, fileSystem.Object);
+            bool result = DeploymentHelper.IsDefaultWebRootContent(webroot);
 
             // Assert
             scenario.Verify(result);
@@ -334,6 +336,9 @@ namespace Kudu.Services.Test
                 directoryBase.Setup(d => d.GetFileSystemEntries(webrootPath))
                              .Returns(new string[2]);
             }
+
+            FileSystemHelpers.Instance = fileSystem.Object;
+
             return fileSystem.Object;
         }
 

--- a/Kudu.Services.Test/RuntimeControllerFacts.cs
+++ b/Kudu.Services.Test/RuntimeControllerFacts.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Infrastructure;
 using Kudu.Services.Diagnostics;
 using Moq;
 using Xunit;
@@ -25,8 +26,8 @@ namespace Kudu.Services.Test
             directory.Setup(d => d.FromDirectoryName(_nodeDir)).Returns(nodeDir.Object);
             var fileSystem = new Mock<IFileSystem>();
             fileSystem.Setup(f => f.DirectoryInfo).Returns(directory.Object);
-
-            var controller = new RuntimeController(Mock.Of<ITracer>(), fileSystem.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
+            var controller = new RuntimeController(Mock.Of<ITracer>());
 
             // Act
             var runtimeInfo = controller.GetRuntimeVersions();
@@ -52,8 +53,8 @@ namespace Kudu.Services.Test
             directoryInfo.Setup(d => d.FromDirectoryName(_nodeDir)).Returns(nodeDir.Object);
             var fileSystem = new Mock<IFileSystem>();
             fileSystem.Setup(f => f.DirectoryInfo).Returns(directoryInfo.Object);
-
-            var controller = new RuntimeController(Mock.Of<ITracer>(), fileSystem.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
+            var controller = new RuntimeController(Mock.Of<ITracer>());
 
             // Act
             var nodeVersions = controller.GetRuntimeVersions().NodeVerions.ToList();

--- a/Kudu.Services/Diagnostics/DiagnosticsController.cs
+++ b/Kudu.Services/Diagnostics/DiagnosticsController.cs
@@ -23,7 +23,7 @@ namespace Kudu.Services.Performance
         private readonly ITracer _tracer;
         private readonly IApplicationLogsReader _applicationLogsReader;
 
-        public DiagnosticsController(IEnvironment environment, IFileSystem fileSystem, ITracer tracer, IApplicationLogsReader applicationLogsReader)
+        public DiagnosticsController(IEnvironment environment, ITracer tracer, IApplicationLogsReader applicationLogsReader)
         {
             // Setup the diagnostics service to collect information from the following paths:
             // 1. The deployments folder
@@ -35,7 +35,7 @@ namespace Kudu.Services.Performance
                 Path.Combine(environment.WebRootPath, Constants.NpmDebugLogFile),
             };
 
-            _settings = new JsonSettings(fileSystem, Path.Combine(environment.DiagnosticsPath, Constants.SettingsJsonFile));
+            _settings = new JsonSettings(Path.Combine(environment.DiagnosticsPath, Constants.SettingsJsonFile));
             _applicationLogsReader = applicationLogsReader;
             _tracer = tracer;
         }

--- a/Kudu.Services/Diagnostics/RuntimeController.cs
+++ b/Kudu.Services/Diagnostics/RuntimeController.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Infrastructure;
 using Newtonsoft.Json;
 
 namespace Kudu.Services.Diagnostics
@@ -17,12 +18,10 @@ namespace Kudu.Services.Diagnostics
         private const string VersionKey = "version";
         private static readonly Regex _versionRegex = new Regex(@"^\d+\.\d+", RegexOptions.ExplicitCapture);
         private readonly ITracer _tracer;
-        private readonly IFileSystem _fileSystem;
 
-        public RuntimeController(ITracer tracer, IFileSystem fileSystem)
+        public RuntimeController(ITracer tracer)
         {
             _tracer = tracer;
-            _fileSystem = fileSystem;
         }
 
         protected override void Initialize(HttpControllerContext controllerContext)
@@ -48,10 +47,10 @@ namespace Kudu.Services.Diagnostics
             }
         }
 
-        private IEnumerable<Dictionary<string, string>> GetNodeVersions()
+        private static IEnumerable<Dictionary<string, string>> GetNodeVersions()
         {
             string nodeRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "nodejs");
-            var directoryInfo = _fileSystem.DirectoryInfo.FromDirectoryName(nodeRoot);
+            var directoryInfo = FileSystemHelpers.DirectoryInfoFromDirectoryName(nodeRoot);
             if (directoryInfo.Exists)
             {
                 return directoryInfo.GetDirectories()

--- a/Kudu.Services/Editor/VfsController.cs
+++ b/Kudu.Services/Editor/VfsController.cs
@@ -21,13 +21,7 @@ namespace Kudu.Services.Editor
     public class VfsController : VfsControllerBase
     {
         public VfsController(ITracer tracer, IEnvironment environment)
-            : this(tracer, environment, new FileSystem())
-        {
-
-        }
-
-        public VfsController(ITracer tracer, IEnvironment environment, IFileSystem fileSystem)
-            : base(tracer, environment, fileSystem, environment.RootPath)
+            : base(tracer, environment, environment.RootPath)
         {
         }
 

--- a/Kudu.Services/FetchHelpers/DropboxHelper.cs
+++ b/Kudu.Services/FetchHelpers/DropboxHelper.cs
@@ -44,7 +44,6 @@ namespace Kudu.Services
         private readonly IDeploymentStatusManager _status;
         private readonly IDeploymentSettingsManager _settings;
         private readonly IEnvironment _environment;
-        private readonly IFileSystem _fileSystem;
         private readonly TimeSpan _timeout;
 
         // stats
@@ -63,7 +62,6 @@ namespace Kudu.Services
             _status = status;
             _settings = settings;
             _environment = environment;
-            _fileSystem = new FileSystem();
             _timeout = settings.GetCommandIdleTimeout();
         }
 
@@ -137,10 +135,10 @@ namespace Kudu.Services
             // initial sync, remove default content
             // for simplicity, we do it blindly whether or not in-place
             // given the end result is the same
-            if (String.IsNullOrEmpty(deployInfo.OldCursor) && DeploymentHelper.IsDefaultWebRootContent(_environment.WebRootPath, _fileSystem))
+            if (String.IsNullOrEmpty(deployInfo.OldCursor) && DeploymentHelper.IsDefaultWebRootContent(_environment.WebRootPath))
             {
                 string hoststarthtml = Path.Combine(_environment.WebRootPath, Constants.HostingStartHtml);
-                FileSystemHelpers.DeleteFileSafe(_fileSystem, hoststarthtml);
+                FileSystemHelpers.DeleteFileSafe(hoststarthtml);
             }
 
             if (!repository.IsEmpty())

--- a/Kudu.Services/GitServer/InfoRefsController.cs
+++ b/Kudu.Services/GitServer/InfoRefsController.cs
@@ -168,7 +168,7 @@ namespace Kudu.Services.GitServer
 
                 var env = GetInstance<IEnvironment>();
                 // it is default webroot content, do nothing
-                if (DeploymentHelper.IsDefaultWebRootContent(env.WebRootPath, GetInstance<IFileSystem>()))
+                if (DeploymentHelper.IsDefaultWebRootContent(env.WebRootPath))
                 {
                     return;
                 }

--- a/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
+++ b/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Web.Http.Routing;
 using Kudu.Contracts.Editor;
+using Kudu.Core.Infrastructure;
 
 namespace Kudu.Services.Infrastructure
 {
@@ -59,11 +60,11 @@ namespace Kudu.Services.Infrastructure
             }
         }
 
-        public static IEnumerable<VfsStatEntry> GetEntries(string baseAddress, IFileSystem fileSystem)
+        public static IEnumerable<VfsStatEntry> GetEntries(string baseAddress)
         {
             if (!String.IsNullOrEmpty(SystemDrivePath))
             {
-                var dir = fileSystem.DirectoryInfo.FromDirectoryName(SystemDrivePath + Path.DirectorySeparatorChar);
+                var dir = FileSystemHelpers.DirectoryInfoFromDirectoryName(SystemDrivePath + Path.DirectorySeparatorChar);
                 yield return new VfsStatEntry
                 {
                     Name = SystemDriveFolder,
@@ -76,7 +77,7 @@ namespace Kudu.Services.Infrastructure
 
             if (!String.IsNullOrEmpty(LocalSiteRootPath))
             {
-                var dir = fileSystem.DirectoryInfo.FromDirectoryName(LocalSiteRootPath + Path.DirectorySeparatorChar);
+                var dir = FileSystemHelpers.DirectoryInfoFromDirectoryName(LocalSiteRootPath + Path.DirectorySeparatorChar);
                 yield return new VfsStatEntry
                 {
                     Name = LocalSiteRootFolder,

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -79,9 +79,6 @@
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\Kudu.Core\Infrastructure\FileSystemHelpers.cs">
-      <Link>Infrastructure\FileSystemHelpers.cs</Link>
-    </Compile>
     <Compile Include="..\Kudu.Core\Infrastructure\OperationManager.cs">
       <Link>Infrastructure\OperationManager.cs</Link>
     </Compile>

--- a/Kudu.Services/SourceControl/LiveScmEditorController.cs
+++ b/Kudu.Services/SourceControl/LiveScmEditorController.cs
@@ -45,18 +45,8 @@ namespace Kudu.Services.SourceControl
                                        IDeploymentManager deploymentManager,
                                        IOperationLock operationLock,
                                        IEnvironment environment,
-                                       IRepository repository) 
-            : this(tracer, deploymentManager, operationLock, environment, repository, new FileSystem())
-        {
-        }
-
-        public LiveScmEditorController(ITracer tracer,
-                                       IDeploymentManager deploymentManager,
-                                       IOperationLock operationLock,
-                                       IEnvironment environment,
-                                       IRepository repository,
-                                       IFileSystem fileSystem)
-            : base(tracer, environment, fileSystem, environment.RepositoryPath)
+                                       IRepository repository)
+            : base(tracer, environment, environment.RepositoryPath)
         {
             _deploymentManager = deploymentManager;
             _operationLock = operationLock;

--- a/Kudu.Services/Zip/ZipController.cs
+++ b/Kudu.Services/Zip/ZipController.cs
@@ -17,7 +17,7 @@ namespace Kudu.Services.Deployment
     public class ZipController : VfsControllerBase
     {
         public ZipController(ITracer tracer, IEnvironment environment)
-            : base(tracer, environment, new FileSystem(), environment.RootPath)
+            : base(tracer, environment, environment.RootPath)
         {
         }
 
@@ -59,7 +59,7 @@ namespace Kudu.Services.Deployment
                 // Hence it's more of a PATCH than a PUT. We should consider supporting both with the right semantic.
                 // Though a true PUT at the root would be scary as it would wipe all existing files!
                 var zipArchive = new ZipArchive(stream, ZipArchiveMode.Read);
-                zipArchive.Extract(new FileSystem(), localFilePath);
+                zipArchive.Extract(localFilePath);
             }
 
             return Request.CreateResponse(HttpStatusCode.OK);

--- a/Kudu.SiteManagement/Kudu.SiteManagement.csproj
+++ b/Kudu.SiteManagement/Kudu.SiteManagement.csproj
@@ -15,6 +15,10 @@
     <DefineConstants>TRACE;SITEMANAGEMENT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Kudu.Core\Kudu.Core.csproj">
+      <Project>{5320177C-725A-44BD-8FA6-F88D9725B46C}</Project>
+      <Name>Kudu.Core</Name>
+    </ProjectReference>
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
@@ -52,9 +56,6 @@
   <ItemGroup>
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\Kudu.Core\Infrastructure\FileSystemHelpers.cs">
-      <Link>FileSystemHelpers.cs</Link>
     </Compile>
     <Compile Include="..\Kudu.Core\Infrastructure\OperationManager.cs">
       <Link>OperationManager.cs</Link>


### PR DESCRIPTION
Fixes #833. Removes FileSystem in arguments and use FileSystemHelpers.Instance instead.
