### PR TITLE
Adding FileSystemWatcher to FileExplorer.js #879

### DIFF
--- a/Kudu.Core.Test/FileSystemHubFacts.cs
+++ b/Kudu.Core.Test/FileSystemHubFacts.cs
@@ -1,0 +1,149 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Kudu.Contracts.Tracing;
+using Kudu.Services.Editor;
+using Microsoft.AspNet.SignalR;
+using Microsoft.AspNet.SignalR.Hubs;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Extensions;
+
+namespace Kudu.Core.Test
+{
+    public class FileSystemHubFacts
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task FileSystemHubRegisterTests(bool update)
+        {
+            // Setup
+            var env = new Mock<IEnvironment>();
+            var tracer = new Mock<ITracer>();
+            var context = new HubCallerContext(Mock.Of<IRequest>(), Guid.NewGuid().ToString());
+            var groups = new Mock<IGroupManager>();
+            var clients = new Mock<IHubCallerConnectionContext>();
+
+            using (
+                var fileSystemHubTest = new FileSystemHubTest(env.Object, tracer.Object, context, groups.Object,
+                    clients.Object))
+            {
+                // Test
+                fileSystemHubTest.TestRegister(@"C:\");
+
+                // Assert
+                Assert.Equal(1, FileSystemHubTest.FileWatchersCount);
+
+                if (update)
+                {
+                    // Test
+                    fileSystemHubTest.TestRegister(@"C:\");
+
+                    // Assert
+                    Assert.Equal(1, FileSystemHubTest.FileWatchersCount);
+                }
+
+                // Test
+                await fileSystemHubTest.TestDisconnect();
+
+                // Assert
+                Assert.Equal(0, FileSystemHubTest.FileWatchersCount);
+            }
+        }
+
+        [Fact]
+        public async Task FileSystemHubDisconnectTest()
+        {
+            // Setup
+            var env = new Mock<IEnvironment>();
+            var tracer = new Mock<ITracer>();
+            var context = new HubCallerContext(Mock.Of<IRequest>(), Guid.NewGuid().ToString());
+            var groups = new Mock<IGroupManager>();
+            var clients = new Mock<IHubCallerConnectionContext>();
+
+            using (
+                var fileSystemHubTest = new FileSystemHubTest(env.Object, tracer.Object, context, groups.Object,
+                    clients.Object))
+            {
+                // Test
+                fileSystemHubTest.TestRegister(@"C:\");
+
+                // Assert
+                Assert.Equal(1, FileSystemHubTest.FileWatchersCount);
+
+                // Test
+                await fileSystemHubTest.TestDisconnect();
+            }
+            // Assert
+            Assert.Equal(0, FileSystemHubTest.FileWatchersCount);
+        }
+
+        [Fact]
+        public void FileSystemHubMaxWatchers()
+        {
+            var listOfFileSystemHubs = new List<FileSystemHubTest>();
+
+            try
+            {
+                // Setup
+                var env = new Mock<IEnvironment>();
+                var tracer = new Mock<ITracer>();
+                var groups = new Mock<IGroupManager>();
+                var clients = new Mock<IHubCallerConnectionContext>();
+
+                // Test
+                for (var i = 0; i < 10; i++)
+                {
+                    var context = new HubCallerContext(Mock.Of<IRequest>(), Guid.NewGuid().ToString());
+                    var fileSystemHubTest = new FileSystemHubTest(env.Object, tracer.Object, context, groups.Object,
+                        clients.Object);
+                    listOfFileSystemHubs.Add(fileSystemHubTest);
+                    fileSystemHubTest.TestRegister(@"C:\");
+
+                    // Assert
+                    Assert.Equal(Math.Min(i + 1, FileSystemHub.MaxFileSystemWatchers), FileSystemHubTest.FileWatchersCount);
+                }
+            }
+            finally
+            {
+                foreach (var fileSystemHub in listOfFileSystemHubs)
+                {
+                    fileSystemHub.Dispose();
+                }
+            }
+        }
+    }
+
+    public class FileSystemHubTest : FileSystemHub, IDisposable
+    {
+        public FileSystemHubTest(IEnvironment environment, ITracer tracer, HubCallerContext context,
+            IGroupManager group, IHubCallerConnectionContext clients) : base(environment, tracer)
+        {
+            Context = context;
+            Groups = group;
+            Clients = clients;
+        }
+
+        public static int FileWatchersCount
+        {
+            get { return _fileWatchers.Count; }
+        }
+
+        public void TestRegister(string path)
+        {
+            Register(path);
+        }
+
+        public Task TestDisconnect()
+        {
+            return OnDisconnected();
+        }
+
+        public new void Dispose()
+        {
+            _fileWatchers.Clear();
+        }
+    }
+}

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -76,6 +76,7 @@
     <Compile Include="DebugConsoleFacts.cs" />
     <Compile Include="Deployment\NodeSiteEnablerTests.cs" />
     <Compile Include="Deployment\DeploymentManagerFacts.cs" />
+    <Compile Include="FileSystemHubFacts.cs" />
     <Compile Include="HgRepositoryFacts.cs" />
     <Compile Include="Hooks\WebHooksManagerTests.cs" />
     <Compile Include="IdleManagerFacts.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -293,6 +293,7 @@ namespace Kudu.Services.Web.App_Start
             public static void Configuration(IAppBuilder app)
             {
                 app.MapSignalR<PersistentCommandController>("/commandstream");
+                app.MapSignalR("/filesystemhub", new HubConfiguration());
             }
         }
 

--- a/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
+++ b/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
@@ -22,6 +22,7 @@ function LoadConsoleV2() {
     function _changeDir(value) {
         //for the very first time, value is empty but we know that the file explorer root is appRoot
         value = value || window.KuduExec.appRoot;
+        curWorkingDir(value);
         if (getShell().toUpperCase() === "POWERSHELL") {
             //PowerShell doesn't return a new line after CD, so let's add a new line in the UI 
             DisplayAndUpdate({ Error: "", Output: "\n" });
@@ -209,6 +210,8 @@ function LoadConsoleV2() {
                     window.KuduExec.appRoot = windowsPath;
                 }
                 curWorkingDir(windowsPath);
+                if (window.KuduExec.updateFileSystemWatcher)
+                    window.KuduExec.updateFileSystemWatcher(windowsPath);
             }
         }
     }

--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -110,5 +110,6 @@
 <script src="/content/scripts/jquery.signalr-2.0.1.min.js"></script>
 <script src="/content/scripts/kuduexec.js"></script>
 <script src="/content/scripts/kuduexecV2.js"></script>
+<script src="/filesystemhub/hubs"></script>
 <script src="/content/scripts/filebrowser.js"></script>
 <script src="/content/scripts/jquery-console/jquery.console.js"></script>

--- a/Kudu.Services/Editor/FileSystemHub.cs
+++ b/Kudu.Services/Editor/FileSystemHub.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Threading;
+using Kudu.Contracts.Tracing;
+using Kudu.Core;
+using Microsoft.AspNet.SignalR;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace Kudu.Services.Editor
+{
+    public class FileSystemHub : Hub
+    {
+        public const int MaxFileSystemWatchers = 5;
+
+        protected static readonly ConcurrentDictionary<string, SimpleFileSystemWatcher> _fileWatchers =
+            new ConcurrentDictionary<string, SimpleFileSystemWatcher>();
+
+        private readonly IEnvironment _environment;
+        private readonly ITracer _tracer;
+
+        public FileSystemHub(IEnvironment environment, ITracer tracer)
+        {
+            _environment = environment;
+            _tracer = tracer;
+        }
+
+        public void Register(string path)
+        {
+            path = path ?? _environment.RootPath;
+            using (
+                _tracer.Step(
+                    String.Format("Registering connectionId {0} for FileSystemWatcher on path: {1}",
+                        Context.ConnectionId, path)))
+            {
+                SimpleFileSystemWatcher watcher;
+                if (_fileWatchers.TryGetValue(Context.ConnectionId, out watcher))
+                {
+                    watcher.Path = path;
+                }
+                else
+                {
+                    _fileWatchers.TryAdd(Context.ConnectionId, GetFileSystemWatcher(path));
+                }
+            }
+        }
+
+        public override async Task OnDisconnected()
+        {
+            using (
+                _tracer.Step(String.Format("Client with connectionId {0} disconnected.",
+                    Context.ConnectionId)))
+            {
+                RemoveFileSystemWatcher(Context.ConnectionId, _tracer);
+                await base.OnDisconnected();
+            }
+        }
+
+        private async void NotifyGroup(string path)
+        {
+            await Clients.Caller.fileExplorerChanged();
+        }
+
+        private SimpleFileSystemWatcher GetFileSystemWatcher(string path)
+        {
+            using (_tracer.Step(String.Format("Creating FileSystemWatcher on path {0}", path)))
+            {
+                var simpleFileSystemWatcher = new SimpleFileSystemWatcher(path)
+                {
+                    EnableRaisingEvents = true,
+                    IncludeSubdirectories = false
+                };
+                simpleFileSystemWatcher.GeneralDirectoryChanged += NotifyGroup;
+                EnsureFileSystemWatchersMax();
+                return simpleFileSystemWatcher;
+            }
+        }
+
+        private static void RemoveFileSystemWatcher(string key, ITracer tracer)
+        {
+            using (tracer.Step(String.Format("Disposing FileSystemWatcher for connectionId {0}", key)))
+            {
+                SimpleFileSystemWatcher temp;
+                if (_fileWatchers.TryRemove(key, out temp))
+                {
+                    temp.Dispose();
+                }
+            }
+        }
+
+        private void EnsureFileSystemWatchersMax()
+        {
+            while (_fileWatchers.Count >= MaxFileSystemWatchers)
+            {
+                var toRemove = _fileWatchers.OrderBy(p => p.Value.LastFired).LastOrDefault();
+                if (String.IsNullOrEmpty(toRemove.Key))
+                {
+                    break;
+                }
+                RemoveFileSystemWatcher(toRemove.Key, _tracer);
+            }
+        }
+
+        protected class SimpleFileSystemWatcher : FileSystemWatcher
+        {
+            public delegate void SimpleFileSystemEventHandler(string path);
+
+            public event SimpleFileSystemEventHandler GeneralDirectoryChanged;
+            public DateTime LastFired { get; private set; }
+
+            public SimpleFileSystemWatcher(string path)
+                : base(path)
+            {
+                Changed += HandleChange;
+                Created += HandleChange;
+                Deleted += HandleChange;
+                Renamed += HandleRename;
+                LastFired = DateTime.MinValue;
+            }
+
+            private void HandleGeneralChange(string fullPath)
+            {
+                GeneralDirectoryChanged.Invoke(System.IO.Path.GetDirectoryName(fullPath));
+                LastFired = DateTime.UtcNow;
+            }
+
+            private void HandleChange(object sender, FileSystemEventArgs args)
+            {
+                HandleGeneralChange(args.FullPath);
+            }
+
+            private void HandleRename(object sender, RenamedEventArgs args)
+            {
+                HandleGeneralChange(args.FullPath);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                GeneralDirectoryChanged = null;
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Diagnostics\LogStreamManager.cs" />
     <Compile Include="Diagnostics\ProcessController.cs" />
     <Compile Include="Diagnostics\RuntimeController.cs" />
+    <Compile Include="Editor\FileSystemHub.cs" />
     <Compile Include="Editor\VfsController.cs" />
     <Compile Include="FetchHelpers\DropboxEntryInfo.cs" />
     <Compile Include="FetchHelpers\DropboxDeployInfo.cs" />


### PR DESCRIPTION
~~actual FileSystemWatcher fires too rapidly. If there are lot of changes in the directory, say you were publishing your site, FileSystemWatcher could fire thousands of events and the JavaScript UI will freeze. 
I added a 500 msec delay between each event and that seems fine.~~
