### PR TITLE
WebJobs: send stdout and stderr to the same file for Triggered jobs

### DIFF
--- a/Kudu.Core/Jobs/TriggeredJobRunLogger.cs
+++ b/Kudu.Core/Jobs/TriggeredJobRunLogger.cs
@@ -20,7 +20,6 @@ namespace Kudu.Core.Jobs
         private readonly string _id;
         private readonly string _historyPath;
         private readonly string _outputFilePath;
-        private readonly string _errorFilePath;
 
         private TriggeredJobRunLogger(string jobName, string id, IEnvironment environment, ITraceFactory traceFactory)
             : base(TriggeredStatusFile, environment, traceFactory)
@@ -31,11 +30,10 @@ namespace Kudu.Core.Jobs
             FileSystemHelpers.EnsureDirectory(_historyPath);
 
             _outputFilePath = Path.Combine(_historyPath, OutputLogFileName);
-            _errorFilePath = Path.Combine(_historyPath, ErrorLogFileName);
         }
 
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We do not want to accept jobs which are not TriggeredJob")]
-        public static TriggeredJobRunLogger LogNewRun(TriggeredJob triggeredJob, IEnvironment environment,  ITraceFactory traceFactory, IDeploymentSettingsManager settings)
+        public static TriggeredJobRunLogger LogNewRun(TriggeredJob triggeredJob, IEnvironment environment, ITraceFactory traceFactory, IDeploymentSettingsManager settings)
         {
             OldRunsCleanup(triggeredJob.Name, environment, traceFactory, settings);
 
@@ -134,9 +132,7 @@ namespace Kudu.Core.Jobs
         {
             message = GetFormattedMessage(level, message, isSystem);
 
-            string logPath = level == Level.Err ? _errorFilePath : _outputFilePath;
-
-            SafeLogToFile(logPath, message);
+            SafeLogToFile(_outputFilePath, message);
         }
     }
 }

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -603,7 +603,6 @@ namespace Kudu.FunctionalTests.Jobs
             Assert.NotNull(actualTriggeredJobRun.Url);
 
             AssertUrlContentAsync(appManager, actualTriggeredJobRun.OutputUrl, expectedOutput).Wait();
-            AssertUrlContentAsync(appManager, actualTriggeredJobRun.ErrorUrl, expectedError).Wait();
         }
 
         private async Task AssertUrlContentAsync(ApplicationManager appManager, Uri requestUrl, string expectedContent)


### PR DESCRIPTION
Fixes #1018
