### PR TITLE
Simplify and fix logic that deals with HOME path

### DIFF
--- a/Kudu.Core/Infrastructure/Executable.cs
+++ b/Kudu.Core/Infrastructure/Executable.cs
@@ -39,13 +39,6 @@ namespace Kudu.Core.Infrastructure
 
         public void SetHomePath(string homePath)
         {
-            // SSH requires HOME directory and applies to git, npm and (CustomBuilder) cmd
-            // Don't set it if it's already set, as would be the case in Azure
-            if (String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("HOME")))
-            {
-                EnvironmentVariables["HOME"] = homePath;
-            }
-
             EnvironmentVariables["HOMEDRIVE"] = homePath.Substring(0, homePath.IndexOf(':') + 1);
             EnvironmentVariables["HOMEPATH"] = homePath.Substring(homePath.IndexOf(':') + 1);
         }

--- a/Kudu.Services.Web/App_Start/PathResolver.cs
+++ b/Kudu.Services.Web/App_Start/PathResolver.cs
@@ -8,28 +8,8 @@ namespace Kudu.Services.Web
     {
         public static string ResolveRootPath()
         {
-            return Path.GetFullPath(ResolveRootPathInternal());
-        }
-
-        private static string ResolveRootPathInternal()
-        {
-            // If MapPath("/app") returns a valid folder, use it. This is the non-Azure code path
-            string path = HostingEnvironment.MapPath(Constants.MappedSite);
-            if (Directory.Exists(path))
-            {
-                return path;
-            }
-
-            // If d:\home exists, use it. This is a 'magic' folder on Azure that points to the root of the site files
-            path = Environment.ExpandEnvironmentVariables(@"%SystemDrive%\home");
-            if (Directory.Exists(path))
-            {
-                return path;
-            }
-
-            // Fall back to the HOME env variable, which is set on Azure but to a longer folder that looks
-            // something like C:\DWASFiles\Sites\MySite\VirtualDirectory0
-            path = Environment.ExpandEnvironmentVariables(@"%HOME%");
+            // The HOME path should always be set correctly
+            string path = Environment.ExpandEnvironmentVariables(@"%HOME%");
             if (Directory.Exists(path))
             {
                 return path;


### PR DESCRIPTION
The idea is to set %HOME% to what it should be at Kudu startup, and then be able to assume that it is correct everywhere else (including all child processes).
