### PR TITLE
etag support for triggered job history

### DIFF
--- a/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
+++ b/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
@@ -4,7 +4,7 @@
     {
         void InvokeTriggeredJob(string jobName);
 
-        TriggeredJobHistory GetJobHistory(string jobName);
+        TriggeredJobHistory GetJobHistory(string jobName, string etag, out string currentETag);
 
         TriggeredJobRun GetJobRun(string jobName, string runId);
     }


### PR DESCRIPTION
This dramatically reduces network latency in polling scenarios for a job run history
