### PR TITLE
Azure Pack 2 is storing it's home path a little differently 

### DIFF
--- a/Kudu.Services.Web/App_Start/PathResolver.cs
+++ b/Kudu.Services.Web/App_Start/PathResolver.cs
@@ -12,6 +12,13 @@ namespace Kudu.Services.Web
             string path = Environment.ExpandEnvironmentVariables(@"%HOME%");
             if (Directory.Exists(path))
             {
+                // For users running Windows Azure Pack 2 (WAP2), %HOME% actually points to the site folder,
+                // which we don't want here. So yank that segment if we detect it.
+                if (Path.GetFileName(path).Equals(Constants.SiteFolder, StringComparison.OrdinalIgnoreCase))
+                {
+                    path = Path.GetDirectoryName(path);
+                }			
+				
                 return path;
             }
 


### PR DESCRIPTION
So we need to detect that and fix it.
This has been tested over the past few months and works perfectly in our Azure Pack environment.
