### PR TITLE
Removed form-inline so textarea.width is 100%.

### DIFF
--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -91,7 +91,7 @@
         <div id="KuduExecConsoleV2" class="left-aligned"></div>
     </div>
     <div class="view edit-view" data-bind="visible: fileEdit()">
-        <div class="form-group form-inline">
+        <div class="form-group">
             <form role="form">
                 <p>
                     &nbsp;


### PR DESCRIPTION
Fixes #1054. From http://getbootstrap.com/css/, when using form-inline we need to set the width of textarea explicitly. If it does not affect layout, we can remove it as well.
