### PR TITLE
Fix unit tests that fail because of culture specific date string comparisons

### DIFF
--- a/Kudu.Services/ServiceHookHandlers/KilnHgHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/KilnHgHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -110,7 +111,7 @@ namespace Kudu.Services.ServiceHookHandlers
                     authorName: ParseNameFromAuthor(author),
                     authorEmail: ParseEmailFromAuthor(author),
                     message: (targetCommit.Value<string>("message") ?? String.Empty).Trim(),
-                    timestamp: new DateTimeOffset(DateTime.Parse(targetCommit.Value<string>("timestamp")), TimeSpan.Zero)
+                    timestamp: new DateTimeOffset(DateTime.Parse(targetCommit.Value<string>("timestamp"), CultureInfo.InvariantCulture), TimeSpan.Zero)
                     )
             };
 


### PR DESCRIPTION
Fixes all date comparison errors. Only have a single unit test failure left to diagnose:

``````
Kudu.Services.Test.ResumableLogReaderFacts.ResumableLogReaderCanHandleFileAccessError: System.ArgumentOutOfRangeException : The UTC time represented when the offset is applied must be between year 0 and 10,000.
Parameter name: offset
   at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset)
   at System.DateTimeOffset..ctor(DateTime dateTime)
   at Kudu.Services.Diagnostics.ApplicationLogsReader.ResumableLogFileReader..ctor(FileInfoBase fileInfo, ITracer tracer, LogFileAccessStats stats) in c:\Dev\Projects\github\kudu\Kudu.Services\Diagnostics\ApplicationLogsReader.cs:line 215
   at Kudu.Services.Test.ResumableLogReaderFacts.ResumableLogReaderCanHandleFileAccessError() in c:\Dev\Projects\github\kudu\Kudu.Services.Test\ApplicationLogsReaderFacts.cs:line 399```
``````
