### PR TITLE
in vfs controller, allow unconditional Range requests

### DIFF
--- a/Kudu.Services/Infrastructure/VfsControllerBase.cs
+++ b/Kudu.Services/Infrastructure/VfsControllerBase.cs
@@ -243,15 +243,15 @@ namespace Kudu.Services.Infrastructure
         /// </summary>
         protected bool IsRangeRequest(EntityTagHeaderValue currentEtag)
         {
-            if (currentEtag != null && Request.Headers.IfRange != null && Request.Headers.Range != null)
+            if (Request.Headers.Range == null)
             {
-                // First check that the etag matches so that we can consider the range request
-                if (currentEtag.Equals(Request.Headers.IfRange.EntityTag))
-                {
-                    return true;
-                }
+                return false;
             }
-            return false;
+            if (Request.Headers.IfRange != null)
+            {
+                return Request.Headers.IfRange.EntityTag.Equals(currentEtag);
+            }
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
This will allow the dashboard to issue queries such as "get job's console out starting with byte #x.
Usage is to allow the console log to be incrementally updated without requiring re-download of the whole log body every time it updates. (consider long-running Continuous jobs).
