### PR TITLE
fix #978 uploading and extracting a zip file from FileExplorer.js

### DIFF
--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -33,18 +33,50 @@ div.spinner {
 }
 
 #fileList {
-    height: 32%;
+    height: 35%;
 }
 
     #fileList > div.table-container {
-        height: 90%;
+        height: 85%;
         overflow-y: auto;
         width: 100%;
+        position: relative;
     }
 
 #resizeHandle {
     cursor: pointer;
     text-align: center;
+}
+
+div.show-on-hover {
+    position: absolute;
+    width: 20%;
+    height: 100%;
+    top: 0;
+    right: 0;
+    z-index: 1;
+    border: 1px solid #36a2ff;
+    background-color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.55);
+    display: none;
+}
+
+div.upload-unzip-hover {
+    background-color: #36a2ff;
+    background-color: rgba(54, 162, 255, 0.8);
+    display: block;
+}
+
+div.upload-unzip-show {
+    display: block;
+}
+
+div.zip-upload-text {
+    font-family: 'Lucida Console', Consolas, 'Courier New', monospace;
+    font-size: large;
+    position: relative;
+    text-align: center;
+    top: 40%;
 }
 
 div.console {

--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -31,11 +31,14 @@
                     <i class="h4 glyphicon glyphicon-hdd" title="System Drive"></i>
                 </a>
                 <div class="spinner">
-                    <i data-bind="visible: processing()" class="fa fa-spinner fa-spin" title="Please wait"></i>
+                    <i data-bind="visible: koprocessing()" class="fa fa-spinner fa-spin" title="Please wait"></i>
                     <i data-bind="visible: errorText, attr: {title: errorText}" class="alert-warning glyphicon glyphicon-exclamation-sign"></i>
                 </div>
             </div>
             <div class="table-container">
+                <div id="upload-unzip" class="show-on-hover">
+                    <div class="zip-upload-text">Drag here to upload and unzip <br /><span class="glyphicon glyphicon-folder-open"></span></div>
+                </div>
                 <table class="table table-striped table-bordered table-hover table-condensed table-responsive">
                     <thead>
                         <tr>


### PR DESCRIPTION
When dragging a zip file, FileExplorer will give you a target to allow uploading and unzipping the file.
the target won't show up if the dragged file isn't a zip file only in Chrome. Both IE and FF don't tell you what the dragged files are until they are dropped so will always display the target.

![fs](https://f.cloud.github.com/assets/645740/2478907/7b7972c8-b08a-11e3-850d-978470174d84.jpg)
