### PR TITLE
WebJobs will now use the actual location of the script as the root binaries directory

### DIFF
--- a/Kudu.Contracts/Jobs/JobBase.cs
+++ b/Kudu.Contracts/Jobs/JobBase.cs
@@ -31,6 +31,8 @@ namespace Kudu.Contracts.Jobs
 
         public string ScriptFilePath { get; set; }
 
+        public string JobBinariesRootPath { get; set; }
+
         public override int GetHashCode()
         {
             return HashHelpers.CalculateCompositeHash(Name, RunCommand, JobType, Error);

--- a/Kudu.Core/Jobs/ContinuousJobRunner.cs
+++ b/Kudu.Core/Jobs/ContinuousJobRunner.cs
@@ -20,15 +20,14 @@ namespace Kudu.Core.Jobs
         private Thread _continuousJobThread;
         private ContinuousJobLogger _continuousJobLogger;
         private JobSettings _jobSettings;
-
         private readonly string _disableFilePath;
 
-        public ContinuousJobRunner(string jobName, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
-            : base(jobName, Constants.ContinuousPath, environment, settings, traceFactory, analytics)
+        public ContinuousJobRunner(ContinuousJob continuousJob, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
+            : base(continuousJob.Name, Constants.ContinuousPath, environment, settings, traceFactory, analytics)
         {
-            _continuousJobLogger = new ContinuousJobLogger(jobName, Environment, TraceFactory);
+            _continuousJobLogger = new ContinuousJobLogger(continuousJob.Name, Environment, TraceFactory);
 
-            _disableFilePath = Path.Combine(JobBinariesPath, "disable.job");
+            _disableFilePath = Path.Combine(continuousJob.JobBinariesRootPath, "disable.job");
 
             _singletonLock = new LockFile(Path.Combine(JobDataPath, "singleton.job.lock"), TraceFactory);
         }

--- a/Kudu.Core/Jobs/ContinuousJobsManager.cs
+++ b/Kudu.Core/Jobs/ContinuousJobsManager.cs
@@ -211,7 +211,7 @@ namespace Kudu.Core.Jobs
             ContinuousJobRunner continuousJobRunner;
             if (!_continuousJobRunners.TryGetValue(continuousJob.Name, out continuousJobRunner))
             {
-                continuousJobRunner = new ContinuousJobRunner(continuousJob.Name, Environment, Settings, TraceFactory, Analytics);
+                continuousJobRunner = new ContinuousJobRunner(continuousJob, Environment, Settings, TraceFactory, Analytics);
                 _continuousJobRunners.Add(continuousJob.Name, continuousJobRunner);
             }
 

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -429,6 +429,17 @@ namespace Kudu.FunctionalTests.Jobs
                 appManager.JobsManager.CreateContinuousJobAsync("job1", zippedJobBinaries).Wait();
                 appManager.JobsManager.CreateContinuousJobAsync("job2", zippedJobBinaries).Wait();
 
+                // Disabling a continuous job should not affect the job count
+                WaitUntilAssertVerified(
+                    "disable continuous job",
+                    TimeSpan.FromSeconds(20),
+                    () => appManager.JobsManager.DisableContinuousJobAsync("job1").Wait());
+
+                // Adding a setting to a triggered job should not affect the job count
+                var jobSettings = new JobSettings();
+                jobSettings["one"] = 1;
+                appManager.JobsManager.SetTriggeredJobSettingsAsync("job1", jobSettings).Wait();
+
                 var triggeredJobs = appManager.JobsManager.ListTriggeredJobsAsync().Result;
                 var continuousJobs = appManager.JobsManager.ListContinuousJobsAsync().Result;
 


### PR DESCRIPTION
This is for files stored as part of the job, for now those are disable.job and settings.job.
Fixes #1092
