### PR TITLE
fixes #1100 Increasing the upload size to kudu

### DIFF
--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -13,7 +13,7 @@
   <system.web>
     <customErrors mode="Off" />
     <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" maxRequestLength="104857600" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" />
+    <httpRuntime targetFramework="4.5" maxRequestLength="4194304" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" />
     <pages controlRenderingCompatibilityVersion="4.0" />
   </system.web>
   <location path="." inheritInChildApplications="false">
@@ -34,7 +34,7 @@
   <system.webServer>
     <security>
       <requestFiltering>
-        <requestLimits maxAllowedContentLength="104857600" />
+        <requestLimits maxAllowedContentLength="4294967295" />
         <fileExtensions allowUnlisted="true">
           <remove fileExtension=".asa" />
           <remove fileExtension=".asax" />


### PR DESCRIPTION
Notes:
-> requestLimits.maxAllowedContentLength is uint (Windows DWORD), in bytes. [MSDN](http://msdn.microsoft.com/en-us/library/ms689462%28v=vs.90%29.aspx)
-> httpRuntime.maxRequestLength is System.Int32, in KB. [MSDN](http://msdn.microsoft.com/en-us/library/e1f13641%28v=vs.85%29.aspx)
