### PR TITLE
fixes #1049 Escaping # symbol in VFS controller

### DIFF
--- a/Kudu.Core/Infrastructure/StringExtensions.cs
+++ b/Kudu.Core/Infrastructure/StringExtensions.cs
@@ -23,5 +23,10 @@ namespace Kudu.Core
         {
             return String.IsNullOrEmpty(str) ? str : str.GetHashCode().ToString();
         }
+
+        public static string EscapeHashCharacter(this string str)
+        {
+            return str.Replace("#", Uri.EscapeDataString("#"));
+        }
     }
 }

--- a/Kudu.Services/Infrastructure/VfsControllerBase.cs
+++ b/Kudu.Services/Infrastructure/VfsControllerBase.cs
@@ -362,7 +362,7 @@ namespace Kudu.Services.Infrastructure
                     MTime = fileSysInfo.LastWriteTimeUtc,
                     Mime = mime,
                     Size = size,
-                    Href = baseAddress + Uri.EscapeUriString(unescapedHref),
+                    Href = (baseAddress + Uri.EscapeUriString(unescapedHref)).EscapeHashCharacter(),
                     Path = fileSysInfo.FullName
                 };
             }


### PR DESCRIPTION
this doesn't address other Windows legal path characters that are illegal in URL like `%`, `&`, and `+`.
