### PR TITLE
fixes #1057 Handling LocalSiteRoot special VFS folder

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -250,7 +250,9 @@ $.connection.hub.start().done(function () {
         }
             
         workingDirChanging = true;
-        var relativeDir = getRelativePath(viewModel.root, newValue) || getRelativePath(viewModel.specialDirsIndex()["SystemDrive"], newValue),
+        var relativeDir = getRelativePath(viewModel.root, newValue) ||
+            getRelativePath(viewModel.specialDirsIndex()["SystemDrive"], newValue) ||
+            getRelativePath(viewModel.specialDirsIndex()["LocalSiteRoot"], newValue),
             deferred;
 
         if (!relativeDir || !relativeDir.relativePath) {

--- a/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
+++ b/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
@@ -77,7 +77,7 @@ namespace Kudu.Services.Infrastructure
 
             if (!String.IsNullOrEmpty(LocalSiteRootPath))
             {
-                var dir = FileSystemHelpers.DirectoryInfoFromDirectoryName(LocalSiteRootPath + Path.DirectorySeparatorChar);
+                var dir = FileSystemHelpers.DirectoryInfoFromDirectoryName(LocalSiteRootPath);
                 yield return new VfsStatEntry
                 {
                     Name = LocalSiteRootFolder,


### PR DESCRIPTION
  LocalSiteRoot is the only folder in VFS that gets a trailing \
  But since the special folders also include SystemDrive which is usually
  D:\ or C:\ where the trailing backslash is necessary, this confuses
  FileExplorer.js
