### PR TITLE
fix #798 improve disconnect and reconnect logic

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -30,6 +30,7 @@ namespace Kudu
         public const string ScriptsPath = "scripts";
         public const string NodeModulesPath = "node_modules";
         public const string FirstDeploymentManifestFileName = "firstDeploymentManifest";
+        public const string ManifestFileName = "manifest";
 
         public const string AppDataPath = "App_Data";
         public const string DataPath = "data";

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -128,6 +128,11 @@ namespace Kudu.Core.Infrastructure
             }
         }
 
+        public static void CopyFile(string sourceFileName, string destFileName, bool overwrite = true)
+        {
+            Instance.File.Copy(sourceFileName, destFileName, overwrite);
+        }
+
         // From MSDN: http://msdn.microsoft.com/en-us/library/bb762914.aspx
         public static void CopyDirectoryRecursive(string sourceDirPath, string destinationDirPath, bool overwrite = true)
         {

--- a/Kudu.FunctionalTests/DeploymentManagerTests.cs
+++ b/Kudu.FunctionalTests/DeploymentManagerTests.cs
@@ -256,7 +256,10 @@ namespace Kudu.FunctionalTests
         public async Task DeleteKuduSiteCleansProperly()
         {
             string appName = "DeleteKuduSiteCleansProperly";
+            // This file is part of HelloWorld repo
             string defaultHtmFile = "default.htm";
+            // This file is part of HelloKudu repo
+            string indexHtmFile = "index.htm";
 
             using (var repo = Git.Clone("HelloWorld"))
             {
@@ -274,6 +277,10 @@ namespace Kudu.FunctionalTests
                     // Verify default.htm file from HelloWorld exists
                     bool defaultHtmExists = appManager.VfsWebRootManager.Exists(defaultHtmFile);
                     Assert.True(defaultHtmExists, defaultHtmFile + " doesn't exist");
+
+                    // Verify index.htm file does not exist
+                    bool indexHtmExists = appManager.VfsWebRootManager.Exists(indexHtmFile);
+                    Assert.False(indexHtmExists, indexHtmFile + " exist");
 
                     // Add file to wwwroot not through deployment/repository
                     string extraFileName = "extra.file";
@@ -294,22 +301,30 @@ namespace Kudu.FunctionalTests
                     defaultHtmExists = appManager.VfsWebRootManager.Exists(defaultHtmFile);
                     Assert.True(defaultHtmExists, defaultHtmFile + " doesn't exist");
 
-                    // Redeploy HelloWorld repository
-                    appManager.GitDeploy(repo.PhysicalPath);
-                    results = (await appManager.DeploymentManager.GetResultsAsync()).ToList();
+                    // Redeploy with new Repo
+                    using (var newRepo = Git.Clone("HelloKudu"))
+                    {
+                        // Redeploy HelloKudu repository
+                        appManager.GitDeploy(newRepo.PhysicalPath);
+                        results = (await appManager.DeploymentManager.GetResultsAsync()).ToList();
 
-                    // Verify deployed properly
-                    Assert.Equal(1, results.Count);
-                    Assert.Equal(DeployStatus.Success, results[0].Status);
-                    Assert.NotNull(results[0].LastSuccessEndTime);
+                        // Verify deployed properly
+                        Assert.Equal(1, results.Count);
+                        Assert.Equal(DeployStatus.Success, results[0].Status);
+                        Assert.NotNull(results[0].LastSuccessEndTime);
 
-                    // Verify default.htm file from HelloWorld exists
-                    defaultHtmExists = appManager.VfsWebRootManager.Exists(defaultHtmFile);
-                    Assert.True(defaultHtmExists, defaultHtmFile + " doesn't exist");
+                        // Verify default.htm file from HelloWorld does not exist
+                        defaultHtmExists = appManager.VfsWebRootManager.Exists(defaultHtmFile);
+                        Assert.False(defaultHtmExists, defaultHtmFile + " exist");
 
-                    // Verify extra.file there
-                    extraFileExists = appManager.VfsWebRootManager.Exists(extraFileName);
-                    Assert.True(extraFileExists, extraFileName + " doesn't exist");
+                        // Verify index.htm file from HelloKudu exists
+                        indexHtmExists = appManager.VfsWebRootManager.Exists(indexHtmFile);
+                        Assert.True(indexHtmExists, indexHtmFile + " doesn't exist");
+
+                        // Verify extra.file there
+                        extraFileExists = appManager.VfsWebRootManager.Exists(extraFileName);
+                        Assert.True(extraFileExists, extraFileName + " doesn't exist");
+                    }
                 });
             }
         }


### PR DESCRIPTION
The idea is to save the latest successful deployment manifest at the location where it can survive across SCM delete api - I chose `/site/firstDeploymentManifest` file.   This file, if exists, will be preferred over the default manifest when reconnecting SCM and initial deployment.  

There are two approaches.
1. Save it at deployment completion time.
2. Save it at DELETE /scm time.

I chose the latter.  It introduces no additional logic to the normal deployment execution path.  It covers the scenario to not require pushing new Deployment for existing site before disconnecting (edge case). 
