### PR TITLE
Added shutdown notification for webjobs to be able to gracefully shutdown jobs.

### DIFF
--- a/Kudu.Contracts/Jobs/JobSettings.cs
+++ b/Kudu.Contracts/Jobs/JobSettings.cs
@@ -21,5 +21,18 @@ namespace Kudu.Contracts.Jobs
         {
             this[key] = value;
         }
+
+        public bool IsSingleton
+        {
+            get
+            {
+                return GetSetting(JobSettingsKeys.IsSingleton, false);
+            }
+        }
+
+        public TimeSpan GetStoppingWaitTime(int defaultTime)
+        {
+            return TimeSpan.FromSeconds(GetSetting(JobSettingsKeys.StoppingWaitTime, defaultTime));
+        }
     }
 }

--- a/Kudu.Contracts/Jobs/JobSettingsKeys.cs
+++ b/Kudu.Contracts/Jobs/JobSettingsKeys.cs
@@ -1,0 +1,8 @@
+﻿namespace Kudu.Contracts.Jobs
+{
+    public static class JobSettingsKeys
+    {
+        public const string IsSingleton = "is_singleton";
+        public const string StoppingWaitTime = "stopping_wait_time";
+    }
+}

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Jobs\IScriptHost.cs" />
     <Compile Include="Jobs\ITriggeredJobsManager.cs" />
     <Compile Include="Jobs\JobBase.cs" />
+    <Compile Include="Jobs\JobSettingsKeys.cs" />
     <Compile Include="Jobs\TriggeredJob.cs" />
     <Compile Include="Jobs\TriggeredJobHistory.cs" />
     <Compile Include="Jobs\TriggeredJobRun.cs" />

--- a/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
+++ b/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
@@ -26,6 +26,7 @@
         public const string WebJobsDataPath = "WEBJOBS_DATA_PATH";
         public const string WebJobsExtraUrlPath = "WEBJOBS_EXTRA_INFO_URL_PATH";
         public const string WebJobsRunId = "WEBJOBS_RUN_ID";
+        public const string WebJobsShutdownNotificationFile = "WEBJOBS_SHUTDOWN_FILE";
 
         public const string CommitId = "SCM_COMMIT_ID";
     }

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -157,7 +157,7 @@ namespace Kudu.FunctionalTests.Jobs
                 JobSettings continuousJobSettings =
                     appManager.JobsManager.GetContinuousJobSettingsAsync(expectedContinuousJob.Name).Result;
 
-                Assert.False(continuousJobSettings.GetSetting<bool>("is_singleton"));
+                Assert.False(continuousJobSettings.IsSingleton);
 
                 continuousJobSettings.SetSetting("is_singleton", true);
                 appManager.JobsManager.SetContinuousJobSettingsAsync(expectedContinuousJob.Name, continuousJobSettings).Wait();


### PR DESCRIPTION
For continuous - Before stopping write a file to a known (through environment setting) location to let the job know it's going to stop, then after 5 seconds if the job is not stopped, kill it.
For triggered - Wait for a default of 30 seconds for the job to go down and after that continue (and the process will get killed).
The waiting time in both cases is configurable using settings.job file.
Fixes #1068
