### PR TITLE
ForwardSlashCombine should not combine when one part is empty.

### DIFF
--- a/Kudu.Core/Infrastructure/ZipArchiveExtensions.cs
+++ b/Kudu.Core/Infrastructure/ZipArchiveExtensions.cs
@@ -41,7 +41,7 @@ namespace Kudu.Core.Infrastructure
 
         private static string ForwardSlashCombine(string part1, string part2)
         {
-            return "{0}/{1}".FormatInvariant(part1.TrimEnd('/'), part2.TrimStart('/'));
+            return Path.Combine(part1, part2).Replace('\\', '/');
         }
 
         public static void AddFile(this ZipArchive zipArchive, string filePath, ITracer tracer, string directoryNameInArchive = "")

--- a/Kudu.Services.Test/ZipArchiveExtensionFacts.cs
+++ b/Kudu.Services.Test/ZipArchiveExtensionFacts.cs
@@ -15,8 +15,8 @@ namespace Kudu.Services.Test
     public class ZipArchiveExtensionFacts
     {
         [Theory]
-        [InlineData("/Foo.txt", "This was a triumph")]
-        [InlineData("/Bar/Qux/Foo.txt", "I'm making a note here")]
+        [InlineData("Foo.txt", "This was a triumph")]
+        [InlineData("Bar/Qux/Foo.txt", "I'm making a note here")]
         public void AddFileToArchiveCreatesEntryUnderDirectory(string fileName, string content)
         {
             // Arrange
@@ -59,11 +59,11 @@ namespace Kudu.Services.Test
             zip.Dispose();
             zip = new ZipArchive(ReOpen(stream));
             Assert.Equal(5, zip.Entries.Count);
-            AssertZipEntry(zip, "/log.txt", "log content");
-            AssertZipEntry(zip, "/site/home.aspx", "home content");
-            AssertZipEntry(zip, "/site/site.css", "some css");
-            AssertZipEntry(zip, "/site/empty-dir/", null);
-            AssertZipEntry(zip, "/zero-length-file", null);
+            AssertZipEntry(zip, "log.txt", "log content");
+            AssertZipEntry(zip, "site/home.aspx", "home content");
+            AssertZipEntry(zip, "site/site.css", "some css");
+            AssertZipEntry(zip, "site/empty-dir/", null);
+            AssertZipEntry(zip, "zero-length-file", null);
         }
 
         [Fact]


### PR DESCRIPTION
Fix #1128.
