### PR TITLE
Small fixes including more agressive process killing when stopping a job...

### DIFF
--- a/Kudu.Core/Jobs/BaseJobRunner.cs
+++ b/Kudu.Core/Jobs/BaseJobRunner.cs
@@ -226,7 +226,7 @@ namespace Kudu.Core.Jobs
                     {
                         try
                         {
-                            process.Kill();
+                            process.Kill(true, TraceFactory.GetTracer());
                         }
                         catch (Exception ex)
                         {
@@ -248,8 +248,11 @@ namespace Kudu.Core.Jobs
         {
             try
             {
-                FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(_shutdownNotificationFilePath));
-                OperationManager.Attempt(() => FileSystemHelpers.WriteAllText(_shutdownNotificationFilePath, DateTime.UtcNow.ToString()));
+                if (_shutdownNotificationFilePath != null)
+                {
+                    FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(_shutdownNotificationFilePath));
+                    OperationManager.Attempt(() => FileSystemHelpers.WriteAllText(_shutdownNotificationFilePath, DateTime.UtcNow.ToString()));
+                }
             }
             catch (Exception ex)
             {

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -588,7 +588,7 @@ namespace Kudu.FunctionalTests.Jobs
         {
             WaitUntilAssertVerified(
                 "continuous job disabled",
-                TimeSpan.FromSeconds(30),
+                TimeSpan.FromSeconds(40),
                 () =>
                 {
                     var jobs = appManager.JobsManager.ListContinuousJobsAsync().Result;
@@ -598,7 +598,7 @@ namespace Kudu.FunctionalTests.Jobs
 
             WaitUntilAssertVerified(
                 "make sure process is down",
-                TimeSpan.FromSeconds(30),
+                TimeSpan.FromSeconds(40),
                 () =>
                 {
                     var allProcesses = appManager.ProcessManager.GetProcessesAsync().Result;


### PR DESCRIPTION
... (to reduce probability of having orphand processes)

Fixing WebJob test which could fail since the shutdown period added 5 seconds to the shutdown process of a continuous WebJob.
