### PR TITLE
ability to turn on/off cookie on the client

### DIFF
--- a/Kudu.Client/Diagnostics/RemoteProcessManager.cs
+++ b/Kudu.Client/Diagnostics/RemoteProcessManager.cs
@@ -12,8 +12,9 @@ namespace Kudu.Client.Diagnostics
 {
     public class RemoteProcessManager : KuduRemoteClientBase
     {
-        public RemoteProcessManager(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
-            : base(serviceUrl, credentials, handler)
+        // default useCookies to true to make sure client sticky to instances
+        public RemoteProcessManager(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null, bool useCookies = true)
+            : base(serviceUrl, credentials, handler, useCookies)
         {
         }
 

--- a/Kudu.Client/Infrastructure/HttpClientHelper.cs
+++ b/Kudu.Client/Infrastructure/HttpClientHelper.cs
@@ -12,14 +12,14 @@ namespace Kudu.Client.Infrastructure
     {
         private static readonly char[] uriPathSeparator = new char[] { '/' };
 
-        public static HttpClient CreateClient(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
+        public static HttpClient CreateClient(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null, bool useCookies = false)
         {
             if (serviceUrl == null)
             {
                 throw new ArgumentNullException("serviceUrl");
             }
 
-            HttpMessageHandler effectiveHandler = handler ?? CreateClientHandler(serviceUrl, credentials);
+            HttpMessageHandler effectiveHandler = handler ?? CreateClientHandler(serviceUrl, credentials, useCookies);
             Uri serviceAddr = new Uri(serviceUrl);
             HttpClient client = new HttpClient(effectiveHandler)
             {
@@ -32,7 +32,7 @@ namespace Kudu.Client.Infrastructure
             return client;
         }
 
-        public static HttpClientHandler CreateClientHandler(string serviceUrl, ICredentials credentials)
+        public static HttpClientHandler CreateClientHandler(string serviceUrl, ICredentials credentials, bool useCookies = false)
         {
             if (serviceUrl == null)
             {
@@ -56,6 +56,10 @@ namespace Kudu.Client.Infrastructure
                 clientHandler.Credentials = credentialCache;
                 clientHandler.PreAuthenticate = true;
             }
+
+            // HttpClient's default UseCookies is true (meaning always roundtripping cookie back)
+            // However, our api will default to false to cover multiple instance scenarios
+            clientHandler.UseCookies = useCookies;
 
             // Our handler is ready
             return clientHandler;

--- a/Kudu.Client/Infrastructure/KuduRemoteClientBase.cs
+++ b/Kudu.Client/Infrastructure/KuduRemoteClientBase.cs
@@ -6,7 +6,7 @@ namespace Kudu.Client.Infrastructure
 {
     public abstract class KuduRemoteClientBase
     {
-        protected KuduRemoteClientBase(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null)
+        protected KuduRemoteClientBase(string serviceUrl, ICredentials credentials = null, HttpMessageHandler handler = null, bool useCookie = false)
         {
             if (serviceUrl == null)
             {
@@ -15,7 +15,7 @@ namespace Kudu.Client.Infrastructure
 
             ServiceUrl = UrlUtility.EnsureTrailingSlash(serviceUrl);
             Credentials = credentials;
-            Client = HttpClientHelper.CreateClient(ServiceUrl, credentials, handler);
+            Client = HttpClientHelper.CreateClient(ServiceUrl, credentials, handler, useCookie);
         }
 
         public string ServiceUrl { get; private set; }

--- a/Kudu.TestHarness/TestHarnessClassCommandAttribute.cs
+++ b/Kudu.TestHarness/TestHarnessClassCommandAttribute.cs
@@ -66,7 +66,7 @@ namespace Kudu.TestHarness
                     }
                     else
                     {
-                        yield return new TestHarnessCommand(attribute, testCommand);
+                        yield return new TestHarnessCommand(attribute, testCommand, testMethod);
                     }
                 }
             }
@@ -76,23 +76,27 @@ namespace Kudu.TestHarness
                 private readonly int _runs;
                 private readonly int _retries;
                 private readonly bool _suppressError;
+                private readonly IMethodInfo _testMethod;
 
-                public TestHarnessCommand(TestHarnessClassCommandAttribute attribute, ITestCommand inner)
+                public TestHarnessCommand(TestHarnessClassCommandAttribute attribute, ITestCommand inner, IMethodInfo testMethod)
                     : base(inner)
                 {
-                    if (!Int32.TryParse(KuduUtils.GetTestSetting(RunsSettingKey), out _runs))
+                    _testMethod = testMethod;
+
+                    // prefer imperative over config settings
+                    if (attribute.Runs != DefaultRuns || !Int32.TryParse(KuduUtils.GetTestSetting(RunsSettingKey), out _runs))
                     {
                         _runs = attribute.Runs;
                     }
                     _runs = Math.Max(DefaultRuns, _runs);
 
-                    if (!Int32.TryParse(KuduUtils.GetTestSetting(RetriesSettingKey), out _retries))
+                    if (attribute.Retries != DefaultRetries || !Int32.TryParse(KuduUtils.GetTestSetting(RetriesSettingKey), out _retries))
                     {
                         _retries = attribute.Retries;
                     }
                     _retries = Math.Max(DefaultRetries, _retries);
 
-                    if (!Boolean.TryParse(KuduUtils.GetTestSetting(SuppressErrorSettingKey), out _suppressError))
+                    if (attribute.SuppressError != DefaultSuppressError || !Boolean.TryParse(KuduUtils.GetTestSetting(SuppressErrorSettingKey), out _suppressError))
                     {
                         _suppressError = attribute.SuppressError;
                     }


### PR DESCRIPTION
There are 2 changes.  This lays ground for Azure fix to support multiple instances.
1. Support turn on/off cookies on HttpClient.  All except ProcessManager will have cookie management turn off - to exercise multiple instances.   For ProcessManager, we want it to be sticky.
2. TestHarnessClassCommandAttribute changes to honor imperative settings over appsetting configuration.
