### PR TITLE
Change tab-autocomplete to behave like cmd.exe and fixes #1144 as well

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/jquery-console/jquery.console.js
+++ b/Kudu.Services.Web/Content/Scripts/jquery-console/jquery.console.js
@@ -286,6 +286,9 @@
 				return false;
 			}
 			if (acceptInput) {
+			    if (typeof config.userInputHandle == 'function') {
+			        config.userInputHandle(keyCode);
+			    }
 				if (keyCode in keyCodes) {
 					cancelKeyPress = keyCode;
 					(keyCodes[keyCode])();
@@ -648,7 +651,7 @@
 				}
 				var len = completions.length;
 				if (len === 1) {
-					extern.promptText(promptText + completions[0]);
+					extern.promptText(completions[0]);
 				} else if (len > 1 && config.cols) {
 					var prompt = promptText;
 					// Compute the number of rows that will fit in the width

--- a/Kudu.Services/Commands/PersistentCommandController.cs
+++ b/Kudu.Services/Commands/PersistentCommandController.cs
@@ -61,7 +61,8 @@ namespace Kudu.Services
         protected override Task OnReceived(IRequest request, string connectionId, string data)
         {
             ProcessInfo process;
-            var shell = request.QueryString != null ? request.QueryString["shell"] : null;
+            data = data ?? String.Empty;
+            var shell = request.QueryString != null ? request.QueryString["shell"] : String.Empty;
             if (!_processes.TryGetValue(connectionId, out process) || process.Process.HasExited)
             {
                 process = _processes.AddOrUpdate(connectionId, cId => StartProcess(cId, shell), (s, p) => StartProcess(s, shell));


### PR DESCRIPTION
I have always found this annoying. I changed the tab behavior to be the same as cmd (i.e. cycle through the options) 

Also a small fix for null ref in the PersistentCommandController if the client doesn't specify a shell or sends in null data
