### PR TITLE
Added path to installed npm global executables

### DIFF
--- a/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
@@ -99,6 +99,8 @@ namespace Kudu.Core.Deployment.Generator
             {
                 toolsPaths.Add(Path.GetDirectoryName(npmExePath));
             }
+            
+            toolsPaths.Add(PathUtility.ResolveNpmGlobalPath());
 
             exe.PrependToPath(toolsPaths);
             return exe;

--- a/Kudu.Core/Infrastructure/PathUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtility.cs
@@ -129,6 +129,12 @@ namespace Kudu.Core.Infrastructure
             return File.Exists(npmExePath) ? npmExePath : null;
         }
 
+        internal static string ResolveNpmGlobalPath()
+        {
+            string appDataDirectory = SystemEnvironment.GetFolderPath(SystemEnvironment.SpecialFolder.ApplicationData);
+            return Path.Combine(appDataDirectory, "npm");
+        }
+
         /// <summary>
         /// Returns the path to the version of node.exe that is used for KuduScript generation and select node version
         /// </summary>


### PR DESCRIPTION
So users can run `bower install` after running `npm install bower -g`.
