### PR TITLE
Allow setting needFileUpdate in json body for /api/deployments

### DIFF
--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -83,10 +83,14 @@ namespace Kudu.Services.Deployment
                     try
                     {
                         bool clean = false;
+                        bool needFileUpdate = true;
 
                         if (result != null)
                         {
                             clean = result.Value<bool>("clean");
+                            JToken needFileUpdateToken;
+                            if (result.TryGetValue("needFileUpdate", out needFileUpdateToken))
+                                needFileUpdate = needFileUpdateToken.Value<bool>();
                         }
 
                         string username = null;
@@ -108,7 +112,7 @@ namespace Kudu.Services.Deployment
                             }
                         }
 
-                        await _deploymentManager.DeployAsync(repository, changeSet, username, clean);
+                        await _deploymentManager.DeployAsync(repository, changeSet, username, clean, needFileUpdate);
                     }
                     catch (FileNotFoundException ex)
                     {


### PR DESCRIPTION
This is related to #1175

I found that setting `needFileUpdate = false` and passing it through to the DeployAsync method in the DeploymentManager will avoid the need to checkout the master branch or a specific revision and do an incremental deploy just like with `git push`.
In my scenario the repository has been updated with additional commits and the repository is checked out on the master branch (latest commit - which I want to deploy), so I don't need to do any additional checkouts. Ideally I would be able to do incremental updates, which this setting seems to allow.

Let me know what you think of this PR.

Thanks!
