### PR TITLE
Added option to provide arguments to the WebJobs script for triggered WebJobs

### DIFF
--- a/Kudu.Client/Jobs/RemoteJobsManager.cs
+++ b/Kudu.Client/Jobs/RemoteJobsManager.cs
@@ -68,9 +68,16 @@ namespace Kudu.Client.Jobs
             await Client.PutJsonAsync<JobSettings, object>("continuous/" + jobName + "/settings", jobSettings);
         }
 
-        public async Task InvokeTriggeredJobAsync(string jobName)
+        public async Task InvokeTriggeredJobAsync(string jobName, string arguments = null)
         {
-            await Client.PostAsync("triggered/" + jobName + "/run");
+            if (arguments != null)
+            {
+                await Client.PostAsync("triggered/" + jobName + "/run?arguments=" + arguments);
+            }
+            else
+            {
+                await Client.PostAsync("triggered/" + jobName + "/run");
+            }
         }
 
         public async Task CreateContinuousJobAsync(string jobName, string scriptFileName, string content = null)

--- a/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
+++ b/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
@@ -2,7 +2,7 @@
 {
     public interface ITriggeredJobsManager : IJobsManager<TriggeredJob>
     {
-        void InvokeTriggeredJob(string jobName);
+        void InvokeTriggeredJob(string jobName, string arguments);
 
         TriggeredJobHistory GetJobHistory(string jobName, string etag, out string currentETag);
 

--- a/Kudu.Contracts/Jobs/JobBase.cs
+++ b/Kudu.Contracts/Jobs/JobBase.cs
@@ -33,6 +33,8 @@ namespace Kudu.Contracts.Jobs
 
         public string JobBinariesRootPath { get; set; }
 
+        public string CommandArguments { get; set; }
+
         public override int GetHashCode()
         {
             return HashHelpers.CalculateCompositeHash(Name, RunCommand, JobType, Error);

--- a/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
+++ b/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
@@ -27,6 +27,7 @@
         public const string WebJobsExtraUrlPath = "WEBJOBS_EXTRA_INFO_URL_PATH";
         public const string WebJobsRunId = "WEBJOBS_RUN_ID";
         public const string WebJobsShutdownNotificationFile = "WEBJOBS_SHUTDOWN_FILE";
+        public const string WebJobsCommandArguments = "WEBJOBS_COMMAND_ARGUMENTS";
 
         public const string CommitId = "SCM_COMMIT_ID";
     }

--- a/Kudu.Core/Jobs/BaseJobRunner.cs
+++ b/Kudu.Core/Jobs/BaseJobRunner.cs
@@ -176,6 +176,7 @@ namespace Kudu.Core.Jobs
                     exe.EnvironmentVariables[WellKnownEnvironmentVariables.WebJobsDataPath] = JobDataPath;
                     exe.EnvironmentVariables[WellKnownEnvironmentVariables.WebJobsRunId] = runId;
                     exe.EnvironmentVariables[WellKnownEnvironmentVariables.WebJobsShutdownNotificationFile] = _shutdownNotificationFilePath;
+                    exe.EnvironmentVariables[WellKnownEnvironmentVariables.WebJobsCommandArguments] = job.CommandArguments;
 
                     UpdateStatus(logger, "Running");
 
@@ -185,7 +186,8 @@ namespace Kudu.Core.Jobs
                             logger.LogStandardOutput,
                             logger.LogStandardError,
                             job.ScriptHost.ArgumentsFormat,
-                            scriptFileName);
+                            scriptFileName,
+                            job.CommandArguments != null ? " " + job.CommandArguments : String.Empty);
 
                     if (exitCode != 0)
                     {

--- a/Kudu.Core/Jobs/PowerShellScriptHost.cs
+++ b/Kudu.Core/Jobs/PowerShellScriptHost.cs
@@ -7,7 +7,7 @@ namespace Kudu.Core.Jobs
         private static readonly string[] Supported = { ".ps1" };
 
         public PowerShellScriptHost()
-            : base("PowerShell.exe", "-ExecutionPolicy RemoteSigned -File {0}")
+            : base("PowerShell.exe", "-ExecutionPolicy RemoteSigned -File {0}{1}")
         {
         }
 

--- a/Kudu.Core/Jobs/ScriptHostBase.cs
+++ b/Kudu.Core/Jobs/ScriptHostBase.cs
@@ -5,7 +5,13 @@ namespace Kudu.Core.Jobs
 {
     public abstract class ScriptHostBase : IScriptHost
     {
-        protected ScriptHostBase(string hostPath, string argumentsFormat = "{0}")
+        /// <summary>
+        /// ctor
+        /// </summary>
+        /// <param name="hostPath">path to the host running the script</param>
+        /// <param name="argumentsFormat">the arguments format passed to the host, {0} is the script file path and {1} are the arguments coming from the user
+        /// ({1} if not empty will have an extra whitespace at the beginning before the arguments start)</param>
+        protected ScriptHostBase(string hostPath, string argumentsFormat = "{0}{1}")
         {
             HostPath = hostPath;
             ArgumentsFormat = argumentsFormat;

--- a/Kudu.Core/Jobs/TriggeredJobsManager.cs
+++ b/Kudu.Core/Jobs/TriggeredJobsManager.cs
@@ -215,13 +215,15 @@ namespace Kudu.Core.Jobs
             return null;
         }
 
-        public void InvokeTriggeredJob(string jobName)
+        public void InvokeTriggeredJob(string jobName, string arguments)
         {
             TriggeredJob triggeredJob = GetJob(jobName);
             if (triggeredJob == null)
             {
                 throw new JobNotFoundException();
             }
+
+            triggeredJob.CommandArguments = arguments;
 
             if (IsShuttingdown)
             {

--- a/Kudu.Core/Jobs/WindowsScriptHost.cs
+++ b/Kudu.Core/Jobs/WindowsScriptHost.cs
@@ -7,7 +7,7 @@ namespace Kudu.Core.Jobs
         private static readonly string[] Supported = { ".cmd", ".bat", ".exe" };
 
         public WindowsScriptHost()
-            : base("cmd", "/c {0}")
+            : base("cmd", "/c {0}{1}")
         {
         }
 

--- a/Kudu.Services/Jobs/JobsController.cs
+++ b/Kudu.Services/Jobs/JobsController.cs
@@ -158,11 +158,11 @@ namespace Kudu.Services.Jobs
         }
 
         [HttpPost]
-        public HttpResponseMessage InvokeTriggeredJob(string jobName)
+        public HttpResponseMessage InvokeTriggeredJob(string jobName, string arguments = null)
         {
             try
             {
-                _triggeredJobsManager.InvokeTriggeredJob(jobName);
+                _triggeredJobsManager.InvokeTriggeredJob(jobName, arguments);
                 return Request.CreateResponse(HttpStatusCode.Accepted);
             }
             catch (JobNotFoundException)


### PR DESCRIPTION
It is provided by a query string ?arguments={arguments}.
The arguments are then propagated to the script using command line arguments and also in an environment variable %WEBJOBS_COMMAND_ARGUMENTS%
Fixes #908
