### PR TITLE
Add Process Explorer and Debug Console as Site Extensions

### DIFF
--- a/Kudu.Contracts/SiteExtensions/SiteExtensionInfo.cs
+++ b/Kudu.Contracts/SiteExtensions/SiteExtensionInfo.cs
@@ -8,6 +8,13 @@ namespace Kudu.Contracts.SiteExtensions
     // This is equivalent to NuGet.IPackage
     public class SiteExtensionInfo
     {
+        public enum SiteExtensionType
+        {
+            Gallery,
+            PreInstalledNonKudu,
+            PreInstalledKuduModule
+        }
+
         public SiteExtensionInfo()
         {
         }
@@ -16,6 +23,7 @@ namespace Kudu.Contracts.SiteExtensions
         {
             Id = info.Id;
             Title = info.Title;
+            Type = info.Type;
             Summary = info.Summary;
             Description = info.Description;
             Version = info.Version;
@@ -36,11 +44,12 @@ namespace Kudu.Contracts.SiteExtensions
         {
             Id = package.Id;
             Title = package.Title;
+            Type = SiteExtensionType.Gallery;
             Summary = package.Summary;
             Description = package.Description;
             Version = package.Version == null ? null : package.Version.ToString();
             ProjectUrl = package.ProjectUrl == null ? null : package.ProjectUrl.ToString();
-            IconUrl = package.IconUrl == null ? null : package.IconUrl.ToString();
+            IconUrl = package.IconUrl == null ? "https://www.siteextensions.net/Content/Images/packageDefaultIcon-50x50.png" : package.IconUrl.ToString();
             LicenseUrl = package.LicenseUrl == null ? null : package.LicenseUrl.ToString();
             Authors = package.Authors;
             PublishedDateTime = package.Published;
@@ -59,6 +68,13 @@ namespace Kudu.Contracts.SiteExtensions
         public string Title
         {
             get;
+            set;
+        }
+
+        [JsonIgnore]
+        public SiteExtensionType Type
+        {
+            get; 
             set;
         }
 

--- a/Kudu.Services.Web/Content/Scripts/SiteExtensions.js
+++ b/Kudu.Services.Web/Content/Scripts/SiteExtensions.js
@@ -48,9 +48,6 @@
     $('#tabHeadings a[href="' + window.location.hash + '"]').tab('show');
 
     function processExtensions(ext) {
-        if (!ext.icon_url) {
-            ext.icon_url = "../Content/Images/Windows Azure Web Site.png";
-        }
         if (ext.download_count < 0) {
             ext.download_count = null;
         }


### PR DESCRIPTION
Alternatively, we can just add Kudu as a site extension. Also fixes #1163.
