### PR TITLE
Only output node.exe and npm.cmd paths when they exist

### DIFF
--- a/Kudu.Core/Scripts/selectNodeVersion.js
+++ b/Kudu.Core/Scripts/selectNodeVersion.js
@@ -245,7 +245,11 @@ try {
         npmPath = resolveNpmPath(npmRootPath, npmVersion || getDefaultNpmVersion(nodeVersionPath));
 
     // Save the node version in a temporary path for kudu service usage
-    saveNodePaths(tempDir, nodeExePath, npmPath);
+    if (existsSync(nodeExePath) && existsSync(npmPath)) {
+        saveNodePaths(tempDir, nodeExePath, npmPath);
+    } else {
+        console.log("One or more of the selected node/npm paths do not exist.");
+    }
 
     if (shouldUpdateIisNodeYml) {
         // Save the version information to iisnode.yml in the start script directory


### PR DESCRIPTION
The deployment script will fail back to the node/npm on %path% when these commands are not provided by selectNodeVersion.js, which is a reasonable choice now since %path% points to recent versions of node/npm.
