### PR TITLE
Unit Test fixes dealing with certain time zones casting DateTime to DateOffset

### DIFF
--- a/Kudu.Services.Test/ApplicationLogsReaderFacts.cs
+++ b/Kudu.Services.Test/ApplicationLogsReaderFacts.cs
@@ -392,6 +392,7 @@ several lines
             FileSystemHelpers.Instance = fileSystemMock.Object;
 
             var fileMock = new Mock<FileInfoBase>();
+            fileMock.SetupGet(p => p.LastWriteTimeUtc).Returns(new DateTime(2000, 1, 1));
 
             var tracerMock = new Mock<ITracer>(MockBehavior.Strict);
             tracerMock.Setup(t => t.Trace("Error occurred", It.IsAny<Dictionary<string,string>>())).Verifiable();


### PR DESCRIPTION
DateTimeOffset constructor throws an System.ArgumentOutOfRangeException "The UTC time represented when the offset is applied must be between year 0 and 10,000."

http://stackoverflow.com/questions/13799214/the-utc-time-represented-when-the-offset-is-applied-must-be-between-year-0-and-1
