### PR TITLE
fixes missing first cd and powershell autocomplete

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -192,7 +192,7 @@ $.connection.hub.start().done(function () {
     }
 
     var root = new node({ name: "/", type: "dir", href: "/vfs/" }),
-        ignoreWorkingDirChange = true,
+        ignoreWorkingDirChange = false,
         workingDirChanging = false,
         viewModel = {
             root: root,

--- a/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
+++ b/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
@@ -37,10 +37,9 @@ function LoadConsoleV2() {
     };
 
     window.KuduExec.changeDir = _changeDir;
-    // call make console after this first command so the current working directory is set.
     var originalMatchString = undefined;
     var currentMatchIndex = -1;
-    var lastLine = "";
+    var lastLine;
     var lastUserInput = null;
     var kuduExecConsole = $('<div class="console">');
     var curReportFun;
@@ -74,8 +73,10 @@ function LoadConsoleV2() {
                 _sendCommand(line);
                 controller.resetHistory();
                 DisplayAndUpdate(lastLine);
-                lastLine.Output = "";
-                lastLine.Error = "";
+                lastLine = {
+                    Output: "",
+                    Error: ""
+                };
                 DisplayAndUpdate(lastLine);
                 fileExplorerChanged = false;
                 if (line.trim().toUpperCase() == "EXIT") {
@@ -104,6 +105,9 @@ function LoadConsoleV2() {
             }
             if (result.length > 0) {
                 result = $.map(result, function (elm) {
+                    if (getShell().toUpperCase() === "POWERSHELL") {
+                        elm = ".\\" + elm;
+                    }
                     if (elm.indexOf(" ") !== -1) {
                         elm = '"' + elm + '"';
                     }


### PR DESCRIPTION
- there was a race with the first `cd` command from the console that caused the file explorer to miss it.
- also fixing #1181 for prepending `.\` to executable 
