### PR TITLE
fix #1226 cleanup index.lock

### DIFF
--- a/Kudu.Core.Test/ProcessApiFacts.cs
+++ b/Kudu.Core.Test/ProcessApiFacts.cs
@@ -26,14 +26,22 @@ namespace Kudu.Core.Test
             var path = @"x:\temp\minidump.dmp";
             var fileSystem = new Mock<IFileSystem>();
             var file = new Mock<FileBase>();
+            var fileInfoFactory = new Mock<IFileInfoFactory>();
+            var fileInfo = new Mock<FileInfoBase>();
 
             // Setup
             fileSystem.SetupGet(fs => fs.File)
                       .Returns(file.Object);
+            fileSystem.SetupGet(fs => fs.FileInfo)
+                      .Returns(fileInfoFactory.Object);
             file.Setup(f => f.Exists(path))
                       .Returns(true);
             file.Setup(f => f.OpenRead(path))
                       .Returns(() => new MemoryStream());
+            fileInfoFactory.Setup(f => f.FromFileName(path))
+                           .Returns(() => fileInfo.Object);
+            fileInfo.Setup(f => f.Exists)
+                    .Returns(true);
             FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
@@ -42,7 +50,7 @@ namespace Kudu.Core.Test
             }
 
             // Assert
-            file.Verify(f => f.Delete(path), Times.Once());
+            fileInfo.Verify(f => f.Delete(), Times.Once());
         }
 
         [Fact]
@@ -52,14 +60,22 @@ namespace Kudu.Core.Test
             var path = @"x:\temp\minidump.dmp";
             var fileSystem = new Mock<IFileSystem>();
             var file = new Mock<FileBase>();
+            var fileInfoFactory = new Mock<IFileInfoFactory>();
+            var fileInfo = new Mock<FileInfoBase>();
 
             // Setup
             fileSystem.SetupGet(fs => fs.File)
                       .Returns(file.Object);
+            fileSystem.SetupGet(fs => fs.FileInfo)
+                      .Returns(fileInfoFactory.Object);
             file.Setup(f => f.Exists(path))
                       .Returns(true);
             file.Setup(f => f.OpenRead(path))
                       .Returns(() => new MemoryStream());
+            fileInfoFactory.Setup(f => f.FromFileName(path))
+                           .Returns(() => fileInfo.Object);
+            fileInfo.Setup(f => f.Exists)
+                    .Returns(true);
             FileSystemHelpers.Instance = fileSystem.Object;
 
             // Test
@@ -67,7 +83,7 @@ namespace Kudu.Core.Test
             stream.Close();
 
             // Assert
-            file.Verify(f => f.Delete(path), Times.Once());
+            fileInfo.Verify(f => f.Delete(), Times.Once());
         }
 
         [Fact]

--- a/Kudu.Core.Test/SSHKeyManagerFacts.cs
+++ b/Kudu.Core.Test/SSHKeyManagerFacts.cs
@@ -117,8 +117,13 @@ namespace Kudu.Core.SSHKey.Test
             var directory = new Mock<DirectoryBase>();
             directory.Setup(d => d.Exists(sshPath)).Returns(true);
             var fileSystem = new Mock<IFileSystem>();
+            var fileInfoFactory = new Mock<IFileInfoFactory>();
+            var fileInfo = new Mock<FileInfoBase>();
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
             fileSystem.SetupGet(f => f.Directory).Returns(directory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(sshPath + @"\id_rsa.pub")).Returns(() => fileInfo.Object);
+            fileInfo.Setup(f => f.Exists).Returns(true);
             FileSystemHelpers.Instance = fileSystem.Object;
 
             var environment = new Mock<IEnvironment>();
@@ -132,7 +137,7 @@ namespace Kudu.Core.SSHKey.Test
 
             // Assert
             fileBase.Verify(s => s.WriteAllText(sshPath + @"\id_rsa", It.IsAny<string>()), Times.Exactly(2));
-            fileBase.Verify(s => s.Delete(sshPath + @"\id_rsa.pub"), Times.Exactly(1));
+            fileInfo.Verify(f => f.Delete());
         }
 
         [Theory]

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -233,20 +233,10 @@ namespace Kudu.Core.Infrastructure
             Instance.File.Delete(path);
         }
 
-        public static bool DeleteFileSafe(string path)
+        public static void DeleteFileSafe(string path)
         {
-            try
-            {
-                if (FileExists(path))
-                {
-                    DeleteFile(path);
-                    return true;
-                }
-            }
-            catch (UnauthorizedAccessException) { }
-            catch (FileNotFoundException) { }
-
-            return false;
+            var info = Instance.FileInfo.FromFileName(path);
+            DeleteFileSystemInfo(info, ignoreErrors: true);
         }
 
         public static void DeleteDirectorySafe(string path, bool ignoreErrors = true)

--- a/Kudu.Services/SourceControl/LiveScmEditorController.cs
+++ b/Kudu.Services/SourceControl/LiveScmEditorController.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Kudu.Common;
 using Kudu.Contracts.Infrastructure;
+using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core;
 using Kudu.Core.Deployment;
@@ -45,12 +46,13 @@ namespace Kudu.Services.SourceControl
                                        IDeploymentManager deploymentManager,
                                        IOperationLock operationLock,
                                        IEnvironment environment,
-                                       IRepository repository)
+                                       IRepository repository,
+                                       IRepositoryFactory repositoryFactory)
             : base(tracer, environment, environment.RepositoryPath)
         {
             _deploymentManager = deploymentManager;
             _operationLock = operationLock;
-            _repository = repository;
+            _repository = repository ?? repositoryFactory.GetRepository();
         }
 
         public override async Task<HttpResponseMessage> GetItem()


### PR DESCRIPTION
The issue is in VfsScm code path - we missed to clean the index.lock after lock acquired.   The reason is pretty subtle.  The deployment lock is historically relying on IRepositoryFactory being ninjected.   However, LiveScmEditorController ninjects IRepository (not IRepositoryFactory) leading to the issue.  I believe this is a standalone case.
