### PR TITLE
Support copy-paste several lines to Debug console, fixes #1230

### DIFF
--- a/Kudu.Core.Test/DebugConsoleFacts.cs
+++ b/Kudu.Core.Test/DebugConsoleFacts.cs
@@ -52,7 +52,7 @@ namespace Kudu.Core.Test
             var settings = new Mock<IDeploymentSettingsManager>();
             var process = new Mock<IProcess>();
             var connectionId = Guid.NewGuid().ToString();
-            var data = Guid.NewGuid().ToString();
+            var data = Guid.NewGuid().ToString() + "\n";
             var mem = new MemoryStream();
 
             using (var controller = new PersistentCommandTest(env.Object, settings.Object, tracer.Object, process.Object))
@@ -78,8 +78,8 @@ namespace Kudu.Core.Test
 
                     mem.Position = 0;
                     var result = new StreamReader(mem).ReadToEnd();
-                    Assert.True(result.EndsWith("\r\n"));
-                    Assert.Equal(data, result.Substring(0, result.Length - 2));
+                    Assert.True(result.EndsWith("\n"));
+                    Assert.Equal(data, result);
                 }
                 else
                 {

--- a/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
+++ b/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
@@ -70,7 +70,7 @@ function LoadConsoleV2() {
                 } else {
                     lastLine.Output = lastUserInput;
                 }
-                _sendCommand(line);
+                _sendCommand(lastUserInput);
                 controller.resetHistory();
                 DisplayAndUpdate(lastLine);
                 lastLine = {

--- a/Kudu.Services/Commands/PersistentCommandController.cs
+++ b/Kudu.Services/Commands/PersistentCommandController.cs
@@ -82,7 +82,8 @@ namespace Kudu.Services
                 }
                 else
                 {
-                    process.Process.StandardInput.WriteLine(data.Replace("\n", ""));
+                    //Both cmd.exe and powershell.exe are okay with either \r\n or \n for end-of-line.
+                    process.Process.StandardInput.Write(data);
                     process.Process.StandardInput.Flush();
                 }
                 process.LastInputTime = DateTime.UtcNow;


### PR DESCRIPTION
jquery (browsers) seems to always convert end of line to `\n` while a command line client, like KuduExec, might depend on the OS it's running on. Either way both `cmd.exe` and `powershell.exe` are okay with both `\r\n` and `\n`
