### PR TITLE
Display Monaco as installed when it is enabled through app setting.

### DIFF
--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -399,25 +399,17 @@ namespace Kudu.Core.SiteExtensions
 
             if (ExtensionRequiresApplicationHost(info))
             {
-                if (FileSystemHelpers.FileExists(Path.Combine(localPath, _applicationHostFile)))
-                {
-                    info.ExtensionUrl = GetFullUrl(GetUrlFromApplicationHost(info));
-                }
-                else
-                {
-                    info.ExtensionUrl = null;
-                }
+                info.ExtensionUrl = FileSystemHelpers.FileExists(Path.Combine(localPath, _applicationHostFile)) 
+                    ? GetFullUrl(GetUrlFromApplicationHost(info)) : null;
+            }
+            else if (String.Equals(info.Id, "Monaco", StringComparison.OrdinalIgnoreCase))
+            {
+                // Monaco does not need ApplicationHost only when it is enabled through app setting 
+                info.ExtensionUrl = GetFullUrl(info.ExtensionUrl);
             }
             else
             {
-                if (!String.IsNullOrEmpty(info.LocalPath))
-                {
-                    info.ExtensionUrl = GetFullUrl(info.ExtensionUrl);
-                }
-                else
-                {
-                    info.ExtensionUrl = null;
-                }
+                info.ExtensionUrl = String.IsNullOrEmpty(info.LocalPath) ? null : GetFullUrl(info.ExtensionUrl);
             }
         }
 

--- a/Kudu.FunctionalTests/SiteExtensionApiFacts.cs
+++ b/Kudu.FunctionalTests/SiteExtensionApiFacts.cs
@@ -25,8 +25,17 @@ namespace Kudu.FunctionalTests
                 Assert.True(results.Any(), "GetRemoteExtensions expects results > 0");
 
                 // get
-                var expected = results.Last();
-                var result = await manager.GetRemoteExtension(expected.Id);
+                var targets = new Dictionary<string, string> 
+                {
+                    {"sitereplicator", "Site"},
+                    {"websitelogs", "Log Browser"},
+                    {"phpmyadmin", "php"},
+                    {"AzureImageOptimizer", "Image Optimizer"},
+                    {"AzureMinifier", "Minifier"},
+                };
+                var expectedId = targets.Keys.ToArray()[new Random().Next(targets.Count)];
+                var expected = results.Find(ext => ext.Id == expectedId);
+                var result = await manager.GetRemoteExtension(expectedId);
                 Assert.Equal(expected.Id, result.Id);
                 Assert.Equal(expected.Version, result.Version);
 
@@ -74,8 +83,15 @@ namespace Kudu.FunctionalTests
                 Assert.True(results.Any(), "GetRemoteExtensions expects results > 0");
 
                 // get
-                var expected = results.Find(ext => StringComparer.OrdinalIgnoreCase.Equals(ext.Id, "monaco"));
-                var result = await manager.GetRemoteExtension(expected.Id);
+                var targets = new Dictionary<string, string> 
+                {
+                    {"monaco", "Visual Studio Online"},
+                    {"kudu", "Kudu"},
+                    {"daas", "Site Diagnostics"}
+                };
+                var expectedId = targets.Keys.ToArray()[new Random().Next(targets.Count)];
+                var expected = results.Find(ext => ext.Id == expectedId);
+                var result = await manager.GetRemoteExtension(expectedId);
                 Assert.Equal(expected.Id, result.Id);
                 Assert.Equal(expected.Version, result.Version);
 


### PR DESCRIPTION
Behavior after this change:
- When Monaco is installed through app setting in old portal, it will show up as installed in new portal.
- Delete action is available for app-setting-enabled Monaco in new portal. The user will get an error when trying to delete it. I will improve site extension api error messages in general in a separate pr.
