### PR TITLE
fix #1256 enable commit-ish for generic deploy handler

### DIFF
--- a/Kudu.Services.Test/GenericHandlerFacts.cs
+++ b/Kudu.Services.Test/GenericHandlerFacts.cs
@@ -91,6 +91,25 @@ namespace Kudu.Services.Test
         }
 
         [Theory]
+        [InlineData("http://scm1.com/repo", "http://scm1.com/repo", null)]
+        [InlineData("http://scm1.com/repo#", "http://scm1.com/repo", null)]
+        [InlineData("http://scm1.com/repo#1234567", "http://scm1.com/repo", "1234567")]
+        [InlineData("http://###:###@scm1.com/repo# 678 ", "http://###:###@scm1.com/repo", "678")]
+        [InlineData("#", "", null)]
+        [InlineData("## ", "#", null)]
+        public void GenericHandlerBranchTest(string url, string repoUrl, string commitId)
+        {
+            // Act
+            var deploymentInfo = new DeploymentInfo();
+
+            GenericHandler.SetRepositoryUrl(deploymentInfo, url);
+            
+            // Assert
+            Assert.Equal(repoUrl, deploymentInfo.RepositoryUrl);
+            Assert.Equal(commitId, deploymentInfo.CommitId);
+        }
+
+        [Theory]
         [InlineData("invalid_url")]
         [InlineData("git@scm.com")]
         [InlineData("scm.com:user/repo")]

--- a/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
+++ b/Kudu.Services/ServiceHookHandlers/DeploymentInfo.cs
@@ -19,6 +19,11 @@ namespace Kudu.Services.ServiceHookHandlers
         public bool IsContinuous { get; set; }
         public IServiceHookHandler Handler { get; set; }
 
+        // this is only set by GenericHandler
+        // the RepositoryUrl can specify specific commitid to deploy
+        // for instance, http://github.com/kuduapps/hellokudu.git#<commitid>
+        public string CommitId { get; set; }
+
         public bool IsValid()
         {
             return !String.IsNullOrEmpty(Deployer);

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -193,14 +193,23 @@ namespace Kudu.Services
                         // set to null as Deploy() below takes over logging
                         innerLogger = null;
 
+                        // The branch or commit id to deploy
+                        string deployBranch = !String.IsNullOrEmpty(deploymentInfo.CommitId) ? deploymentInfo.CommitId : targetBranch;
+
                         // In case the commit or perhaps fetch do no-op.
-                        if (deploymentInfo.TargetChangeset != null && ShouldDeploy(repository, deploymentInfo, targetBranch))
+                        if (deploymentInfo.TargetChangeset != null && ShouldDeploy(repository, deploymentInfo, deployBranch))
                         {
                             // Perform the actual deployment
-                            var changeSet = repository.GetChangeSet(targetBranch);
+                            var changeSet = repository.GetChangeSet(deployBranch);
+
+                            if (changeSet == null && !String.IsNullOrEmpty(deploymentInfo.CommitId))
+                            {
+                                throw new InvalidOperationException(String.Format("Invalid revision '{0}'!", deployBranch));
+                            }
 
                             // Here, we don't need to update the working files, since we know Fetch left them in the correct state
-                            await _deploymentManager.DeployAsync(repository, changeSet, deploymentInfo.Deployer, clean: false, needFileUpdate: false);
+                            // unless for GenericHandler where specific commitId is specified
+                            await _deploymentManager.DeployAsync(repository, changeSet, deploymentInfo.Deployer, clean: false, needFileUpdate: !String.IsNullOrEmpty(deploymentInfo.CommitId));
                         }
                     }
                     catch (Exception ex)

--- a/Kudu.Services/ServiceHookHandlers/GenericHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/GenericHandler.cs
@@ -43,12 +43,31 @@ namespace Kudu.Services.ServiceHookHandlers
             }
 
             deploymentInfo = new DeploymentInfo();
-            deploymentInfo.RepositoryUrl = url;
+            SetRepositoryUrl(deploymentInfo, url);
             deploymentInfo.RepositoryType = is_hg ? RepositoryType.Mercurial : RepositoryType.Git;
             deploymentInfo.Deployer = GetDeployerFromUrl(url);
             deploymentInfo.TargetChangeset = DeploymentManager.CreateTemporaryChangeSet(message: "Fetch from " + url);
 
             return DeployAction.ProcessDeployment;
+        }
+
+        public static void SetRepositoryUrl(DeploymentInfo deploymentInfo, string url)
+        {
+            string commitId = null;
+            if (url.Contains("#"))
+            {
+                var parts = url.Split('#');
+                url = String.Join("#", parts, 0, parts.Length - 1);
+
+                var last = parts[parts.Length - 1].Trim();
+                if (!String.IsNullOrEmpty(last))
+                {
+                    commitId = last;
+                }
+            }
+
+            deploymentInfo.RepositoryUrl = url;
+            deploymentInfo.CommitId = commitId;
         }
     }
 }


### PR DESCRIPTION
For generic `/deploy` payload, we allow the url to define the commit to deploy (hash tag below).   The branch being fetch is still based on settings; however, we will checkout the givencommit when deploying.   Tests are included to cover Git and Hg plus error scenarios.

```
{
  'url':'https://github.com/KuduApps/HelloKudu2.git#1234567',
  'format':'basic'
}
```
