### PR TITLE
Consider the file to be a zip file if filetype is empty. This will only ...

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -517,7 +517,7 @@ $.connection.hub.start().done(function () {
         var items = evt.originalEvent.dataTransfer.items || evt.originalEvent.dataTransfer.files;
         if (items) {
             var filesArray = $.map(items, function(item) {
-                if (item.type === 'application/x-zip-compressed')
+                if (item.type === 'application/x-zip-compressed' || item.type === 'application/zip' || item.type === '')
                     return item;
             });
             if (filesArray && filesArray.length === items.length) {


### PR DESCRIPTION
...affect files dragged into zip target area. Fixes #1278 

@amitapl can you please try this on your machine and see it it fixes the drag-and-drop issues you were having? I can't repro the original issue.
