### PR TITLE
marking scm site processes and webjob processes. Fixes #1295 and #1294

### DIFF
--- a/Kudu.Contracts/Diagnostics/ProcessInfo.cs
+++ b/Kudu.Contracts/Diagnostics/ProcessInfo.cs
@@ -104,5 +104,14 @@ namespace Kudu.Core.Diagnostics
 
         [JsonProperty(PropertyName = "environment_variables", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Dictionary<string, string> EnvironmentVariables { get; set; }
+
+        [JsonProperty(PropertyName = "is_scm_site", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool IsScmSite { get; set; }
+
+        [JsonProperty(PropertyName = "is_webjob", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool IsWebJob { get; set; }
+
+        [JsonProperty(PropertyName = "description", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Description { get; set; }
     }
 }

--- a/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
+++ b/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
@@ -17,6 +17,7 @@
         public const string NextManifestPath = "NEXT_MANIFEST_PATH";
         public const string InPlaceDeployment = "IN_PLACE_DEPLOYMENT";
         public const string PostDeploymentActionsDirectoryKey = "POST_DEPLOYMENT_ACTIONS_DIR";
+        public const string ApplicationPoolId = "APP_POOL_ID";
 
         public const string WebJobsDeployCommandKey = "WEBJOBS_DEPLOY_CMD";
         public const string WebJobsRootPath = "WEBJOBS_PATH";

--- a/Kudu.Core/Infrastructure/ProcessExtensions.cs
+++ b/Kudu.Core/Infrastructure/ProcessExtensions.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Kudu.Contracts.Tracing;
+using Kudu.Core.Deployment;
 using Kudu.Core.Tracing;
 
 namespace Kudu.Core.Infrastructure
@@ -225,6 +226,22 @@ namespace Kudu.Core.Infrastructure
         public static string GetCommandLine(this Process process)
         {
             return GetCommandLineCore(process.Handle);
+        }
+
+        public static bool GetIsScmSite(Dictionary<string, string> environment)
+        {
+            return environment[WellKnownEnvironmentVariables.ApplicationPoolId].StartsWith("~1", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool GetIsWebJob(Dictionary<string, string> environment)
+        {
+            return environment.ContainsKey(WellKnownEnvironmentVariables.WebJobsName);
+        }
+
+        public static string GetDescription(Dictionary<string, string> environment)
+        {
+            const string webJobTemplate = "WebJob: {0}, Type: {1}";
+            return String.Format(webJobTemplate, environment[WellKnownEnvironmentVariables.WebJobsName], environment[WellKnownEnvironmentVariables.WebJobsType]);
         }
 
         private static async Task CopyStreamAsync(Stream from, Stream to, IdleManager idleManager, CancellationToken cancellationToken, bool closeAfterCopy = false)

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -306,10 +306,16 @@ var Process = (function () {
 
         var td = document.createElement('td');
         td.style.paddingLeft = (level === 0 ? 5 : level * 30) + 'px';
+        var suffix = "";
+        if (this._json.is_webjob) {
+            suffix = " <span class='label label-info'>webjob</span>";
+        } else if (this._json.is_scm_site) {
+            suffix = " <span class='label label-primary'>scm</span>";
+        }
         if (this._json.children.length > 0) {
-            $(td).wrapInner('<span class="toggle"></span>    ' + this.FullName);
+            $(td).wrapInner('<span class="toggle"></span>    ' + this.FullName + suffix);
         } else {
-            td.textContent = this.FullName;
+            $(td).wrapInner(this.FullName + suffix);
         }
         tr.appendChild(td);
         tr.appendChild(Utilities.ToTd(this._json.id));
@@ -378,7 +384,10 @@ var Process = (function () {
         div.appendChild(Utilities.toRow("id", this._json.id));
         div.appendChild(Utilities.toRow("name", this._json.name));
         div.appendChild(Utilities.toRow("file name", this._json.file_name));
-        div.appendChild(Utilities.toRow("command line", _this._json.command_line));
+        div.appendChild(Utilities.toRow("command line", this._json.command_line));
+        div.appendChild(Utilities.toRow("description", this._json.description ? this._json.description : ""));
+        div.appendChild(Utilities.toRow("is scm site", this._json.is_scm_site));
+        div.appendChild(Utilities.toRow("is webjob", this._json.is_scm_site));
         div.appendChild(Utilities.toRow("handle count", Utilities.commaSeparateNumber(this._json.handle_count)));
         div.appendChild(Utilities.toRow("module countid", Utilities.commaSeparateNumber(this._json.module_count)));
         div.appendChild(Utilities.toRow("thread count", Utilities.commaSeparateNumber(this._json.thread_count)));

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -462,6 +462,9 @@ namespace Kudu.Services.Performance
                 info.TimeStamp = DateTime.UtcNow;
                 info.EnvironmentVariables = SafeGetValue(process.GetEnvironmentVariables, null);
                 info.CommandLine = SafeGetValue(process.GetCommandLine, null);
+                info.IsScmSite = SafeGetValue(() => ProcessExtensions.GetIsScmSite(info.EnvironmentVariables), false);
+                info.IsWebJob = SafeGetValue(() => ProcessExtensions.GetIsWebJob(info.EnvironmentVariables), false);
+                info.Description = SafeGetValue(() => ProcessExtensions.GetDescription(info.EnvironmentVariables), null);
             }
 
             return info;


### PR DESCRIPTION
There are 3 new properties in the process object. `IsScmSite`, `IsWebJob`, `Description`

I am not too sure about the description. Right now it's very specific to webjobs. I don't know what other descriptions can a process have?
