### PR TITLE
fix #1320 returning Last-Modified header along with ETag

### DIFF
--- a/Kudu.Services/Editor/VfsController.cs
+++ b/Kudu.Services/Editor/VfsController.cs
@@ -56,6 +56,7 @@ namespace Kudu.Services.Editor
 
             // Get current etag
             EntityTagHeaderValue currentEtag = CreateEntityTag(info);
+            DateTime lastModified = info.LastWriteTimeUtc;
 
             // Check whether we have a range request (taking If-Range condition into account)
             bool isRangeRequest = IsRangeRequest(currentEtag);
@@ -65,7 +66,7 @@ namespace Kudu.Services.Editor
             if (!isRangeRequest && IsIfNoneMatchRequest(currentEtag))
             {
                 HttpResponseMessage notModifiedResponse = Request.CreateResponse(HttpStatusCode.NotModified);
-                notModifiedResponse.Headers.ETag = currentEtag;
+                notModifiedResponse.SetEntityTagHeader(currentEtag, lastModified);
                 return Task.FromResult(notModifiedResponse);
             }
 
@@ -88,7 +89,7 @@ namespace Kudu.Services.Editor
                 }
 
                 // Set etag for the file
-                successFileResponse.Headers.ETag = currentEtag;
+                successFileResponse.SetEntityTagHeader(currentEtag, lastModified);
                 return Task.FromResult(successFileResponse);
             }
             catch (InvalidByteRangeException invalidByteRangeException)
@@ -178,7 +179,7 @@ namespace Kudu.Services.Editor
 
                 // Set updated etag for the file
                 info.Refresh();
-                successFileResponse.Headers.ETag = CreateEntityTag(info);
+                successFileResponse.SetEntityTagHeader(CreateEntityTag(info), info.LastWriteTimeUtc);
                 return successFileResponse;
 
             }

--- a/Kudu.Services/Infrastructure/HttpResponseMessageExtensions.cs
+++ b/Kudu.Services/Infrastructure/HttpResponseMessageExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Kudu.Services.Infrastructure
+{
+    internal static class HttpResponseMessageExtensions
+    {
+        public static void SetEntityTagHeader(this HttpResponseMessage httpResponseMessage, EntityTagHeaderValue etag, DateTime lastModified)
+        {
+            if (httpResponseMessage.Content == null)
+            {
+                httpResponseMessage.Content = new NullContent();
+            }
+
+            httpResponseMessage.Headers.ETag = etag;
+            httpResponseMessage.Content.Headers.LastModified = lastModified;
+        }
+
+        class NullContent : StringContent
+        {
+            public NullContent()
+                : base(String.Empty)
+            {
+                Headers.ContentType = null;
+                Headers.ContentLength = null;
+            }
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Deployment\DeploymentController.cs" />
     <Compile Include="Diagnostics\LogStreamHandler.cs" />
     <Compile Include="Diagnostics\LogStreamManager.cs" />
+    <Compile Include="Infrastructure\HttpResponseMessageExtensions.cs" />
     <Compile Include="Infrastructure\LowerCaseFormatterConfigAttribute.cs" />
     <Compile Include="Diagnostics\ProcessController.cs" />
     <Compile Include="Diagnostics\RuntimeController.cs" />


### PR DESCRIPTION
This is a targeted fix addressing vfs and etag/Last-Modified header.   
- Only `/vfs/` endpoint that we will return Last-Modified header along with etag.
- Only GET, PUT and HEAD Http verbs.
