### PR TITLE
Retake status file lock if an error caused it to be lost (for WebJobs).

### DIFF
--- a/Kudu.Core/Jobs/JobLogger.cs
+++ b/Kudu.Core/Jobs/JobLogger.cs
@@ -70,7 +70,7 @@ namespace Kudu.Core.Jobs
             ReportStatus(status, logStatus: true);
         }
 
-        protected void ReportStatus<TJobStatus>(TJobStatus status, bool logStatus) where TJobStatus : class, IJobStatus
+        protected virtual void ReportStatus<TJobStatus>(TJobStatus status, bool logStatus) where TJobStatus : class, IJobStatus
         {
             try
             {


### PR DESCRIPTION
Fixes #1340
