### PR TITLE
fix CannotUnloadAppDomainException issue

### DIFF
--- a/Kudu.TestHarness/AppDomainHelper.cs
+++ b/Kudu.TestHarness/AppDomainHelper.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kudu.TestHarness
+{
+    public static class AppDomainHelper
+    {
+        static object _lock;
+        static ManualResetEvent _threadCompletion;
+        static int _threadCount;
+
+        static AppDomainHelper()
+        {
+            var appDomain = AppDomain.CurrentDomain;
+
+            // default appdomain unload with process termination
+            if (!appDomain.IsDefaultAppDomain())
+            {
+                _lock = new object();
+                _threadCompletion = new ManualResetEvent(true);
+                _threadCount = 0;
+
+                appDomain.DomainUnload += delegate
+                {
+                    // wait for all task completion
+                    _threadCompletion.WaitOne(60000);
+                };
+            }
+        }
+
+        public static async Task RunTask(Func<Task> action)
+        {
+            OnBeginTask();
+            await Task.Run(async () =>
+            {
+                try
+                {
+                    await action();
+                }
+                finally
+                {
+                    OnEndTask();
+                }
+            });
+        }
+
+        static void OnBeginTask()
+        {
+            if (_lock != null)
+            {
+                lock (_lock)
+                {
+                    _threadCompletion.Reset();
+                    _threadCount++;
+                }
+            }
+        }
+
+        static void OnEndTask()
+        {
+            if (_lock != null)
+            {
+                lock (_lock)
+                {
+                    _threadCount--;
+                    if (_threadCount == 0)
+                    {
+                        _threadCompletion.Set();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Kudu.TestHarness/Kudu.TestHarness.csproj
+++ b/Kudu.TestHarness/Kudu.TestHarness.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppDomainHelper.cs" />
     <Compile Include="ApplicationManager.cs" />
     <Compile Include="ApplicationManagerExtensions.cs" />
     <Compile Include="TestHarnessClassCommandAttribute.cs" />

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -34,7 +34,7 @@ namespace Kudu.TestHarness
 
         private static async void EnsureNextApplication()
         {
-            await Task.Run(async () => 
+            await AppDomainHelper.RunTask(async () => 
             {
                 await _semaphore.WaitAsync();
                 try


### PR DESCRIPTION
Drain all the threads before shutting down appDomain.   I will need to apply the same fix on private kudu DeleteSiteSafe api.
