### PR TITLE
fix 1372 due to git HEAD file corrupted issue

### DIFF
--- a/Kudu.Client/Editor/RemoteVfsManager.cs
+++ b/Kudu.Client/Editor/RemoteVfsManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -56,6 +57,18 @@ namespace Kudu.Client.Editor
                 request.RequestUri = new Uri(path, UriKind.Relative);
                 request.Headers.IfMatch.Add(EntityTagHeaderValue.Any);
                 request.Content = new StringContent(content);
+                Client.SendAsync(request).Result.EnsureSuccessful();
+            }
+        }
+
+        public void WriteAllBytes(string path, byte[] buffer)
+        {
+            using (var request = new HttpRequestMessage())
+            {
+                request.Method = HttpMethod.Put;
+                request.RequestUri = new Uri(path, UriKind.Relative);
+                request.Headers.IfMatch.Add(EntityTagHeaderValue.Any);
+                request.Content = new StreamContent(new MemoryStream(buffer));
                 Client.SendAsync(request).Result.EnsureSuccessful();
             }
         }

--- a/Kudu.Core/SourceControl/Git/GitExeRepository.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeRepository.cs
@@ -79,7 +79,7 @@ namespace Kudu.Core.SourceControl.Git
 
                 try
                 {
-                    string output = Execute("rev-parse --git-dir");
+                    string output = ParseGitDirectory();
                     // If no exception and the output is .git (not a full directory to .git which means somewhere there's a git repository which is a parent of this directory)
                     // Then git repository directory found
                     return String.Equals(output.Trim(), ".git", StringComparison.OrdinalIgnoreCase);
@@ -451,6 +451,52 @@ echo $i > pushinfo
             }
 
             return output;
+        }
+
+        private string ParseGitDirectory()
+        {
+            const string revParseArgs = "rev-parse --git-dir";
+            try
+            {
+                return Execute(revParseArgs);
+            }
+            catch (Exception)
+            {
+                if (!TryFixCorruptedGit())
+                {
+                    throw;
+                }
+            }
+
+            return Execute(revParseArgs);
+        }
+
+        // Corrupted git where .git/HEAD exists but only contains \0.
+        private bool TryFixCorruptedGit()
+        {
+            var headFile = Path.Combine(_gitExe.WorkingDirectory, ".git", "HEAD");
+            if (FileSystemHelpers.FileExists(headFile))
+            {
+                bool isCorrupted;
+                using (var stream = FileSystemHelpers.OpenRead(headFile))
+                {
+                    isCorrupted = stream.ReadByte() == 0;
+                }
+
+                if (isCorrupted)
+                {
+                    ITracer tracer = _tracerFactory.GetTracer();
+                    using (tracer.Step(@"Fix corrupted .git\HEAD file"))
+                    {
+                        FileSystemHelpers.DeleteFile(headFile);
+                        Execute(tracer, "init");
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private string Execute(string arguments, params object[] args)


### PR DESCRIPTION
In case of HEAD file corrupted, we simply delete the HEAD file and run `git init`.
