### PR TITLE
fix #1382 making adding Monaco siteextension robust

### DIFF
--- a/Kudu.Core/SiteExtensions/applicationHost.xdt.xml
+++ b/Kudu.Core/SiteExtensions/applicationHost.xdt.xml
@@ -3,6 +3,7 @@
   <system.applicationHost>
     <sites>
       <site name="%XDT_SCMSITENAME%" xdt:Locator="Match(name)">
+        <application path="{0}" xdt:Locator="Match(path)" xdt:Transform="Remove" />
         <application path="{0}" applicationPool="%XDT_APPPOOLNAME%" xdt:Transform="Insert">
           <virtualDirectory path="/" physicalPath="{1}" />
         </application>


### PR DESCRIPTION
User encountered this issue and the result was site unavailable.   First, he enabled the Monaco site extension via Kudu site extension gallery.   Then somehow he also enabled the VS Online on the portal.   Our generated xdt from gallery is not idempotent causing duplicated application to be added.
