### PR TITLE
fix #1392 corrupted status xml

### DIFF
--- a/Kudu.Console/Program.cs
+++ b/Kudu.Console/Program.cs
@@ -95,7 +95,7 @@ namespace Kudu.Console
                                                           traceFactory,
                                                           analytics,
                                                           settingsManager,
-                                                          new DeploymentStatusManager(env, statusLock),
+                                                          new DeploymentStatusManager(env, analytics, statusLock),
                                                           deploymentLock,
                                                           GetLogger(env, level, logger),
                                                           hooksManager);

--- a/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.IO.Abstractions;
+using System.Text;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
@@ -10,6 +13,7 @@ using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 using Moq;
 using Xunit;
+using Xunit.Extensions;
 
 namespace Kudu.Core.Test.Deployment
 {
@@ -57,6 +61,216 @@ namespace Kudu.Core.Test.Deployment
             Assert.Equal("author", statusFile.Author);
             Assert.Equal("author@email.com", statusFile.AuthorEmail);
             Assert.Equal("commit message", statusFile.Message);
+        }
+
+        [Fact]
+        public void InvalidCommitTextTests()
+        {
+            var id = Guid.NewGuid().ToString();
+            var deploymentPath = @"x:\sites\deployments";
+            var environment = Mock.Of<IEnvironment>(e => e.DeploymentsPath == deploymentPath);
+            var analytics = Mock.Of<IAnalytics>();
+            var statusLock = Mock.Of<IOperationLock>(l => l.Lock() == true);
+            var stream = new Mock<MemoryStream> { CallBase = true };
+            stream.Setup(s => s.Close());
+
+            var statusFile = Path.Combine(deploymentPath, id, "status.xml");
+
+            FileSystemHelpers.Instance = GetMockFileSystem(statusFile, () =>
+            {
+                stream.Object.Position = 0;
+                return Encoding.UTF8.GetString(stream.Object.GetBuffer(), 0, (int)stream.Object.Length);
+            });
+
+            var fileBase = Mock.Get(FileSystemHelpers.Instance.File);
+            fileBase.Setup(f => f.Create(statusFile))
+                    .Returns((string path) => stream.Object);
+
+            try
+            {
+                var deploymentStatus = DeploymentStatusFile.Create(id, environment, statusLock);
+                deploymentStatus.Id = id;
+                deploymentStatus.Status = DeployStatus.Success;
+                deploymentStatus.StatusText = "Success";
+                deploymentStatus.AuthorEmail = "john.doe@live.com";
+                deploymentStatus.Author = "John Doe \x08";
+                deploymentStatus.Message = "Invalid char is \u0010";
+                deploymentStatus.Progress = String.Empty;
+                deploymentStatus.EndTime = DateTime.UtcNow;
+                deploymentStatus.LastSuccessEndTime = DateTime.UtcNow;
+                deploymentStatus.Complete = true;
+                deploymentStatus.IsTemporary = false;
+                deploymentStatus.IsReadOnly = false;
+
+                // Save
+                deploymentStatus.Save();
+
+                // Roundtrip
+                deploymentStatus = DeploymentStatusFile.Open(id, environment, analytics, statusLock);
+
+                // Assert
+                Assert.Equal(id, deploymentStatus.Id);
+                Assert.Equal("John Doe ?", deploymentStatus.Author);
+                Assert.Equal("Invalid char is ?", deploymentStatus.Message);
+            }
+            finally
+            {
+                FileSystemHelpers.Instance = null;
+            }
+        }
+
+        [Theory]
+        [PropertyData("DeploymentStatusFileScenarios")]
+        public void CorruptedDeploymentStatusFileTests(string content, bool expectedNull, bool expectedError)
+        {
+            var id = Guid.NewGuid().ToString();
+            var deploymentPath = @"x:\sites\deployments";
+            var environment = Mock.Of<IEnvironment>(e => e.DeploymentsPath == deploymentPath);
+            var analytics = Mock.Of<IAnalytics>();
+            var statusLock = Mock.Of<IOperationLock>(l => l.Lock() == true);
+
+            var statusFile = Path.Combine(deploymentPath, id, "status.xml");
+
+            FileSystemHelpers.Instance = GetMockFileSystem(statusFile, () => content);
+
+            try
+            {
+                var status = DeploymentStatusFile.Open(id, environment, analytics, statusLock);
+
+                if (expectedNull)
+                {
+                    Assert.Null(status);
+
+                    Mock.Get(FileSystemHelpers.Instance.DirectoryInfo.FromDirectoryName(Path.Combine(deploymentPath, id)))
+                        .Verify(d => d.Delete(), Times.Once());
+                }
+                else
+                {
+                    Assert.NotNull(status);
+
+                    Mock.Get(FileSystemHelpers.Instance.DirectoryInfo.FromDirectoryName(Path.Combine(deploymentPath, id)))
+                        .Verify(d => d.Delete(), Times.Never());
+                }
+
+                if (expectedError)
+                {
+                    Mock.Get(analytics).Verify(a => a.UnexpectedException(It.IsAny<Exception>(), true), Times.Once());
+                }
+                else
+                {
+                    Mock.Get(analytics).Verify(a => a.UnexpectedException(It.IsAny<Exception>(), It.IsAny<bool>()), Times.Never());
+                }
+            }
+            finally
+            {
+                FileSystemHelpers.Instance = null;
+            }
+        }
+
+        public static IEnumerable<object[]> DeploymentStatusFileScenarios
+        {
+            get
+            {
+                // happy case
+                var validContent = "<?xml version=\"1.0\" encoding=\"utf-8\"" + @"?>
+<deployment>
+  <id>2f45d28c063eb367ee76b3c9a4b844b673ca2ad6</id>
+  <author>Suwath Ch</author>
+  <deployer></deployer>
+  <authorEmail>suwatch@microsoft.com</authorEmail>
+  <message>change 28</message>
+  <progress></progress>
+  <status>Success</status>
+  <statusText></statusText>
+  <lastSuccessEndTime>2014-11-16T01:41:39.2074382Z</lastSuccessEndTime>
+  <receivedTime>2014-11-16T01:41:38.2948183Z</receivedTime>
+  <startTime>2014-11-16T01:41:38.4919528Z</startTime>
+  <endTime>2014-11-16T01:41:39.2074382Z</endTime>
+  <complete>True</complete>
+  <is_temp>False</is_temp>
+  <is_readonly>False</is_readonly>
+</deployment>";
+                yield return new object[] { validContent, false, false };
+
+                // missing status.xml
+                string missingContent = null;
+                yield return new object[] { missingContent, true, false };
+
+                // invalid xml
+                var partialContent = "<?xml version=\"1.0\" encoding=\"utf-8\"" + @"?>
+<deployment>
+  <id>2f45d28c063eb367ee76b3c9a4b844b673ca2ad6</id>
+  <author>Suwath Ch</author>
+  <deployer></deployer>
+  <authorEmail>suwatch@microsoft.com</authorEmail>
+  <message>change 28</message>
+  <progress></progress>
+  <status>Success</status>
+  <statusText></statusText>
+  <lastSuccessEndTime>2014-11-16T01:41:39.2074382Z</lastSuccessEndTime>
+  <receivedTime>2014-11-16T01:4";
+                yield return new object[] { partialContent, true, true };
+
+                // valid xml but missing properties
+                var missingProperty = "<?xml version=\"1.0\" encoding=\"utf-8\"" + @"?>
+<deployment>
+  <id>2f45d28c063eb367ee76b3c9a4b844b673ca2ad6</id>
+  <author>Suwath Ch</author>
+  <deployer></deployer>
+  <authorEmail>suwatch@microsoft.com</authorEmail>
+  <message>change 28</message>
+  <progress></progress>
+</deployment>";
+                yield return new object[] { missingProperty, true, true };
+            }
+        }
+
+        private IFileSystem GetMockFileSystem(string file, Func<string> content)
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var dirInfoBase = new Mock<DirectoryInfoBase>(MockBehavior.Strict);
+            var dirInfoFactory = new Mock<IDirectoryInfoFactory>(MockBehavior.Strict);
+
+            // Setup
+            fileSystem.Setup(f => f.File)
+              .Returns(fileBase.Object);
+            fileSystem.Setup(f => f.Directory)
+              .Returns(dirBase.Object);
+            fileSystem.Setup(f => f.DirectoryInfo)
+              .Returns(dirInfoFactory.Object);
+
+            fileBase.Setup(f => f.Exists(It.IsAny<string>()))
+                    .Returns((string path) => path == file && content() != null);
+            fileBase.Setup(f => f.OpenRead(It.IsAny<string>()))
+                    .Returns((string path) =>
+                    {
+                        if (path == file)
+                        {
+                            return new MemoryStream(Encoding.UTF8.GetBytes(content()));
+                        }
+
+                        throw new InvalidOperationException("Should not reach here!");
+                    });
+            fileBase.Setup(f => f.WriteAllText(It.IsAny<string>(), It.IsAny<string>()));
+
+            dirInfoFactory.Setup(d => d.FromDirectoryName(It.IsAny<string>()))
+                          .Returns(dirInfoBase.Object);
+
+            dirBase.Setup(d => d.Exists(It.IsAny<string>()))
+                   .Returns((string path) => path == Path.GetDirectoryName(file));
+
+            dirInfoBase.SetupGet(d => d.Exists)
+                       .Returns(true);
+            dirInfoBase.SetupSet(d => d.Attributes = FileAttributes.Normal);
+            dirInfoBase.Setup(d => d.GetFileSystemInfos())
+                       .Returns(new FileSystemInfoBase[0]);
+            dirInfoBase.Setup(d => d.Delete());
+
+            FileSystemHelpers.Instance = fileSystem.Object;
+
+            return fileSystem.Object;
         }
 
         public class TestDeploymentStatusFile : IDeploymentStatusFile

--- a/Kudu.Core/Deployment/DeploymentStatusFile.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusFile.cs
@@ -4,6 +4,7 @@ using System.IO.Abstractions;
 using System.Xml.Linq;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
 
 namespace Kudu.Core.Deployment
 {
@@ -47,7 +48,7 @@ namespace Kudu.Core.Deployment
             };
         }
 
-        public static DeploymentStatusFile Open(string id, IEnvironment environment, IOperationLock statusLock)
+        public static DeploymentStatusFile Open(string id, IEnvironment environment, IAnalytics analytics, IOperationLock statusLock)
         {
             return statusLock.LockOperation(() =>
             {
@@ -56,15 +57,31 @@ namespace Kudu.Core.Deployment
 
                 if (!FileSystemHelpers.FileExists(path))
                 {
+                    FileSystemHelpers.DeleteDirectorySafe(Path.GetDirectoryName(path), ignoreErrors: true);
+
                     return null;
                 }
 
-                using (var stream = FileSystemHelpers.OpenRead(path))
+                try
                 {
-                    document = XDocument.Load(stream);
-                }
+                    using (var stream = FileSystemHelpers.OpenRead(path))
+                    {
+                        document = XDocument.Load(stream);
+                    }
 
-                return new DeploymentStatusFile(id, environment, statusLock, document);
+                    return new DeploymentStatusFile(id, environment, statusLock, document);
+                }
+                catch (Exception ex)
+                {
+                    // in the scenario where w3wp is abruptly terminated while xml is being written,
+                    // we may end up with corrupted xml.  we will handle the error and remove the problematic directory.
+                    analytics.UnexpectedException(ex);
+
+                    FileSystemHelpers.DeleteDirectorySafe(Path.GetDirectoryName(path), ignoreErrors: true);
+
+                    // it is ok to return null as callers already handle null.
+                    return null;
+                }
             }, DeploymentStatusManager.LockTimeout);
         }
 
@@ -145,10 +162,10 @@ namespace Kudu.Core.Deployment
 
             var document = new XDocument(new XElement("deployment",
                     new XElement("id", Id),
-                    new XElement("author", Author),
+                    new XElement("author", XmlUtils.RemoveInvalidXMLChars(Author)),
                     new XElement("deployer", Deployer),
                     new XElement("authorEmail", AuthorEmail),
-                    new XElement("message", Message),
+                    new XElement("message", XmlUtils.RemoveInvalidXMLChars(Message)),
                     new XElement("progress", Progress),
                     new XElement("status", Status),
                     new XElement("statusText", StatusText),

--- a/Kudu.Core/Deployment/DeploymentStatusManager.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Abstractions;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
 
 namespace Kudu.Core.Deployment
 {
@@ -11,13 +12,16 @@ namespace Kudu.Core.Deployment
     {
         public static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(60);
         private readonly IEnvironment _environment;
+        private readonly IAnalytics _analytics;
         private readonly IOperationLock _statusLock;
         private readonly string _activeFile;
 
         public DeploymentStatusManager(IEnvironment environment,
+                                       IAnalytics analytics,
                                        IOperationLock statusLock)
         {
             _environment = environment;
+            _analytics = analytics;
             _statusLock = statusLock;
             _activeFile = Path.Combine(environment.DeploymentsPath, Constants.ActiveDeploymentFile);
         }
@@ -29,7 +33,7 @@ namespace Kudu.Core.Deployment
 
         public IDeploymentStatusFile Open(string id)
         {
-            return DeploymentStatusFile.Open(id, _environment, _statusLock);
+            return DeploymentStatusFile.Open(id, _environment, _analytics, _statusLock);
         }
 
         public void Delete(string id)

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -241,12 +241,12 @@ namespace Kudu.Core.Infrastructure
 
         public static void DeleteDirectorySafe(string path, bool ignoreErrors = true)
         {
-            DeleteFileSystemInfo(new DirectoryInfoWrapper(new DirectoryInfo(path)), ignoreErrors);
+            DeleteFileSystemInfo(Instance.DirectoryInfo.FromDirectoryName(path), ignoreErrors);
         }
 
         public static void DeleteDirectoryContentsSafe(string path, bool ignoreErrors = true)
         {
-            DeleteDirectoryContentsSafe(new DirectoryInfoWrapper(new DirectoryInfo(path)), ignoreErrors);
+            DeleteDirectoryContentsSafe(Instance.DirectoryInfo.FromDirectoryName(path), ignoreErrors);
         }
 
         private static void DeleteDirectoryContentsSafe(DirectoryInfoBase directoryInfo, bool ignoreErrors)

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Deployment\ISiteBuilderFactory.cs" />
     <Compile Include="Deployment\XmlLogger.cs" />
     <Compile Include="Environment.cs" />
+    <Compile Include="XmlUtils.cs" />
     <Compile Include="Infrastructure\FileSystemHelpers.cs" />
     <Compile Include="Deployment\LoggerExtensions.cs" />
     <Compile Include="Infrastructure\ParserHelpers.cs" />

--- a/Kudu.Core/XmlUtils.cs
+++ b/Kudu.Core/XmlUtils.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Kudu.Core
+{
+    public static class XmlUtils
+    {
+        // http://stackoverflow.com/questions/397250/unicode-regex-invalid-xml-characters
+        // filters control characters but allows only properly-formed surrogate sequences
+        // #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+        private static Regex _invalidXMLChars = new Regex(
+            @"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]",
+            RegexOptions.Compiled);
+
+        public static string RemoveInvalidXMLChars(string text)
+        {
+            if (String.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            return _invalidXMLChars.Replace(text, "?");
+        }
+    }
+}


### PR DESCRIPTION
when detecting corrupted deployment status xml (either file not exists, invalid xml, missing property), we will handle and return null.  BTW this is safe since caller already expecting null.  

In addition we also cleanup this specific deployment id directory.
