### PR TITLE
Adding Bower, Gulp, and Grunt to the PATH

### DIFF
--- a/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Kudu.Contracts.Settings;
 using Kudu.Core.Infrastructure;
 
@@ -93,7 +94,13 @@ namespace Kudu.Core.Deployment.Generator
             };
 
             toolsPaths.AddRange(PathUtility.ResolveNodeNpmPaths());
-            
+            toolsPaths.AddRange(new[]
+            {
+                PathUtility.ResolveBowerPath(),
+                PathUtility.ResolveGruntPath(),
+                PathUtility.ResolveGulpPath()
+            }.Where(p => !String.IsNullOrEmpty(p)).Select(Path.GetDirectoryName));
+
             toolsPaths.Add(PathUtility.ResolveNpmGlobalPrefix());
 
             exe.PrependToPath(toolsPaths);


### PR DESCRIPTION
If there is a `<TOOLNAME>_PATH` specified, then use that, otherwise use the pre-installed one.
If there is a `<TOOLNAME>_VERSION` defined, use that, otherwise use the latest one.
