### PR TITLE
When deploying a site extension deploy its WebJobs.

### DIFF
--- a/Kudu.Contracts/Jobs/IJobsManager.cs
+++ b/Kudu.Contracts/Jobs/IJobsManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 
 namespace Kudu.Contracts.Jobs
 {
@@ -14,12 +13,16 @@ namespace Kudu.Contracts.Jobs
 
         TJob CreateOrReplaceJobFromFileStream(Stream scriptFileStream, string jobName, string scriptFileName);
 
-        Task DeleteJobAsync(string jobName);
+        void DeleteJob(string jobName);
 
         JobSettings GetJobSettings(string jobName);
 
         void SetJobSettings(string jobName, JobSettings jobSettings);
 
         void CleanupDeletedJobs();
+
+        void SyncExternalJobs(string sourcePath, string sourceName);
+
+        void CleanupExternalJobs(string sourceName);
     }
 }

--- a/Kudu.Core/Jobs/ContinuousJobsManager.cs
+++ b/Kudu.Core/Jobs/ContinuousJobsManager.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading;
 using Kudu.Contracts.Jobs;
 using Kudu.Contracts.Settings;
-using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
 
@@ -327,9 +326,9 @@ namespace Kudu.Core.Jobs
             {
                 path = path.Substring(JobsBinariesPath.Length).TrimStart(Path.DirectorySeparatorChar);
                 int firstSeparator = path.IndexOf(Path.DirectorySeparatorChar);
-                if (firstSeparator > 0)
+                string jobName = firstSeparator >= 0 ? path.Substring(0, firstSeparator) : path;
+                if (!String.IsNullOrWhiteSpace(jobName))
                 {
-                    string jobName = path.Substring(0, firstSeparator);
                     MarkJobUpdated(jobName);
                 }
             }

--- a/Kudu.Services/Jobs/JobsController.cs
+++ b/Kudu.Services/Jobs/JobsController.cs
@@ -244,7 +244,7 @@ namespace Kudu.Services.Jobs
 
         private HttpResponseMessage RemoveJob<TJob>(string jobName, IJobsManager<TJob> jobsManager) where TJob : JobBase, new()
         {
-            jobsManager.DeleteJobAsync(jobName);
+            jobsManager.DeleteJob(jobName);
             return Request.CreateResponse(HttpStatusCode.OK);
         }
 
@@ -303,7 +303,7 @@ namespace Kudu.Services.Jobs
             // On error, delete job (if exists)
             if (errorMessage != null)
             {
-                await jobsManager.DeleteJobAsync(jobName);
+                jobsManager.DeleteJob(jobName);
                 return CreateErrorResponse(errorStatusCode, errorMessage);
             }
 


### PR DESCRIPTION
The site extension needs to have the WebJobs under `App_Data\jobs\{job type}\{job name}`.
The jobs will be moved (not copied).
The result WebJob name will be `{site extension id}({job name})`.
Fixes #1393
