### PR TITLE
fix #1419 add duration time to trace

### DIFF
--- a/Kudu.Core.Test/Tracing/XmlTracerTests.cs
+++ b/Kudu.Core.Test/Tracing/XmlTracerTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Web;
+using System.Xml;
 using System.Xml.Linq;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
@@ -78,10 +79,16 @@ namespace Kudu.Core.Test.Tracing
                 }
 
                 var traces = new List<RequestInfo>();
-                foreach (var file in FileSystemHelpers.GetFiles(path, "*.xml").OrderBy(n => n))
+                foreach (var file in FileSystemHelpers.GetFiles(path, "*s.xml").OrderBy(n => n))
                 {
                     var document = XDocument.Load(FileSystemHelpers.OpenRead(file));
                     var trace = new RequestInfo { Url = document.Root.Attribute("url").Value };
+                    var elapsed = document.Root.Nodes().Last();
+
+                    // Assert
+                    Assert.Equal(XmlNodeType.Comment, elapsed.NodeType);
+                    Assert.Contains("duration:", ((XComment)elapsed).Value);
+
                     traces.Add(trace);
                 }
 


### PR DESCRIPTION
Sample traces below.

```xml
<step title="Incoming Request" date="2015-01-06T02:22:33.476" instance="SUWATC" url="/git-receive-pack" method="POST" type="request" pid="11112,16,6" Content-Length="8227" Content-Type="application/x-git-receive-pack-request" Accept="application/x-git-receive-pack-result" Accept-Encoding="gzip" Host="localhost:48474" User-Agent="git/1.8.4.msysgit.0" >
  <step title="RpcService.ReceivePack" date="2015-01-06T02:22:33.492" >
    <step title="Executing external process" date="2015-01-06T02:22:33.492" type="process" path="git.exe" arguments="rev-parse --git-dir" /><!-- duration: 31ms -->
    <step title="Assuming git repository at C:\Kudu-Test-Files\KuduApps\TestRunnerSiteSUWATCHASUS011\site\repository" date="2015-01-06T02:22:33.523" /><!-- duration: 0ms -->
    <step title="Executing external process" date="2015-01-06T02:22:33.523" type="process" path="git.exe" arguments="rev-parse --git-dir" /><!-- duration: 16ms -->
    <step title="Assuming git repository at C:\Kudu-Test-Files\KuduApps\TestRunnerSiteSUWATCHASUS011\site\repository" date="2015-01-06T02:22:33.539" /><!-- duration: 0ms -->
    <step title="Creating temporary deployment" date="2015-01-06T02:22:33.554" /><!-- duration: 31ms -->
    <step title="GitExeServer.Receive" date="2015-01-06T02:22:33.586" >
      <step title="Executing external process" date="2015-01-06T02:22:33.601" type="process" path="git.exe" arguments="receive-pack --stateless-rpc &quot;C:\Kudu-Test-Files\KuduApps\TestRunnerSiteSUWATCHASUS011\site\repository&quot;" /><!-- duration: 1722ms -->
    </step><!-- duration: 1738ms -->
  </step><!-- duration: 1847ms -->
  <step title="Outgoing response" date="2015-01-06T02:22:35.339" type="response" statusCode="200" statusText="OK" Server="Microsoft-IIS/8.5" Expires="Fri, 01 Jan 1980 00:00:00 GMT" Pragma="no-cache" Cache-Control="no-cache, max-age=0, must-revalidate" X-AspNet-Version="4.0.30319" Content-Type="application/x-git-receive-pack-result" /><!-- duration: 0ms -->
</step><!-- duration: 1863ms -->
```

Sample file names.
```
 2015-01-06T01-53-10_SUWATC_001_Startup_GET_api-filesystemhub-reconnect_0s.xml
 2015-01-06T01-53-24_SUWATC_001_Startup_GET_api-commandstream-reconnect_0s.xml
 2015-01-06T01-53-26_SUWATC_002_GET_info-refs_200_1s.xml
 2015-01-06T01-53-27_SUWATC_003_POST_git-receive-pack_200_2s.xml
 2015-01-06T01-53-28_SUWATC_001_kudu.exe_1s.xml
```