### PR TITLE
Fix serviceSitePath and sitesPath for Release configuration.

### DIFF
--- a/Kudu.Web/Web.Release.config
+++ b/Kudu.Web/Web.Release.config
@@ -3,6 +3,23 @@
 <!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <appSettings>
+    <!--
+      The "Release" configuration is used to deploy Kudu to a server. In this case
+      the service site and the user-created sites are two levels above the Kudu
+      site, e.g. if the path to KuduWeb is C:\inetpub\wwwroot\KuduWeb then the
+      service site is located at C:\inetpub\Kudu.Services.Web. This differs from
+      "Debug" configuration, used when developing or testing from source control
+      and each project directory is on the same level, so traversing up one level
+      is sufficient.
+    -->
+    <add key="serviceSitePath"
+      value="..\..\Kudu.Services.Web"
+      xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/>
+    <add key="sitesPath"
+      value="..\..\apps"
+      xdt:Transform="SetAttributes" xdt:Locator="Match(key)"/>
+  </appSettings>
   <!--
     In the example below, the "SetAttributes" transform will change the value of 
     "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 


### PR DESCRIPTION
As discussed in #1441 directory structure for deploying to a server is different from developing/debugging with Visual Studio.

Use XML transformation to have the keys in Web.config point to the correct paths. When building with Release configuration they are one level higher. This is because Release is used when deploying Kudu to a server, so Kudu.Services.Web\ and apps\ are located in e.g. C:\inetpub\ while KuduWeb\ is in e.g. C:\inetpub\wwwroot\.