### PR TITLE
Update site extension action to be ARM async

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -17,6 +17,7 @@ namespace Kudu
         public const string NpmDebugLogFile = "npm-debug.log";
 
         public const string DeploymentCachePath = "deployments";
+        public const string SiteExtensionsCachePath = "siteextensions";
         public const string DeploymentToolsPath = "tools";
         public const string SiteFolder = @"site";
         public const string LogFilesPath = @"LogFiles";
@@ -65,7 +66,22 @@ namespace Kudu
             get { return _maxAllowedExectionTime; }
         }
 
+        public const string RequestIdHeader = "x-ms-request-id";
+
         public const string SiteOperationHeaderKey = "X-MS-SITE-OPERATION";
         public const string SiteOperationRestart = "restart";
+
+        public const string SiteExtensionProvisioningStateCreated = "Created";
+        public const string SiteExtensionProvisioningStateAccepted = "Accepted";
+        public const string SiteExtensionProvisioningStateSucceeded = "Succeeded";
+        public const string SiteExtensionProvisioningStateFailed = "Failed";
+        public const string SiteExtensionProvisioningStateCanceled = "Canceled";
+
+        public const string SiteExtensionOperationInstall = "install";
+
+        // TODO: need localization?
+        public const string SiteExtensionProvisioningStateNotFoundMessageFormat = "'{0}' not found.";
+        public const string SiteExtensionProvisioningStateDownloadFailureMessageFormat = "'{0}' download failure.";
+        public const string SiteExtensionProvisioningStateInvalidPackageMessageFormat = "Invalid '{0}' package.";
     }
 }

--- a/Kudu.Client/Infrastructure/HttpClientExtensions.cs
+++ b/Kudu.Client/Infrastructure/HttpClientExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Kudu.Contracts.SiteExtensions;
 using Newtonsoft.Json;
 
 namespace Kudu.Client.Infrastructure
@@ -19,10 +18,8 @@ namespace Kudu.Client.Infrastructure
 
         public static async Task<T> GetJsonAsync<T>(this HttpClient client, string url)
         {
-            HttpResponseMessage result = await client.GetAsync(url);
-
-            string content = await result.EnsureSuccessful().Content.ReadAsStringAsync();
-
+            HttpResponseMessage response = await client.GetAsync(url);
+            string content = await response.EnsureSuccessful().Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<T>(content);
         }
 
@@ -90,22 +87,6 @@ namespace Kudu.Client.Infrastructure
         {
             HttpResponseMessage response = await client.PutAsJsonAsync(url, param);
             string content = await response.EnsureSuccessful().Content.ReadAsStringAsync();
-
-            var outputType = typeof(TOutput);
-            if (HttpResponseResultUtils.IsTypeOfHttpResponseRresult(outputType))
-            {
-                Type bodyType = outputType.GenericTypeArguments[0]; // HttpResponseResult<T> takes one generic type
-                var bodyObject = JsonConvert.DeserializeObject(value: content, type: bodyType);
-                var headerDict = new Dictionary<string, IEnumerable<string>>();
-
-                foreach (var item in response.Headers)
-                {
-                    headerDict.Add(item.Key, item.Value);
-                }
-
-                return (TOutput)HttpResponseResultUtils.CreateHttpResponseResultInstance(outputType, headerDict, bodyObject);
-            }
-
             return JsonConvert.DeserializeObject<TOutput>(content);
         }
     }

--- a/Kudu.Client/Kudu.Client.csproj
+++ b/Kudu.Client/Kudu.Client.csproj
@@ -51,7 +51,6 @@
     <Compile Include="Infrastructure\HttpResponseMessageExtensions.cs" />
     <Compile Include="Infrastructure\HttpClientExtensions.cs" />
     <Compile Include="Infrastructure\HttpClientHelper.cs" />
-    <Compile Include="Infrastructure\HttpResponseResult.cs" />
     <Compile Include="Infrastructure\ICredentialProvider.cs" />
     <Compile Include="Infrastructure\IEventProvider.cs" />
     <Compile Include="Infrastructure\KuduRemoteClientBase.cs" />

--- a/Kudu.Client/app.config
+++ b/Kudu.Client/app.config
@@ -3,8 +3,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -8,6 +8,7 @@
         string WebRootPath { get; }             // e.g. /site/wwwroot
         string DeploymentsPath { get; }         // e.g. /site/deployments
         string DeploymentToolsPath { get; }     // e.g. /site/deployments/tools
+        string SiteExtensionSettingsPath { get; }     // e.g. /site/siteextensions
         string DiagnosticsPath { get; }         // e.g. /site/diagnostics
         string LocksPath { get; }               // e.g. /site/locks
         string SSHKeyPath { get; }

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -15,7 +15,7 @@ namespace Kudu.Contracts.Settings
 
         public const int DefaultMaxJobRunsHistoryCount = 50;
 
-        public static readonly string DefaultSiteExtensionFeedUrl = "http://www.siteextensions.net/api/v2/";
+        public static readonly string DefaultSiteExtensionFeedUrl = "https://www.siteextensions.net/api/v2/";
 
         public static string GetValue(this IDeploymentSettingsManager settings, string key)
         {

--- a/Kudu.Contracts/SiteExtensions/ISiteExtensionManager.cs
+++ b/Kudu.Contracts/SiteExtensions/ISiteExtensionManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Kudu.Contracts.Tracing;
 
 namespace Kudu.Contracts.SiteExtensions
 {
@@ -16,7 +17,7 @@ namespace Kudu.Contracts.SiteExtensions
         /// <summary>
         /// Install or update a site extension
         /// </summary>
-        Task<SiteExtensionInfo> InstallExtension(string id, string version, string feedUrl);
+        Task<SiteExtensionInfo> InstallExtension(string id, string version, string feedUrl, ITracer tracer);
 
         Task<bool> UninstallExtension(string id);
     }

--- a/Kudu.Contracts/SiteExtensions/SiteExtensionInfo.cs
+++ b/Kudu.Contracts/SiteExtensions/SiteExtensionInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using Kudu.Contracts.Infrastructure;
 using Newtonsoft.Json;
 using NuGet.Client.VisualStudio;
@@ -184,10 +185,25 @@ namespace Kudu.Contracts.SiteExtensions
             set;
         }
 
+        // For Arm Request
         [JsonProperty(PropertyName = "name")]
         public string Name
         {
-            get { return this.Id; }
+            get { return Id; }
+        }
+
+        [JsonProperty(PropertyName = "provisioningState")]
+        public string ProvisioningState
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty(PropertyName = "comment")]
+        public string Comment
+        {
+            get;
+            set;
         }
     }
 }

--- a/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
+++ b/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
@@ -15,7 +15,7 @@ namespace Kudu.Core.Test
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() =>
-                new Environment(null, null, null, null, null, null, null, null, null, null, null, null));
+                new Environment(null, null, null, null, null, null, null, null, null, null, null, null, null));
 
             Assert.Equal("repositoryPath", ex.ParamName);
         }
@@ -125,7 +125,8 @@ namespace Kudu.Core.Test
             string sshKeyPath = null,
             string scriptPath = null,
             string nodeModulesPath = null,
-            string dataPath = null)
+            string dataPath = null,
+            string siteExtensionSettingsPath = null)
         {
             fileSystem = fileSystem ?? Mock.Of<IFileSystem>();
             repositoryPath = repositoryPath ?? "";
@@ -144,7 +145,8 @@ namespace Kudu.Core.Test
                     sshKeyPath,
                     scriptPath,
                     nodeModulesPath,
-                    dataPath);
+                    dataPath,
+                    siteExtensionSettingsPath);
         }
     }
 }

--- a/Kudu.Core.Test/LockFileTests.cs
+++ b/Kudu.Core.Test/LockFileTests.cs
@@ -20,6 +20,7 @@ namespace Kudu.Core.Test
         {
             // Mock
             var lockFile = MockLockFile(@"x:\path\file.lock");
+            var lockFile2 = MockLockFile(@"x:\path\file.lock");
 
             for (int i = 0; i < 2; i++)
             {
@@ -31,9 +32,13 @@ namespace Kudu.Core.Test
                 Assert.Equal(true, lockFile.IsHeld);
                 Assert.Equal(false, lockFile.Lock());
 
+                Assert.Equal(true, lockFile2.IsHeld);
+                Assert.Equal(false, lockFile2.Lock());
+
                 // Release
                 lockFile.Release();
                 Assert.Equal(false, lockFile.IsHeld);
+                Assert.Equal(false, lockFile2.IsHeld);
             }
         }
 
@@ -61,7 +66,7 @@ namespace Kudu.Core.Test
                         Thread.Sleep(0);
                         totals = val + 1;
 
-                        using (var reader = new StreamReader(FileSystemHelpers.OpenFile(file, FileMode.Open, FileAccess.Read, FileShare.Write))) 
+                        using (var reader = new StreamReader(FileSystemHelpers.OpenFile(file, FileMode.Open, FileAccess.Read, FileShare.Write)))
                         {
                             Assert.Contains("at Kudu.Core.Test.LockFileTests", reader.ReadToEnd());
                         }

--- a/Kudu.Core.Test/Tracing/XmlTracerTests.cs
+++ b/Kudu.Core.Test/Tracing/XmlTracerTests.cs
@@ -105,7 +105,7 @@ namespace Kudu.Core.Test.Tracing
 
         [Theory]
         [PropertyData("TraceRequests")]
-        public void TraceFiltersTests(bool expected, TraceLevel level, Kudu.Core.Tracing.XmlTracer.TraceInfo info, int statusCode)
+        public void TraceFiltersTests(bool expected, TraceLevel level, TraceInfo info, int statusCode)
         {
             Assert.Equal(expected, XmlTracer.ShouldTrace(level, info, statusCode));
         }
@@ -128,7 +128,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     true, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>()), 
+                    new TraceInfo("title", new Dictionary<string, string>()), 
                     200
                 };
 
@@ -137,7 +137,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     true, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "POST" },
@@ -151,7 +151,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     true, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "GET" },
@@ -165,7 +165,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     false, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "GET" },
@@ -179,7 +179,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     false, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "GET" },
@@ -193,7 +193,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     false, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "GET" },
@@ -207,7 +207,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     false, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "GET" },
@@ -221,7 +221,7 @@ namespace Kudu.Core.Test.Tracing
                 { 
                     false, 
                     TraceLevel.Error,
-                    new Kudu.Core.Tracing.XmlTracer.TraceInfo("title", new Dictionary<string, string>
+                    new TraceInfo("title", new Dictionary<string, string>
                         {
                             { "type", "request" },
                             { "method", "GET" },

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -9,6 +9,7 @@ namespace Kudu.Core
         private readonly string _webRootPath;
         private readonly string _deploymentsPath;
         private readonly string _deploymentToolsPath;
+        private readonly string _siteExtensionSettingsPath;
         private readonly string _diagnosticsPath;
         private readonly string _locksPath;
         private readonly string _sshKeyPath;
@@ -38,7 +39,8 @@ namespace Kudu.Core
                 string sshKeyPath,
                 string scriptPath,
                 string nodeModulesPath,
-                string dataPath)
+                string dataPath,
+                string siteExtensionSettingsPath)
         {
             if (repositoryPath == null)
             {
@@ -52,6 +54,7 @@ namespace Kudu.Core
             _webRootPath = webRootPath;
             _deploymentsPath = deploymentsPath;
             _deploymentToolsPath = Path.Combine(_deploymentsPath, Constants.DeploymentToolsPath);
+            _siteExtensionSettingsPath = siteExtensionSettingsPath;
             _diagnosticsPath = diagnosticsPath;
             _locksPath = locksPath;
             _sshKeyPath = sshKeyPath;
@@ -84,6 +87,7 @@ namespace Kudu.Core
             _webRootPath = Path.Combine(SiteRootPath, Constants.WebRoot);
             _deploymentsPath = Path.Combine(SiteRootPath, Constants.DeploymentCachePath);
             _deploymentToolsPath = Path.Combine(_deploymentsPath, Constants.DeploymentToolsPath);
+            _siteExtensionSettingsPath = Path.Combine(SiteRootPath, Constants.SiteExtensionsCachePath);
             _diagnosticsPath = Path.Combine(SiteRootPath, Constants.DiagnosticsPath);
             _locksPath = Path.Combine(SiteRootPath, Constants.LocksPath);
             _sshKeyPath = Path.Combine(rootPath, Constants.SSHKeyPath);
@@ -187,7 +191,7 @@ namespace Kudu.Core
                 return _scriptPath;
             }
         }
-        
+
         public string NodeModulesPath
         {
             get
@@ -255,6 +259,11 @@ namespace Kudu.Core
         public string JobsBinariesPath
         {
             get { return _jobsBinariesPath; }
+        }
+
+        public string SiteExtensionSettingsPath
+        {
+            get { return _siteExtensionSettingsPath; }
         }
 
         public static bool IsAzureEnvironment()

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -176,7 +176,9 @@
     <Compile Include="Settings\DiagnosticsSettingsManager.cs" />
     <Compile Include="SiteExtensions\DummyReference.cs" />
     <Compile Include="SiteExtensions\FeedExtensions.cs" />
+    <Compile Include="SiteExtensions\SiteExtensionInstallationLock.cs" />
     <Compile Include="SiteExtensions\SemanticVersion.cs" />
+    <Compile Include="SiteExtensions\SiteExtensionArmSettings.cs" />
     <Compile Include="SiteExtensions\SiteExtensionManager.cs" />
     <Compile Include="SourceControl\Git\IGitRepository.cs" />
     <Compile Include="SourceControl\Git\LibGit2SharpRepository.cs" />
@@ -233,6 +235,7 @@
     <Compile Include="Tracing\NullTracerFactory.cs" />
     <Compile Include="Tracing\TextTracer.cs" />
     <Compile Include="Tracing\TraceExtensions.cs" />
+    <Compile Include="Tracing\TraceInfo.cs" />
     <Compile Include="Tracing\TracerFactory.cs" />
     <Compile Include="Tracing\TraceStep.cs" />
     <Compile Include="Tracing\XmlTracer.cs" />

--- a/Kudu.Core/SiteExtensions/FeedExtensions.cs
+++ b/Kudu.Core/SiteExtensions/FeedExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -80,6 +81,12 @@ namespace Kudu.Core.SiteExtensions
             var downloadResource = await srcRepo.GetResourceAsync<DownloadResource>();
             using (Stream sourceStream = await downloadResource.GetStream(identity, CancellationToken.None))
             {
+                if (sourceStream == null)
+                {
+                    // package not exist from feed
+                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Package {0} - {1} not found when try to download.", identity.Id, identity.Version.ToNormalizedString()));
+                }
+
                 Stream packageStream = sourceStream;
                 try
                 {

--- a/Kudu.Core/SiteExtensions/SiteExtensionArmSettings.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionArmSettings.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Kudu.Contracts.SiteExtensions;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Settings;
+
+namespace Kudu.Core.SiteExtensions
+{
+    public class SiteExtensionStatus
+    {
+        private const string _statusSettingsFileName = "SiteExtensionStatus.json";
+        private const string _provisioningStateSetting = "provisioningState";
+        private const string _commentMessageSetting = "comment";
+        private const string _statusSetting = "status";
+        private const string _operationSetting = "operation";
+
+        private string _filePath;
+        private JsonSettings _jsonSettings;
+
+        public string ProvisioningState
+        {
+            get { return _jsonSettings.GetValue(_provisioningStateSetting); }
+            set { _jsonSettings.SetValue(_provisioningStateSetting, value); }
+        }
+
+        public string Comment
+        {
+            get { return _jsonSettings.GetValue(_commentMessageSetting); }
+            set
+            {
+                _jsonSettings.SetValue(_commentMessageSetting, value);
+            }
+        }
+
+        public HttpStatusCode Status
+        {
+            get
+            {
+                string statusStr = _jsonSettings.GetValue(_statusSetting);
+                HttpStatusCode statusCode = HttpStatusCode.OK;
+                Enum.TryParse<HttpStatusCode>(statusStr, out statusCode);
+                return statusCode;
+            }
+            set { _jsonSettings.SetValue(_statusSetting, Enum.GetName(typeof(HttpStatusCode), value)); }
+        }
+
+        /// <summary>
+        /// <para>Property to indicate current operation</para>
+        /// <para>Empty/null means there is no recent operation</para>
+        /// </summary>
+        public string Operation
+        {
+            get { return _jsonSettings.GetValue(_operationSetting); }
+            set { _jsonSettings.SetValue(_operationSetting, value); }
+        }
+
+        public SiteExtensionStatus(string rootPath, string id)
+        {
+            _filePath = GetFilePath(rootPath, id);
+            _jsonSettings = new JsonSettings(_filePath);
+        }
+
+        public void FillSiteExtensionInfo(SiteExtensionInfo info, string defaultProvisionState = null)
+        {
+            info.ProvisioningState = ProvisioningState ?? defaultProvisionState;
+            info.Comment = Comment;
+        }
+
+        public void ReadSiteExtensionInfo(SiteExtensionInfo info)
+        {
+            ProvisioningState = info.ProvisioningState;
+            Comment = info.Comment;
+        }
+
+        public async Task RemoveArmSettings()
+        {
+            try
+            {
+                string dirName = Path.GetDirectoryName(_filePath);
+                if (FileSystemHelpers.DirectoryExists(dirName))
+                {
+                    FileSystemHelpers.DeleteDirectoryContentsSafe(dirName);
+                    // call DeleteDirectorySafe directly would sometime causing "Access denied" on folder
+                    // work-around: remove content and wait briefly before delete folder 
+                    await Task.Delay(300);
+                    FileSystemHelpers.DeleteDirectorySafe(dirName);
+                }
+            }
+            catch
+            {
+                // no-op
+            }
+        }
+
+        public bool IsTerminalStatus()
+        {
+            return string.Equals(Constants.SiteExtensionProvisioningStateSucceeded, ProvisioningState, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Constants.SiteExtensionProvisioningStateFailed, ProvisioningState, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Constants.SiteExtensionProvisioningStateCanceled, ProvisioningState, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetFilePath(string rootPath, string id)
+        {
+            return Path.Combine(rootPath, id, _statusSettingsFileName);
+        }
+    }
+}

--- a/Kudu.Core/SiteExtensions/SiteExtensionInstallationLock.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionInstallationLock.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using Kudu.Core.Infrastructure;
+
+namespace Kudu.Core.SiteExtensions
+{
+    public class SiteExtensionInstallationLock : LockFile
+    {
+        private string _path;
+        private SiteExtensionInstallationLock(string path)
+            : base(path)
+        {
+            _path = path;
+        }
+
+        protected override void OnLockRelease()
+        {
+            // if installed failed, when release lock, we should also remove empty folder as well
+            base.OnLockRelease();
+            try
+            {
+                string folder = Path.GetDirectoryName(_path);
+                if (FileSystemHelpers.GetFiles(folder, "*").Length == 0)
+                {
+                    FileSystemHelpers.DeleteDirectorySafe(folder);
+                }
+            }
+            catch
+            {
+                // no-op
+            }
+        }
+
+        /// <summary>
+        /// <para>Will create a file lock like this: {rootPath}/{site extension id}/install.lock</para>
+        /// <para>e.g 'D:\home\site\siteextension\filecounter\install.lock'</para>
+        /// </summary>
+        public static SiteExtensionInstallationLock CreateLock(string rootPath, string id)
+        {
+            string lockFilePath = Path.Combine(rootPath, id, "install.lock");
+            var installationLock = new SiteExtensionInstallationLock(lockFilePath);
+            installationLock.InitializeAsyncLocks();
+            return installationLock;
+        }
+    }
+}

--- a/Kudu.Core/Tracing/TraceInfo.cs
+++ b/Kudu.Core/Tracing/TraceInfo.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Kudu.Core.Tracing
+{
+    public class TraceInfo
+    {
+        private string _title;
+        private IDictionary<string, string> _attribs;
+        private DateTime _startTime;
+
+        public TraceInfo(string title, IDictionary<string, string> attribs)
+        {
+            _title = title;
+            _attribs = attribs;
+            _startTime = DateTime.UtcNow;
+        }
+
+        public string Title
+        {
+            get { return _title; }
+        }
+
+        public IDictionary<string, string> Attributes
+        {
+            get { return _attribs; }
+        }
+
+        public DateTime StartTime
+        {
+            get { return _startTime; }
+        }
+    }
+}

--- a/Kudu.Core/Tracing/XmlTracer.cs
+++ b/Kudu.Core/Tracing/XmlTracer.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 
@@ -20,7 +19,8 @@ namespace Kudu.Core.Tracing
         public const string StartupRequestTrace = "Startup Request";
         public const string ProcessShutdownTrace = "Process Shutdown";
         public const string ExecutingExternalProcessTrace = "Executing external process";
-        
+        public const string BackgroundTrace = "BackgroundTrace";
+
         public const int MaxXmlFiles = 200;
         public const int CleanUpIntervalSecs = 10;
 
@@ -254,7 +254,7 @@ namespace Kudu.Core.Tracing
                     return;
                 }
 
-                foreach (var file in files.OrderBy(n => n).Take(files.Length - (MaxXmlFiles * 80)/100))
+                foreach (var file in files.OrderBy(n => n).Take(files.Length - (MaxXmlFiles * 80) / 100))
                 {
                     FileSystemHelpers.DeleteFileSafe(file);
                 }
@@ -297,6 +297,11 @@ namespace Kudu.Core.Tracing
                 var path = info.Attributes["path"].Split('\\').Last();
                 strb.AppendFormat("_{0}", path);
             }
+            else if (string.Equals(XmlTracer.BackgroundTrace, info.Title, StringComparison.Ordinal))
+            {
+                var path = info.Attributes["url"].Split('?')[0].Trim('/');
+                strb.AppendFormat("_Background_{0}_{1}", info.Attributes["method"], path.Replace('/', '-'));
+            }
             else if (!String.IsNullOrEmpty(info.Title))
             {
                 strb.AppendFormat("_{0}", info.Title.Replace(' ', '-'));
@@ -324,35 +329,6 @@ namespace Kudu.Core.Tracing
             catch
             {
                 // no-op
-            }
-        }
-
-        public class TraceInfo
-        {
-            private string _title;
-            private IDictionary<string, string> _attribs;
-            private DateTime _startTime;
-
-            public TraceInfo(string title, IDictionary<string, string> attribs)
-            {
-                _title = title;
-                _attribs = attribs;
-                _startTime = DateTime.UtcNow;
-            }
-
-            public string Title 
-            { 
-                get { return _title; } 
-            }
-
-            public IDictionary<string, string> Attributes 
-            {
-                get { return _attribs; } 
-            }
-
-            public DateTime StartTime
-            {
-                get { return _startTime; }
             }
         }
     }

--- a/Kudu.FunctionalTests/SiteExtensionApiFacts.cs
+++ b/Kudu.FunctionalTests/SiteExtensionApiFacts.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
-using Kudu.Client.Infrastructure;
+using Kudu.Client;
+using Kudu.Client.SiteExtensions;
 using Kudu.Contracts.SiteExtensions;
 using Kudu.Core.Infrastructure;
+using Kudu.FunctionalTests.Infrastructure;
 using Kudu.Services.Arm;
 using Kudu.TestHarness;
 using Xunit;
@@ -32,46 +36,46 @@ namespace Kudu.FunctionalTests
         };
 
         [Theory]
-        [InlineData("https://api.nuget.org/v3/index.json")]
-        [InlineData("http://www.nuget.org/api/v2/")]
-        public async Task SiteExtensionV2AndV3FeedTests(string feedEndpoint)
+        [InlineData(null, "sitereplicator", "1.1.2")]    // default site extension endpoint
+        [InlineData("https://www.nuget.org/api/v2/", "bootstrap", "3.0.0")]    // external v2 endpoint
+        [InlineData("https://api.nuget.org/v3/index.json", "bootstrap", "3.0.0")]    // external v3 endpoint
+        public async Task SiteExtensionV2AndV3FeedTests(string feedEndpoint, string testPackageId, string testPackageVersion)
         {
             TestTracer.Trace("Testing against feed: '{0}'", feedEndpoint);
 
             const string appName = "SiteExtensionV2AndV3FeedTests";
-            const string testPackageId = "bootstrap";
-            const string testPackageVersion = "3.0.0";
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
                 var manager = appManager.SiteExtensionManager;
 
                 // list package
                 TestTracer.Trace("Search extensions by id: '{0}'", testPackageId);
-                IEnumerable<SiteExtensionInfo> results = await manager.GetRemoteExtensions(
-                    filter: testPackageId,
-                    feedUrl: feedEndpoint);
+                HttpResponseMessage responseMessage = await manager.GetRemoteExtensions(filter: testPackageId, feedUrl: feedEndpoint);
+                IEnumerable<SiteExtensionInfo> results = await responseMessage.Content.ReadAsAsync<IEnumerable<SiteExtensionInfo>>();
                 Assert.True(results.Count() > 0, string.Format("GetRemoteExtensions for '{0}' package result should > 0", testPackageId));
 
                 // get package
                 TestTracer.Trace("Get an extension by id: '{0}'", testPackageId);
-                SiteExtensionInfo result = await manager.GetRemoteExtension(testPackageId, feedUrl: feedEndpoint);
+                SiteExtensionInfo result = await (await manager.GetRemoteExtension(testPackageId, feedUrl: feedEndpoint)).Content.ReadAsAsync<SiteExtensionInfo>();
                 Assert.Equal(testPackageId, result.Id);
 
                 TestTracer.Trace("Get an extension by id: '{0}' and version: '{1}'", testPackageId, testPackageVersion);
-                result = await manager.GetRemoteExtension(testPackageId, version: testPackageVersion, feedUrl: feedEndpoint);
+                result = await (await manager.GetRemoteExtension(testPackageId, version: testPackageVersion, feedUrl: feedEndpoint)).Content.ReadAsAsync<SiteExtensionInfo>();
                 Assert.Equal(testPackageId, result.Id);
                 Assert.Equal(testPackageVersion, result.Version);
 
                 // install
                 TestTracer.Trace("Install an extension by id: '{0}' and version: '{1}'", testPackageId, testPackageVersion);
-                HttpResponseResult<SiteExtensionInfo> richResult = await manager.InstallExtension<SiteExtensionInfo>(testPackageId, version: testPackageVersion, feedUrl: feedEndpoint);
-                Assert.Equal(testPackageId, richResult.Body.Id);
-                Assert.Equal(testPackageVersion, richResult.Body.Version);
-                Assert.False(richResult.Headers.ContainsKey(Constants.SiteOperationHeaderKey)); // only ARM request will have SiteOperation header
+                responseMessage = await manager.InstallExtension(testPackageId, version: testPackageVersion, feedUrl: feedEndpoint);
+                result = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal(testPackageId, result.Id);
+                Assert.Equal(testPackageVersion, result.Version);
+                Assert.False(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey)); // only ARM request will have SiteOperation header
 
                 // uninstall
                 TestTracer.Trace("Uninstall an extension by id: '{0}'", testPackageId);
-                Assert.True(await manager.UninstallExtension(testPackageId));
+                bool deleteResult = await (await manager.UninstallExtension(testPackageId)).Content.ReadAsAsync<bool>();
+                Assert.True(deleteResult);
             });
         }
 
@@ -85,106 +89,79 @@ namespace Kudu.FunctionalTests
                 var manager = appManager.SiteExtensionManager;
 
                 // list
-                List<SiteExtensionInfo> results = (await manager.GetRemoteExtensions()).ToList();
+                List<SiteExtensionInfo> results = await (await manager.GetRemoteExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 Assert.True(results.Any(), "GetRemoteExtensions expects results > 0");
 
                 // pick site extension
                 var expectedId = _galleryInstalledExtensions.Keys.ToArray()[new Random().Next(_galleryInstalledExtensions.Count)];
                 var expected = results.Find(ext => String.Equals(ext.Id, expectedId, StringComparison.OrdinalIgnoreCase));
-                TestTracer.Trace("Testing Against Site Extension {0}", expectedId);
+                TestTracer.Trace("Testing Against Site Extension '{0}' - '{1}'", expectedId, expected.Version);
 
                 // get
-                var result = await manager.GetRemoteExtension(expectedId);
+                TestTracer.Trace("Perform GetRemoteExtension with id '{0}' only", expectedId);
+                HttpResponseMessage responseMessage = await manager.GetRemoteExtension(expectedId);
+                SiteExtensionInfo result = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
                 Assert.Equal(expected.Id, result.Id);
                 Assert.Equal(expected.Version, result.Version);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
 
                 // clear local extensions
-                results = (await manager.GetLocalExtensions()).ToList();
+                TestTracer.Trace("Clear all installed extensions.");
+                results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
+                HttpResponseMessage deleteResponseMessage = null;
                 foreach (var ext in results)
                 {
-                    Assert.True(await manager.UninstallExtension(ext.Id), "Delete must return true");
+                    deleteResponseMessage = await manager.UninstallExtension(ext.Id);
+                    Assert.True(await deleteResponseMessage.Content.ReadAsAsync<bool>(), "Delete must return true");
+                    Assert.True(deleteResponseMessage.Headers.Contains(Constants.RequestIdHeader));
                 }
 
                 // install/update
-                HttpResponseResult<SiteExtensionInfo> richResult = await manager.InstallExtension<SiteExtensionInfo>(expected.Id);
-                Assert.Equal(expected.Id, richResult.Body.Id);
-                Assert.Equal(expected.Version, richResult.Body.Version);
+                TestTracer.Trace("Perform InstallExtension with id '{0}' only", expectedId);
+                responseMessage = await manager.InstallExtension(expected.Id);
+                result = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal(expected.Id, result.Id);
+                Assert.Equal(expected.Version, result.Version);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
 
                 // list
-                results = (await manager.GetLocalExtensions()).ToList();
+                TestTracer.Trace("Perform GetLocalExtensions with no parameter");
+                results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 Assert.True(results.Any(), "GetLocalExtensions expects results > 0");
 
                 // get
-                result = await manager.GetLocalExtension(expected.Id);
+                TestTracer.Trace("Perform GetLocalExtension with id '{0}' only.", expectedId);
+                responseMessage = await manager.GetLocalExtension(expected.Id);
+                result = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
                 Assert.Equal(expected.Id, result.Id);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
 
                 // delete
-                var deleted = await manager.UninstallExtension(expected.Id);
-                Assert.True(deleted, "Delete must return true");
+                TestTracer.Trace("Perform UninstallExtension with id '{0}' only.", expectedId);
+                responseMessage = await manager.UninstallExtension(expected.Id);
+                bool deleteResult = await responseMessage.Content.ReadAsAsync<bool>();
+                Assert.True(deleteResult, "Delete must return true");
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
 
                 // list installed
-                results = (await manager.GetLocalExtensions()).ToList();
+                TestTracer.Trace("Verify only '{0}' is installed", expectedId);
+                results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 Assert.False(results.Exists(ext => ext.Id == expected.Id), "After deletion extension " + expected.Id + " should not exist.");
 
                 // install from non-default endpoint
-                richResult = await manager.InstallExtension<SiteExtensionInfo>("bootstrap", version: "3.0.0", feedUrl: "http://www.nuget.org/api/v2/");
-                Assert.Equal("bootstrap", richResult.Body.Id);
-                Assert.Equal("3.0.0", richResult.Body.Version);
-                Assert.Equal("http://www.nuget.org/api/v2/", richResult.Body.FeedUrl);
+                responseMessage = await manager.InstallExtension("bootstrap", version: "3.0.0", feedUrl: "https://www.nuget.org/api/v2/");
+                result = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal("bootstrap", result.Id);
+                Assert.Equal("3.0.0", result.Version);
+                Assert.Equal("https://www.nuget.org/api/v2/", result.FeedUrl);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
 
                 // update site extension installed from non-default endpoint
-                richResult = await manager.InstallExtension<SiteExtensionInfo>("bootstrap");
-                Assert.Equal("bootstrap", richResult.Body.Id);
-                Assert.Equal("http://www.nuget.org/api/v2/", richResult.Body.FeedUrl);
-            });
-        }
-
-        [Theory]
-        [InlineData("https://api.nuget.org/v3/index.json")]
-        [InlineData("http://www.nuget.org/api/v2/")]
-        public async Task SiteExtensionInstallUpdateIdempotentTest(string feedEndpoint)
-        {
-            TestTracer.Trace("Testing against feed: '{0}'", feedEndpoint);
-
-            const string appName = "SiteExtensionInstallIdempotentTest";
-            const string testPackageId = "bootstrap";
-
-            await ApplicationManager.RunAsync(appName, async appManager =>
-            {
-                var manager = appManager.SiteExtensionManager;
-
-                // Get the latest package, make sure that call will return right away when we try to update
-                TestTracer.Trace("Get latest package '{0}' from '{1}'", testPackageId, feedEndpoint);
-                SiteExtensionInfo latestPackage = await manager.GetRemoteExtension(testPackageId, feedUrl: feedEndpoint);
-
-                TestTracer.Trace("Uninstall package '{0}'", latestPackage.Id);
-                try
-                {
-                    // uninstall package if it is there
-                    await manager.UninstallExtension(testPackageId);
-                }
-                catch
-                {
-                    // ignore exception
-                }
-
-                // install from non-default endpoint
-                TestTracer.Trace("Install package '{0}'-'{1}' fresh from '{2}'.", latestPackage.Id, latestPackage.Version, feedEndpoint);
-                HttpResponseResult<ArmEntry<SiteExtensionInfo>> richResult = await manager.InstallExtension<ArmEntry<SiteExtensionInfo>>(id: testPackageId, version: latestPackage.Version, feedUrl: feedEndpoint);
-                Assert.Equal(latestPackage.Id, richResult.Body.Properties.Id);
-                Assert.Equal(latestPackage.Version, richResult.Body.Properties.Version);
-                Assert.Equal(feedEndpoint, richResult.Body.Properties.FeedUrl);
-                Assert.True(richResult.Headers[Constants.SiteOperationHeaderKey].Contains(Constants.SiteOperationRestart));
-
-                TestTracer.Trace("Try to update package '{0}' without given a feed.", testPackageId);
-                // Not passing feed endpoint will default to feed endpoint from installed package
-                // Update should return right away, expecting code to look up from feed that store in local package
-                // since we had installed the latest package, there is nothing to update.
-                // We shouldn`t see any site operation header value
-                richResult = await manager.InstallExtension<ArmEntry<SiteExtensionInfo>>(testPackageId);
-                Assert.Equal(latestPackage.Id, richResult.Body.Properties.Id);
-                Assert.Equal(feedEndpoint, richResult.Body.Properties.FeedUrl);
-                Assert.False(richResult.Headers.ContainsKey(Constants.SiteOperationHeaderKey));
+                responseMessage = await manager.InstallExtension("bootstrap");
+                result = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal("bootstrap", result.Id);
+                Assert.Equal("https://www.nuget.org/api/v2/", result.FeedUrl);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
             });
         }
 
@@ -198,7 +175,7 @@ namespace Kudu.FunctionalTests
                 var manager = appManager.SiteExtensionManager;
 
                 // list
-                List<SiteExtensionInfo> results = (await manager.GetRemoteExtensions()).ToList();
+                List<SiteExtensionInfo> results = await (await manager.GetRemoteExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 Assert.True(results.Any(), "GetRemoteExtensions expects results > 0");
 
                 // pick site extension
@@ -207,36 +184,38 @@ namespace Kudu.FunctionalTests
                 TestTracer.Trace("Testing Against Site Extension {0}", expectedId);
 
                 // get
-                var result = await manager.GetRemoteExtension(expectedId);
+                SiteExtensionInfo result = await (await manager.GetRemoteExtension(expectedId)).Content.ReadAsAsync<SiteExtensionInfo>();
                 Assert.Equal(expected.Id, result.Id);
                 Assert.Equal(expected.Version, result.Version);
 
                 // clear local extensions
-                results = (await manager.GetLocalExtensions()).ToList();
+                results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
+                bool deleteResult = false;
                 foreach (var ext in results)
                 {
-                    Assert.True(await manager.UninstallExtension(ext.Id), "Delete must return true");
+                    deleteResult = await (await manager.UninstallExtension(ext.Id)).Content.ReadAsAsync<bool>();
+                    Assert.True(deleteResult, "Delete must return true");
                 }
 
                 // install/update
-                HttpResponseResult<SiteExtensionInfo> richResult = await manager.InstallExtension<SiteExtensionInfo>(expected.Id);
-                Assert.Equal(expected.Id, richResult.Body.Id);
-                Assert.Equal(expected.Version, richResult.Body.Version);
+                result = await (await manager.InstallExtension(expected.Id)).Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal(expected.Id, result.Id);
+                Assert.Equal(expected.Version, result.Version);
 
                 // list
-                results = (await manager.GetLocalExtensions()).ToList();
+                results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 Assert.True(results.Any(), "GetLocalExtensions expects results > 0");
 
                 // get
-                result = await manager.GetLocalExtension(expected.Id);
+                result = await (await manager.GetLocalExtension(expected.Id)).Content.ReadAsAsync<SiteExtensionInfo>();
                 Assert.Equal(expected.Id, result.Id);
 
                 // delete
-                var deleted = await manager.UninstallExtension(expected.Id);
-                Assert.True(deleted, "Delete must return true");
+                deleteResult = await (await manager.UninstallExtension(expected.Id)).Content.ReadAsAsync<bool>();
+                Assert.True(deleteResult, "Delete must return true");
 
                 // list installed
-                results = (await manager.GetLocalExtensions()).ToList();
+                results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 Assert.False(results.Exists(ext => ext.Id == expected.Id), "After deletion extension " + expected.Id + " should not exist.");
             });
         }
@@ -251,14 +230,14 @@ namespace Kudu.FunctionalTests
                 var manager = appManager.SiteExtensionManager;
 
                 TestTracer.Trace("Clean site extensions");
-                var results = (await manager.GetLocalExtensions()).ToList();
+                List<SiteExtensionInfo> results = await (await manager.GetLocalExtensions()).Content.ReadAsAsync<List<SiteExtensionInfo>>();
                 foreach (var ext in results)
                 {
                     await manager.UninstallExtension(ext.Id);
                 }
 
                 TestTracer.Trace("Install site extension with jobs");
-                await manager.InstallExtension<SiteExtensionInfo>("filecounterwithwebjobs", null, "https://www.myget.org/F/amitaptest/");
+                await manager.InstallExtension("filecounterwithwebjobs", null, "https://www.myget.org/F/amitaptest/");
 
                 TestTracer.Trace("Verify jobs were deployed");
                 await OperationManager.AttemptAsync(async () =>
@@ -285,6 +264,210 @@ namespace Kudu.FunctionalTests
                 triggeredJobs = (await appManager.JobsManager.ListTriggeredJobsAsync()).ToArray();
                 Assert.Equal(0, triggeredJobs.Length);
             });
+        }
+
+        [Theory]
+        [InlineData(null, "sitereplicator")]    // default site extension endpoint
+        [InlineData("https://www.nuget.org/api/v2/", "bootstrap")]    // external v2 endpoint
+        [InlineData("https://api.nuget.org/v3/index.json", "bootstrap")]    // external v3 endpoint
+        public async Task SiteExtensionInstallUninstallAsyncTest(string feedEndpoint, string testPackageId)
+        {
+            TestTracer.Trace("Testing against feed: '{0}'", feedEndpoint);
+
+            const string appName = "SiteExtensionInstallUninstallAsyncTest";
+
+            await ApplicationManager.RunAsync(appName, async appManager =>
+            {
+                var manager = appManager.SiteExtensionManager;
+
+                // Get the latest package, make sure that call will return right away when we try to update
+                TestTracer.Trace("Get latest package '{0}' from '{1}'", testPackageId, feedEndpoint);
+                SiteExtensionInfo latestPackage = await (await manager.GetRemoteExtension(testPackageId, feedUrl: feedEndpoint)).Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal(testPackageId, latestPackage.Id);
+
+                TestTracer.Trace("Uninstall package '{0}'", testPackageId);
+                try
+                {
+                    // uninstall package if it is there
+                    await manager.UninstallExtension(testPackageId);
+                }
+                catch
+                {
+                    // ignore exception
+                }
+
+                // install from non-default endpoint
+                UpdateHeaderIfGoingToBeArmRequest(manager.Client, true);
+                TestTracer.Trace("Install package '{0}'-'{1}' fresh from '{2}' async", testPackageId, latestPackage.Version, feedEndpoint);
+                HttpResponseMessage responseMessage = await manager.InstallExtension(id: testPackageId, version: latestPackage.Version, feedUrl: feedEndpoint);
+                ArmEntry<SiteExtensionInfo> armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                Assert.Equal(string.Empty, armResult.Location);   // test "x-ms-geo-location" header is empty, same value should be assign to "Location"
+                Assert.Equal(HttpStatusCode.Created, responseMessage.StatusCode);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                //TestTracer.Trace("Poll for status. Expecting 200 response eventually with site operation header.");
+                responseMessage = await PollAndVerifyAfterArmInstallation(manager, testPackageId);
+                armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                // after successfully installed, should return SiteOperationHeader to notify GEO to restart website
+                Assert.True(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey));
+                Assert.Equal(feedEndpoint, armResult.Properties.FeedUrl);
+                Assert.Equal(latestPackage.Version, armResult.Properties.Version);
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                TestTracer.Trace("Get '{0}' again. Expecting 200 response without site operation header", testPackageId);
+                responseMessage = await manager.GetLocalExtension(testPackageId);
+                armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                // get again shouldn`t see SiteOperationHeader anymore
+                Assert.False(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey));
+                Assert.Equal(feedEndpoint, armResult.Properties.FeedUrl);
+                Assert.Equal(latestPackage.Version, armResult.Properties.Version);
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                TestTracer.Trace("Try to update package '{0}' without given a feed", testPackageId);
+                // Not passing feed endpoint will default to feed endpoint from installed package
+                // Update should return right away, expecting code to look up from feed that store in local package
+                // since we had installed the latest package, there is nothing to update.
+                // We shouldn`t see any site operation header value
+                responseMessage = await manager.InstallExtension(testPackageId);
+                armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                Assert.Equal(string.Empty, armResult.Location);   // test "x-ms-geo-location" header is empty, same value should be assign to "Location"
+                Assert.Equal(HttpStatusCode.Created, responseMessage.StatusCode);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                TestTracer.Trace("Poll for status. Expecting 200 without site operation header, since no actual installation happened");
+                responseMessage = await PollAndVerifyAfterArmInstallation(manager, testPackageId);
+                armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                Assert.Equal(latestPackage.Id, armResult.Properties.Id);
+                Assert.Equal(feedEndpoint, armResult.Properties.FeedUrl);
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+                // no installation operation happened, shouldn`t see SiteOperationHeader return
+                Assert.False(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey));
+
+                TestTracer.Trace("Uninstall '{0}' async", testPackageId);
+                responseMessage = await manager.UninstallExtension(testPackageId);
+                armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                Assert.Null(armResult);
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                TestTracer.Trace("Get '{0}' again. Expecting 404.", testPackageId);
+                var ex = await KuduAssert.ThrowsUnwrappedAsync<HttpUnsuccessfulRequestException>(async () =>
+                {
+                    await manager.GetLocalExtension(testPackageId);
+                });
+                Assert.Equal(HttpStatusCode.NotFound, ex.ResponseMessage.StatusCode);
+            });
+        }
+
+        [Fact]
+        public async Task SiteExtensionGetArmTest()
+        {
+            const string appName = "SiteExtensionGetAsyncTest";
+            const string externalPackageId = "bootstrap";
+            const string externalFeed = "https://api.nuget.org/v3/index.json";
+
+            await ApplicationManager.RunAsync(appName, async appManager =>
+            {
+                var manager = appManager.SiteExtensionManager;
+
+                UpdateHeaderIfGoingToBeArmRequest(manager.Client, true);
+                TestTracer.Trace("GetRemoteExtensions with Arm header, expecting site extension info will be wrap inside Arm envelop");
+                HttpResponseMessage responseMessage = await manager.GetRemoteExtensions(externalPackageId, true, externalFeed);
+                ArmListEntry<SiteExtensionInfo> armResultList = await responseMessage.Content.ReadAsAsync<ArmListEntry<SiteExtensionInfo>>();
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.NotNull(armResultList);
+                Assert.NotEmpty(armResultList.Value);
+                Assert.Equal(externalPackageId, armResultList.Value.First<ArmEntry<SiteExtensionInfo>>().Properties.Id);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                TestTracer.Trace("GetRemoteExtension with Arm header, expecting site extension info will be wrap inside Arm envelop");
+                responseMessage = await manager.GetRemoteExtension(externalPackageId, feedUrl: externalFeed);
+                ArmEntry<SiteExtensionInfo> armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.NotNull(armResult);
+                Assert.Equal(externalPackageId, armResult.Properties.Id);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                UpdateHeaderIfGoingToBeArmRequest(manager.Client, false);
+                responseMessage = await manager.InstallExtension(externalPackageId, feedUrl: externalFeed);
+                SiteExtensionInfo syncResult = await responseMessage.Content.ReadAsAsync<SiteExtensionInfo>();
+                Assert.Equal(externalPackageId, syncResult.Id);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                UpdateHeaderIfGoingToBeArmRequest(manager.Client, true);
+                TestTracer.Trace("GetLocalExtensions (no filter) with Arm header, expecting site extension info will be wrap inside Arm envelop");
+                responseMessage = await manager.GetLocalExtensions();
+                armResultList = await responseMessage.Content.ReadAsAsync<ArmListEntry<SiteExtensionInfo>>();
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.NotNull(armResultList);
+                Assert.NotEmpty(armResultList.Value);
+                Assert.Equal(externalPackageId, armResultList.Value.First<ArmEntry<SiteExtensionInfo>>().Properties.Id);
+                Assert.Equal(Constants.SiteExtensionProvisioningStateSucceeded, armResultList.Value.First<ArmEntry<SiteExtensionInfo>>().Properties.ProvisioningState);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+
+                TestTracer.Trace("GetLocalExtensions (with filter) with Arm header, expecting site extension info will be wrap inside Arm envelop");
+                responseMessage = await manager.GetLocalExtensions(externalPackageId);
+                armResultList = await responseMessage.Content.ReadAsAsync<ArmListEntry<SiteExtensionInfo>>();
+                Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
+                Assert.NotNull(armResultList);
+                Assert.NotEmpty(armResultList.Value);
+                Assert.Equal(externalPackageId, armResultList.Value.First<ArmEntry<SiteExtensionInfo>>().Properties.Id);
+                Assert.True(responseMessage.Headers.Contains(Constants.RequestIdHeader));
+                foreach (var item in armResultList.Value)
+                {
+                    Assert.Equal(Constants.SiteExtensionProvisioningStateSucceeded, item.Properties.ProvisioningState);
+                }
+            });
+        }
+
+        private async Task<HttpResponseMessage> PollAndVerifyAfterArmInstallation(RemoteSiteExtensionManager manager, string packageId)
+        {
+            TestTracer.Trace("Polling for status");
+            DateTime start = DateTime.UtcNow;
+            HttpResponseMessage responseMessage = null;
+
+            UpdateHeaderIfGoingToBeArmRequest(manager.Client, true);
+            do
+            {
+                responseMessage = await manager.GetLocalExtension(packageId);
+
+                if (HttpStatusCode.Created == responseMessage.StatusCode)
+                {
+                    TestTracer.Trace("Action is on-going, wait for 3 seconds for next poll.");
+                    await Task.Delay(TimeSpan.FromSeconds(3));
+                }
+                else if (HttpStatusCode.OK == responseMessage.StatusCode)
+                {
+                    TestTracer.Trace("Action is done successfully.");
+                    break;
+                }
+
+                Assert.True(
+                    HttpStatusCode.Created == responseMessage.StatusCode
+                    || HttpStatusCode.OK == responseMessage.StatusCode, "Action failed.");
+
+            } while ((DateTime.UtcNow - start).TotalSeconds < 30);
+
+            TestTracer.Trace("Polled for {0} seconds. Response status is {1}", (DateTime.UtcNow - start).TotalSeconds, responseMessage.StatusCode);
+            Assert.True(HttpStatusCode.OK == responseMessage.StatusCode, "Action failed.");
+            return responseMessage;
+        }
+
+        private static void UpdateHeaderIfGoingToBeArmRequest(HttpClient client, bool isArmRequest)
+        {
+            var containsArmHeader = client.DefaultRequestHeaders.Contains(ArmUtils.GeoLocationHeaderKey);
+
+            if (isArmRequest && !containsArmHeader)
+            {
+                client.DefaultRequestHeaders.Add(ArmUtils.GeoLocationHeaderKey, string.Empty);
+            }
+            else if (!isArmRequest && containsArmHeader)
+            {
+                client.DefaultRequestHeaders.Remove(ArmUtils.GeoLocationHeaderKey);
+            }
         }
     }
 }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -307,6 +307,7 @@ namespace Kudu.Services.Web.App_Start
                 new TraceDeprecatedActionAttribute(
                     kernel.Get<IAnalytics>(),
                     kernel.Get<ITraceFactory>()));
+            GlobalConfiguration.Configuration.Filters.Add(new EnsureRequestIdHandlerAttribute());
         }
 
         public static class SignalRStartup

--- a/Kudu.Services/EnsureRequestIdHandlerAttribute.cs
+++ b/Kudu.Services/EnsureRequestIdHandlerAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web;
+using System.Web.Http.Filters;
+
+namespace Kudu.Services
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class EnsureRequestIdHandlerAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            IEnumerable<string> requestIds;
+            if (actionExecutedContext.Request.Headers.TryGetValues(Constants.RequestIdHeader, out requestIds))
+            {
+                foreach (var rid in requestIds)
+                {
+                    // do not use Response from actionExecutedContext, if exception is throw, response will be null
+                    HttpContext.Current.Response.AddHeader(Constants.RequestIdHeader, rid);
+                }
+            }
+            else
+            {
+                string newRequestId = Guid.NewGuid().ToString();
+                HttpContext.Current.Response.AddHeader(Constants.RequestIdHeader, newRequestId);
+            }
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Deployment\DeploymentController.cs" />
     <Compile Include="Diagnostics\LogStreamHandler.cs" />
     <Compile Include="Diagnostics\LogStreamManager.cs" />
+    <Compile Include="EnsureRequestIdHandlerAttribute.cs" />
     <Compile Include="Error404Controller.cs" />
     <Compile Include="Infrastructure\HttpResponseMessageExtensions.cs" />
     <Compile Include="Infrastructure\LowerCaseFormatterConfigAttribute.cs" />

--- a/Kudu.TestHarness/TestEnvironment.cs
+++ b/Kudu.TestHarness/TestEnvironment.cs
@@ -123,5 +123,11 @@ namespace Kudu.TestHarness
             get;
             set;
         }
+
+        public string SiteExtensionSettingsPath
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
- Update install action to ARM async
- Update other action to be ARM friendly (sync but when it is arm request, will wrap data inside ARM envelop)


sample trace
```xml
<step title="Queue installation into background worker queue." date="2015-02-25T21:59:15.665" instance="XIAOWU" Accept="application/json" Expect="100-continue" Host="localhost:54866" x-ms-geo-location="" /><!-- duration: 2ms -->
<step title="Perform installation with background worker." date="2015-02-25T21:59:15.669" instance="XIAOWU" >
  <step title="Search package by id: bootstrap and version: 3.3.2" date="2015-02-25T21:59:15.672" /><!-- duration: 86ms -->
  <step title="Install package: bootstrap." date="2015-02-25T21:59:15.760" >
    <step title="Download site extension: bootstrap.3.3.2" date="2015-02-25T21:59:15.761" /><!-- duration: 294ms -->
    <step title="Check if applicationhost.xdt file existed." date="2015-02-25T21:59:16.056" >
      <step title="Missing xdt file, creating one." date="2015-02-25T21:59:16.058" /><!-- duration: 1ms -->
    </step><!-- duration: 5ms -->
    <step title="Trigger site extension job" date="2015-02-25T21:59:16.062" /><!-- duration: 1ms -->
  </step><!-- duration: 308ms -->
  <step title="Update arm settings for bootstrap installation. Status: OK" date="2015-02-25T21:59:16.153" /><!-- duration: 9ms -->
</step><!-- duration: 496ms -->

```
