### PR TITLE
Fixes #1501, Avoid restart when install to WebRoot with no XDT

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -66,6 +66,8 @@ namespace Kudu
             get { return _maxAllowedExectionTime; }
         }
 
+        public const string ApplicationHostXdtFileName = "applicationHost.xdt";
+
         public const string RequestIdHeader = "x-ms-request-id";
 
         public const string SiteOperationHeaderKey = "X-MS-SITE-OPERATION";

--- a/Kudu.FunctionalTests/SiteExtensionApiFacts.cs
+++ b/Kudu.FunctionalTests/SiteExtensionApiFacts.cs
@@ -695,8 +695,8 @@ namespace Kudu.FunctionalTests
                 TestTracer.Trace("Poll for status. Expecting 200 response eventually with site operation header.");
                 responseMessage = await PollAndVerifyAfterArmInstallation(manager, externalPackageId);
                 ArmEntry<SiteExtensionInfo> armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
-                // after successfully installed, should return SiteOperationHeader to notify GEO to restart website
-                Assert.True(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey));
+                // shouldn`t see restart header since package doesn`t come with XDT
+                Assert.False(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey));
                 Assert.Equal(externalFeed, armResult.Properties.FeedUrl);
                 Assert.Equal(externalPackageVersion, armResult.Properties.Version);
                 Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);
@@ -741,6 +741,8 @@ namespace Kudu.FunctionalTests
 
                 TestTracer.Trace("Poll for status. Expecting 200 response eventually with site operation header.");
                 responseMessage = await PollAndVerifyAfterArmInstallation(manager, externalPackageWithXdtId);
+                // after successfully installed, should return SiteOperationHeader to notify GEO to restart website
+                Assert.True(responseMessage.Headers.Contains(Constants.SiteOperationHeaderKey));
                 armResult = await responseMessage.Content.ReadAsAsync<ArmEntry<SiteExtensionInfo>>();
                 Assert.Equal(externalFeed, armResult.Properties.FeedUrl);
                 Assert.Equal(HttpStatusCode.OK, responseMessage.StatusCode);


### PR DESCRIPTION
1) if site extension install to site extension folder, we will trigger restart
2) if site extension install to wwwroot, and there is xdt file come with package, we will trigger restart
3) if site extension install to wwwroot and no xdt file come with pakcage, we will NOT generate XDT file and will NOT trigger restart