### PR TITLE
Enabling a disabled WebJob resulted in the WebJob starting

### DIFF
--- a/Kudu.Core/Jobs/ContinuousJobRunner.cs
+++ b/Kudu.Core/Jobs/ContinuousJobRunner.cs
@@ -189,8 +189,13 @@ namespace Kudu.Core.Jobs
             }
         }
 
-        public void RefreshJob(ContinuousJob continuousJob, JobSettings jobSettings)
+        public void RefreshJob(ContinuousJob continuousJob, JobSettings jobSettings, bool logRefresh)
         {
+            if (logRefresh)
+            {
+                _continuousJobLogger.LogInformation("Detected WebJob file/s were updated, refreshing WebJob");
+            }
+
             StopJob();
             JobSettings = jobSettings;
             StartJob(continuousJob);
@@ -200,13 +205,11 @@ namespace Kudu.Core.Jobs
         {
             OperationManager.Attempt(() => FileSystemHelpers.WriteAllBytes(_disableFilePath, new byte[0]));
             _continuousJobLogger.ReportStatus(ContinuousJobStatus.Disabling);
-            StopJob();
         }
 
-        public void EnableJob(ContinuousJob continuousJob)
+        public void EnableJob()
         {
             OperationManager.Attempt(() => FileSystemHelpers.DeleteFile(_disableFilePath));
-            StartJob(continuousJob);
         }
 
         protected override void UpdateStatus(IJobLogger logger, string status)


### PR DESCRIPTION
after 5 seconds it was stopped and started again.

This is due to 2 things that were fixed in this change:

1. Enable job deleted the disable.job file but also started the job, deleting the file causes the job to restart after 5 seconds.
Fix is to not start the job and have the file change detection do it.

2. Enable / Disable job causes file change twice, once after creating or deleting the disable.job and a second time it seems the directory of the job is changed but this only happens after the job refreshes which causes it to refresh again.
I could pinpoint exactly why this happens but "change" file notification on the job directory is not important and so we will ignore it.

Also added log line for when WebJob files update causes WebJob refresh.

Fixes #1549