### PR TITLE
Added cleanup logic if there is leftover data when perform install; Release installation lock when check for installation.

### DIFF
--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -35,6 +35,31 @@ namespace Kudu.Core.Infrastructure
             return path;
         }
 
+        public static void MoveDirectory(string sourceDirName, string destDirName)
+        {
+            // Instance.Directory.Move will result in access denied sometime. Do it ourself!
+
+            EnsureDirectory(destDirName);
+
+            string[] files = Instance.Directory.GetFiles(sourceDirName);
+            string[] dirs = Instance.Directory.GetDirectories(sourceDirName);
+
+            foreach (var filePath in files)
+            {
+                var fi = new FileInfo(filePath);
+                MoveFile(filePath, Path.Combine(destDirName, fi.Name));
+            }
+
+            foreach (var dirPath in dirs)
+            {
+                var di = new DirectoryInfo(dirPath);
+                MoveDirectory(dirPath, Path.Combine(destDirName, di.Name));
+                Instance.Directory.Delete(dirPath, false);
+            }
+
+            Instance.Directory.Delete(sourceDirName, false);
+        }
+
         public static bool FileExists(string path)
         {
             return Instance.File.Exists(path);

--- a/Kudu.Core/SiteExtensions/FeedExtensions.cs
+++ b/Kudu.Core/SiteExtensions/FeedExtensions.cs
@@ -85,10 +85,6 @@ namespace Kudu.Core.SiteExtensions
             var downloadResource = await srcRepo.GetResourceAndValidateAsync<DownloadResource>();
             using (Stream packageStream = await srcRepo.GetPackageStream(identity))
             {
-                WriteStreamToFile(packageStream, pathToLocalCopyOfNupkg);
-                // set position back to the head of stream
-                packageStream.Position = 0;
-
                 using (ZipFile zipFile = ZipFile.Read(packageStream))
                 {
                     // we only care about stuff under "content" folder
@@ -105,6 +101,12 @@ namespace Kudu.Core.SiteExtensions
                         }
                     }
                 }
+
+                // set position back to the head of stream
+                packageStream.Position = 0;
+
+                // save a copy of the nupkg at last
+                WriteStreamToFile(packageStream, pathToLocalCopyOfNupkg);                
             }
         }
 

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -295,6 +295,7 @@ namespace Kudu.Services.Web.App_Start
 
             MigrateSite(environment, noContextDeploymentsSettingsManager);
             RemoveOldTracePath(environment);
+            RemoveTempFileFromUserDrive(environment);
 
             // Temporary fix for https://github.com/npm/npm/issues/5905
             EnsureNpmGlobalDirectory();
@@ -488,6 +489,11 @@ namespace Kudu.Services.Web.App_Start
         private static void RemoveOldTracePath(IEnvironment environment)
         {
             FileSystemHelpers.DeleteDirectorySafe(Path.Combine(environment.LogFilesPath, "Git"), ignoreErrors: true);
+        }
+
+        private static void RemoveTempFileFromUserDrive(IEnvironment environment)
+        {
+            FileSystemHelpers.DeleteDirectorySafe(Path.Combine(environment.RootPath, "data", "Temp"), ignoreErrors: true);
         }
 
         // Perform migration tasks to deal with legacy sites that had different file layout


### PR DESCRIPTION
Added cleanup logic if there is leftover data when perform install; 
Release installation lock when check for installation.

sample log:

````xml
<step title="Incoming Request" date="2015-05-11T19:52:52.277" instance="0aa838" url="/api/siteextensions/Microsoft.ApplicationInsights.AzureWebSites" method="PUT" type="request" pid="32420,2,6" Connection="Keep-Alive" Content-Length="0" Content-Type="application/json" Accept="application/json" Accept-Language="en" Host="kudutest1.scm.azurewebsites.net" User-Agent="Portal-Exp/5.11.2.723 (Kudu) Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/42.0.2311.135 Safari/537.36" x-ms-version="2013-08-01" x-ms-client-request-id="9794E0E3-5ABF-40C9-B799-E4893F0827A9" x-ms-client-session-id="8faf3524a9a44193ab90b7d0134ff616" X-SITE-DEPLOYMENT-ID="kudutest1" X-MS-WAWS-JWT="" >
  <step title="Installing Microsoft.ApplicationInsights.AzureWebSites, version:  from feed: " date="2015-05-11T19:52:52.386" /><!-- duration: 16ms -->
  <step title="Version is null, search latest package by id: Microsoft.ApplicationInsights.AzureWebSites, will not search for unlisted package." date="2015-05-11T19:52:52.917" /><!-- duration: 109ms -->
  <step title="Install package: Microsoft.ApplicationInsights.AzureWebSites." date="2015-05-11T19:52:53.042" >
    <step title="There was leftover data from previous uninstallation. Trying to cleanup now." date="2015-05-11T19:52:53.074" >
      <step title="Error occurred" date="2015-05-11T19:52:55.245" type="error" text="Access to the path &apos;Microsoft.ApplicationInsights.Extensions.Base_x86.dll&apos; is denied." stackTrace="   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileInfo.Delete()
   at System.IO.Abstractions.FileInfoWrapper.Delete()
   at Kudu.Core.Infrastructure.OperationManager.&lt;&gt;c__DisplayClass1.&lt;Attempt&gt;b__0()
   at Kudu.Core.Infrastructure.OperationManager.Attempt[T](Func`1 action, Int32 retries, Int32 delayBeforeRetry, Func`2 shouldRetry)
   at Kudu.Core.Infrastructure.OperationManager.Attempt(Action action, Int32 retries, Int32 delayBeforeRetry)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DoSafeAction(Action action, Boolean ignoreErrors)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo, Boolean ignoreErrors)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DeleteDirectoryContentsSafe(DirectoryInfoBase directoryInfo, Boolean ignoreErrors)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo, Boolean ignoreErrors)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DeleteDirectoryContentsSafe(DirectoryInfoBase directoryInfo, Boolean ignoreErrors)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DeleteFileSystemInfo(FileSystemInfoBase fileSystemInfo, Boolean ignoreErrors)
   at Kudu.Core.Infrastructure.FileSystemHelpers.DeleteDirectorySafe(String path, Boolean ignoreErrors)
   at Kudu.Core.SiteExtensions.SiteExtensionManager.&lt;&gt;c__DisplayClass69.&lt;EnsureInstallationEnviroment&gt;b__66()
   at Kudu.Core.Infrastructure.OperationManager.&lt;&gt;c__DisplayClass1.&lt;Attempt&gt;b__0()
   at Kudu.Core.Infrastructure.OperationManager.Attempt[T](Func`1 action, Int32 retries, Int32 delayBeforeRetry, Func`2 shouldRetry)
   at Kudu.Core.Infrastructure.OperationManager.Attempt(Action action, Int32 retries, Int32 delayBeforeRetry)
   at Kudu.Core.SiteExtensions.SiteExtensionManager.EnsureInstallationEnviroment(String installationDir, ITracer tracer)" /><!-- duration: 0ms -->
      <step title="Failed to cleanup. Moving leftover data to D:\home\data\Temp\SiteExtensions\Microsoft.ApplicationInsights.AzureWebSites-cbcf0c89" date="2015-05-11T19:52:55.277" /><!-- duration: 375ms -->
    </step><!-- duration: 2578ms -->
    <step title="Download site extension: Microsoft.ApplicationInsights.AzureWebSites.0.14.0.25797" date="2015-05-11T19:52:58.339" /><!-- duration: 578ms -->
    <step title="Check if applicationhost.xdt file existed." date="2015-05-11T19:52:58.933" /><!-- duration: 0ms -->
    <step title="Trigger site extension job" date="2015-05-11T19:52:58.933" /><!-- duration: 16ms -->
    <step title="Execute install.cmd" date="2015-05-11T19:52:58.948" >
      <step title="Executing external process" date="2015-05-11T19:52:58.964" type="process" path="install.cmd" arguments="" /><!-- duration: 21562ms -->
    </step><!-- duration: 21593ms -->
  </step><!-- duration: 27562ms -->
  <step title="Update arm settings for Microsoft.ApplicationInsights.AzureWebSites installation. Status: OK" date="2015-05-11T19:53:20.761" /><!-- duration: 205ms -->
  <step title="Outgoing response" date="2015-05-11T19:53:21.028" type="response" statusCode="200" statusText="OK" Server="Microsoft-IIS/8.0" x-ms-request-id="e30cca29-f687-4dbf-a547-9f5b84a2f708" Cache-Control="private" X-AspNet-Version="4.0.30319" Content-Type="application/json; charset=utf-8" /><!-- duration: 16ms -->
</step><!-- duration: 28767ms -->

````