### PR TITLE
ProcessController writing extraneous error logs

### DIFF
--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -106,6 +106,7 @@
     <Compile Include="OperationLockTests.cs" />
     <Compile Include="PathUtilityFacts.cs" />
     <Compile Include="ProcessApiFacts.cs" />
+    <Compile Include="ProcessExtensionsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PurgeDeploymentsTests.cs" />
     <Compile Include="RepositoryFactoryFacts.cs" />

--- a/Kudu.Core.Test/ProcessExtensionsFacts.cs
+++ b/Kudu.Core.Test/ProcessExtensionsFacts.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
+using Xunit;
+
+namespace Kudu.Core.Test
+{
+    public class ProcessExtensionsFacts
+    {
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("NotSCMAppPool", false)]
+        [InlineData("~1SCMAppPool", true)]
+        [InlineData("~1SCMAppPool", true)]
+        public void GetIsScmSite_ReturnsExpectedResult(string appPoolId, bool expectedValue)
+        {
+            Dictionary<string, string> environment = new Dictionary<string, string>();
+            if (appPoolId != null)
+            {
+                environment[WellKnownEnvironmentVariables.ApplicationPoolId] = appPoolId;
+            }
+
+            Assert.Equal(expectedValue, ProcessExtensions.GetIsScmSite(environment));
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", true)]
+        [InlineData("TestWebJob", true)]
+        public void GetIsWebJob_ReturnsExpectedResult(string webJobName, bool expectedValue)
+        {
+            Dictionary<string, string> environment = new Dictionary<string, string>();
+            if (webJobName != null)
+            {
+                environment[WellKnownEnvironmentVariables.WebJobsName] = webJobName;
+            }
+
+            Assert.Equal(expectedValue, ProcessExtensions.GetIsWebJob(environment));
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("TestJob", null, null)]
+        [InlineData(null, "Continuous", null)]
+        [InlineData("TestJob", "Continuous", "WebJob: TestJob, Type: Continuous")]
+        [InlineData("", "", "WebJob: , Type: ")]
+        public void GetDescription_WebJob_ReturnsExpectedResult(string webJobName, string webJobType, string expectedValue)
+        {
+            Dictionary<string, string> environment = new Dictionary<string, string>();
+            if (webJobName != null)
+            {
+                environment[WellKnownEnvironmentVariables.WebJobsName] = webJobName;
+            }
+            if (webJobType != null)
+            {
+                environment[WellKnownEnvironmentVariables.WebJobsType] = webJobType;
+            }
+
+            Assert.Equal(expectedValue, ProcessExtensions.GetDescription(environment));
+        }
+    }
+}

--- a/Kudu.Core/Infrastructure/ProcessExtensions.cs
+++ b/Kudu.Core/Infrastructure/ProcessExtensions.cs
@@ -244,7 +244,14 @@ namespace Kudu.Core.Infrastructure
 
         public static bool GetIsScmSite(Dictionary<string, string> environment)
         {
-            return environment[WellKnownEnvironmentVariables.ApplicationPoolId].StartsWith("~1", StringComparison.OrdinalIgnoreCase);
+            string appPool = null;
+            if (environment.TryGetValue(WellKnownEnvironmentVariables.ApplicationPoolId, out appPool) &&
+                !string.IsNullOrEmpty(appPool))
+            {
+                return appPool.StartsWith("~1", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
         }
 
         public static bool GetIsWebJob(Dictionary<string, string> environment)
@@ -255,7 +262,16 @@ namespace Kudu.Core.Infrastructure
         public static string GetDescription(Dictionary<string, string> environment)
         {
             const string webJobTemplate = "WebJob: {0}, Type: {1}";
-            return String.Format(webJobTemplate, environment[WellKnownEnvironmentVariables.WebJobsName], environment[WellKnownEnvironmentVariables.WebJobsType]);
+
+            string webJobName = null;
+            string webJobType = null;
+            if (environment.TryGetValue(WellKnownEnvironmentVariables.WebJobsName, out webJobName) &&
+                environment.TryGetValue(WellKnownEnvironmentVariables.WebJobsType, out webJobType))
+            {
+                return String.Format(webJobTemplate, webJobName, webJobType);
+            }
+
+            return null;
         }
 
         private static bool TryGetProcessHandle(this Process process, out IntPtr processHandle)

--- a/Kudu.Services.Test/Diagnostics/ProcessControllerFacts.cs
+++ b/Kudu.Services.Test/Diagnostics/ProcessControllerFacts.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.Tracing;
+using Kudu.Core;
+using Kudu.Core.Diagnostics;
+using Kudu.Services.Performance;
+using Moq;
+using Xunit;
+
+namespace Kudu.Services.Test.Diagnostics
+{
+    public class ProcessControllerFacts : IDisposable
+    {
+        private Mock<ITracer> _tracerMock;
+        private Mock<IEnvironment> _environmentMock;
+        private Mock<IDeploymentSettingsManager> _deploymentSettingsManagerMock;
+        private ProcessController _controller;
+
+        public ProcessControllerFacts()
+        {
+            _tracerMock = new Mock<ITracer>(MockBehavior.Strict);
+            _environmentMock = new Mock<IEnvironment>(MockBehavior.Strict);
+            _deploymentSettingsManagerMock = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+            _controller = new ProcessController(_tracerMock.Object, _environmentMock.Object, _deploymentSettingsManagerMock.Object);
+        }
+
+        [Fact]
+        public void SetEnvironmentInfo_NotWebJob_ReturnsExpectedResults()
+        {
+            Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
+            ProcessInfo processInfo = new ProcessInfo
+            {
+                EnvironmentVariables = environmentVariables
+            };
+            _controller.SetEnvironmentInfo(processInfo);
+
+            Assert.False(processInfo.IsScmSite);
+            Assert.False(processInfo.IsWebJob);
+            Assert.Null(processInfo.Description);
+        }
+
+        [Fact]
+        public void SetEnvironmentInfo_WebJob_ReturnsExpectedResults()
+        {
+            Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
+            environmentVariables.Add("APP_POOL_ID", "~1SCMPool");
+            environmentVariables.Add("WEBJOBS_NAME", "TestJob");
+            environmentVariables.Add("WEBJOBS_TYPE", "Continuous");
+            ProcessInfo processInfo = new ProcessInfo
+            {
+                EnvironmentVariables = environmentVariables
+            };
+            _controller.SetEnvironmentInfo(processInfo);
+
+            Assert.True(processInfo.IsScmSite);
+            Assert.True(processInfo.IsWebJob);
+            Assert.Equal("WebJob: TestJob, Type: Continuous", processInfo.Description);
+        }
+
+        public void Dispose()
+        {
+            if (_controller != null)
+            {
+                _controller.Dispose();
+            }
+        }
+    }
+}

--- a/Kudu.Services.Test/Kudu.Services.Test.csproj
+++ b/Kudu.Services.Test/Kudu.Services.Test.csproj
@@ -74,6 +74,7 @@
     <Compile Include="CodePlexHandlerFacts.cs" />
     <Compile Include="CustomGitRepositoryHandlerFacts.cs" />
     <Compile Include="DeploymentControllerFacts.cs" />
+    <Compile Include="Diagnostics\ProcessControllerFacts.cs" />
     <Compile Include="DropboxHelperFacts.cs" />
     <Compile Include="FileInfoBase.cs" />
     <Compile Include="FetchHandlerFacts.cs" />

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -398,15 +398,21 @@ namespace Kudu.Services.Performance
                 info.TimeStamp = DateTime.UtcNow;
                 info.EnvironmentVariables = SafeGetValue(process.GetEnvironmentVariables, null);
                 info.CommandLine = SafeGetValue(process.GetCommandLine, null);
-                if (info.EnvironmentVariables != null)
-                {
-                    info.IsScmSite = SafeGetValue(() => ProcessExtensions.GetIsScmSite(info.EnvironmentVariables), false);
-                    info.IsWebJob = SafeGetValue(() => ProcessExtensions.GetIsWebJob(info.EnvironmentVariables), false);
-                    info.Description = SafeGetValue(() => ProcessExtensions.GetDescription(info.EnvironmentVariables), null);
-                }
+
+                SetEnvironmentInfo(info);
             }
 
             return info;
+        }
+
+        internal void SetEnvironmentInfo(ProcessInfo processInfo)
+        {
+            if (processInfo.EnvironmentVariables != null)
+            {
+                processInfo.IsScmSite = SafeGetValue(() => ProcessExtensions.GetIsScmSite(processInfo.EnvironmentVariables), false);
+                processInfo.IsWebJob = SafeGetValue(() => ProcessExtensions.GetIsWebJob(processInfo.EnvironmentVariables), false);
+                processInfo.Description = SafeGetValue(() => ProcessExtensions.GetDescription(processInfo.EnvironmentVariables), null);
+            }
         }
 
         private Process GetProcessById(int id)


### PR DESCRIPTION
When determining ProcessInfo, Process controller was tracing errors when it shouldn't be, based on invalid dictionary lookups being done by ProcessExtensions. This issue was reported by a customer in the below forum thread. Fixed the helpers to use TryGetValue.

https://social.msdn.microsoft.com/Forums/en-US/02d4bc1d-06b5-48e5-8fcd-5bde8a495b07/azure-web-apps-responses-empty?forum=windowsazurewebsitespreview