### PR TITLE
Added default option to not init async lock in SiteExtensionInstallat…

### DIFF
--- a/Kudu.Core/SiteExtensions/SiteExtensionInstallationLock.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionInstallationLock.cs
@@ -24,7 +24,7 @@ namespace Kudu.Core.SiteExtensions
             try
             {
                 string folder = Path.GetDirectoryName(_path);
-                if (FileSystemHelpers.GetFiles(folder, "*").Length == 0)
+                if (FileSystemHelpers.DirectoryExists(folder) && FileSystemHelpers.GetFiles(folder, "*").Length == 0)
                 {
                     FileSystemHelpers.DeleteDirectorySafe(folder);
                 }
@@ -39,11 +39,16 @@ namespace Kudu.Core.SiteExtensions
         /// <para>Will create a file lock like this: {rootPath}/{site extension id}/install.lock</para>
         /// <para>e.g 'D:\home\site\siteextension\filecounter\install.lock'</para>
         /// </summary>
-        public static SiteExtensionInstallationLock CreateLock(string rootPath, string id)
+        public static SiteExtensionInstallationLock CreateLock(string rootPath, string id, bool enableAsync = false)
         {
             string lockFilePath = Path.Combine(rootPath, id, LockNameSuffix);
             var installationLock = new SiteExtensionInstallationLock(lockFilePath);
-            installationLock.InitializeAsyncLocks();
+
+            if (enableAsync)
+            {
+                installationLock.InitializeAsyncLocks();
+            }
+
             return installationLock;
         }
 

--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -299,7 +299,7 @@ namespace Kudu.Core.SiteExtensions
         {
             try
             {
-                var installationLock = SiteExtensionInstallationLock.CreateLock(_environment.SiteExtensionSettingsPath, id);
+                var installationLock = SiteExtensionInstallationLock.CreateLock(_environment.SiteExtensionSettingsPath, id, enableAsync: true);
                 // hold on to lock till action complete (success or fail)
                 return await installationLock.LockOperationAsync<SiteExtensionInfo>(async () =>
                 {


### PR DESCRIPTION
To avoid folder create->delete->create, added default option to not init async lock in SiteExtensionInstallationLock. 
since "InitializeAsyncLocks" will always try to ensure folder exist, while for site extension installation. if it is a brand new installation, folder would not be there at the first place.