### PR TITLE
Editor font is now monospace

### DIFF
--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -102,7 +102,9 @@
                     &nbsp;
                     <button class="btn" data-bind="click: cancelEdit">Cancel</button>
                 </p>
-                <textarea class="span12 form-control" rows="20" id="txtarea" data-bind="value: editText, valueUpdate: 'afterkeydown'"></textarea>
+                <pre>
+                    <textarea class="span12 form-control" rows="20" id="txtarea" data-bind="value: editText, valueUpdate: 'afterkeydown'"></textarea>
+                </pre>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Wrapped `<textarea>` in `<pre></pre>` for the lightweight text editor.

As per `bootstrap.css v3.1.1`, `<pre>` gets styled like this:

```css
code,
kbd,
pre,
samp {
  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
}
```

Assuming this `Menlo` thing is what Safari defaults to for monospaced text..
I trust the Bootstrap people for putting in the work here and testing for multiple platforms.

Tested by me on Windows 10 in Chrome and IE.
http://i.imgur.com/p3FnXKh.png