### PR TITLE
Disable schedule webjob when it is Basic site

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -84,5 +84,8 @@ namespace Kudu
         public const string SiteExtensionProvisioningStateNotFoundMessageFormat = "'{0}' not found.";
         public const string SiteExtensionProvisioningStateDownloadFailureMessageFormat = "'{0}' download failure.";
         public const string SiteExtensionProvisioningStateInvalidPackageMessageFormat = "Invalid '{0}' package.";
+
+        public const string FreeSKU = "Free";
+        public const string BasicSKU = "Basic";
     }
 }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -248,7 +248,8 @@ namespace Kudu.Services.Web.App_Start
                 triggeredJobsManager,
                 noContextTraceFactory,
                 kernel.Get<IAnalytics>(),
-                environment);
+                environment,
+                kernel.Get<IDeploymentSettingsManager>());
 
             kernel.Bind<TriggeredJobsScheduler>().ToConstant(triggeredJobsScheduler)
                                              .InTransientScope();

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -10,7 +10,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Web.Http;
-using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
 using Kudu.Core;
@@ -24,8 +23,6 @@ namespace Kudu.Services.Performance
 {
     public class ProcessController : ApiController
     {
-        private const string FreeSiteSku = "Free";
-
         private readonly ITracer _tracer;
         private readonly IEnvironment _environment;
         private readonly IDeploymentSettingsManager _settings;
@@ -152,7 +149,7 @@ namespace Kudu.Services.Performance
                 }
 
                 string siteSku = _settings.GetWebSiteSku();
-                if ((MINIDUMP_TYPE)dumpType == MINIDUMP_TYPE.WithFullMemory && siteSku.Equals(FreeSiteSku, StringComparison.OrdinalIgnoreCase))
+                if ((MINIDUMP_TYPE)dumpType == MINIDUMP_TYPE.WithFullMemory && siteSku.Equals(Constants.FreeSKU, StringComparison.OrdinalIgnoreCase))
                 {
                     return Request.CreateErrorResponse(HttpStatusCode.InternalServerError,
                         String.Format(CultureInfo.CurrentCulture, Resources.Error_FullMiniDumpNotSupported, siteSku));


### PR DESCRIPTION
when site is basic, upload a trigger job with scheduled setting will see below log:
````
[07/02/2015 23:12:42 > 0f3ee9: SYS INFO] 'Basic' tier website doesn`t support scheduled WebJob.
````

when site was other SKU but not Basic, and later change to Basic, will see below log:
````
[07/02/2015 23:00:42 > 0f31d2: SYS INFO] Scheduling WebJob with 0,10,20,30,40,50 * * * * * next schedule expected in 00:00:00
[07/02/2015 23:00:42 > 0f31d2: SYS INFO] WebJob invoked
[07/02/2015 23:00:42 > 0f31d2: SYS INFO] Next schedule expected in 00:00:07.2740780
[07/02/2015 23:00:50 > 0f31d2: SYS INFO] WebJob invoked
[07/02/2015 23:00:50 > 0f31d2: SYS INFO] Next schedule expected in 00:00:09.9296460
[07/02/2015 23:01:00 > 0f31d2: SYS INFO] WebJob invoked
[07/02/2015 23:01:00 > 0f31d2: SYS INFO] Next schedule expected in 00:00:09.8526465
[07/02/2015 23:01:10 > 0f31d2: SYS INFO] WebJob invoked
[07/02/2015 23:01:10 > 0f31d2: SYS INFO] Next schedule expected in 00:00:09.9154028
[07/02/2015 23:01:21 > 0f31d2: SYS INFO] WebJob invoked
[07/02/2015 23:01:21 > 0f31d2: SYS INFO] Next schedule expected in 00:00:08.7271807
[07/02/2015 23:01:59 > 0f3ee9: SYS INFO] 'Basic' tier website doesn`t support scheduled WebJob.
````