### PR TITLE
Fix to force IE to not use compatibility mode

### DIFF
--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
@@ -32,6 +32,12 @@
     </system.webServer>
   </location>
   <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <!-- This forces IE to not use compatibility mode, which Kudu is broken for -->
+        <add name="X-UA-Compatible" value="IE=edge" />
+      </customHeaders>
+    </httpProtocol>
     <security>
       <requestFiltering>
         <requestLimits maxAllowedContentLength="4294967295" />

--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -32,12 +32,6 @@
     </system.webServer>
   </location>
   <system.webServer>
-    <httpProtocol>
-      <customHeaders>
-        <!-- This forces IE to not use compatibility mode, which Kudu is broken for -->
-        <add name="X-UA-Compatible" value="IE=edge" />
-      </customHeaders>
-    </httpProtocol>
     <security>
       <requestFiltering>
         <requestLimits maxAllowedContentLength="4294967295" />

--- a/Kudu.Services.Web/_Layout.cshtml
+++ b/Kudu.Services.Web/_Layout.cshtml
@@ -2,6 +2,8 @@
 
 <html>
 <head>
+    <!-- This forces IE to not use compatibility mode, which Kudu is broken for -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width" charset="utf-8" />
     <title>@Page.Title</title>
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet" />


### PR DESCRIPTION
By default IE displays intranet sites in compatibility mode. The SCM site appears broken when it is displayed in compatibility mode. Many OnPrem deployments would be run on the local intranet, hence by default, the SCM sites for those deployments would appear to be broken. This PR fixes that behavior.
TFS work item ID: 4285419