### PR TITLE
Ace is now the code editor in DebugConsole

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -1,0 +1,59 @@
+// Resize editor window based on browser window.innerHeight
+function resizeAce() {
+    // http://stackoverflow.com/questions/11584061/
+    var new_height = (window.innerHeight - 170) + 'px';
+    $('#editor').css({'height': new_height});
+    editor.resize();
+}
+
+
+// Additional syntax highlight logic
+function getCustomMode(filename) {
+    var _config = (/^(web|app).config$/i);
+    var _csproj = (/.(cs|vb)proj$/i);
+    var syntax_mode = 'ace/mode/text';
+    if (
+        filename.match(_config) ||
+        filename.match(_csproj)
+       )
+    {
+        syntax_mode = 'ace/mode/xml';
+    }
+    return syntax_mode;
+}
+
+
+// Init Ace
+var editor = ace.edit("editor");
+editor.setTheme("ace/theme/github");
+editor.getSession().setTabSize(4);
+editor.getSession().setUseSoftTabs(true);
+editor.$blockScrolling = Infinity;
+editor.setOptions({
+    "showPrintMargin": false,
+    "fontSize": 14
+});
+
+
+// Hook the little pencil glyph and apply Ace syntax mode based on file extension
+$('#fileList').on('click', '.glyphicon-pencil', function () {
+    if ($('.edit-view').is(':visible')) {
+        var filename = (window.viewModel.fileEdit.peek()).name();
+	if (typeof filename !== 'undefined') {
+            var modelist = ace.require('ace/ext/modelist');
+	    var mode = modelist.getModeForPath(filename).mode;
+            if (mode === 'ace/mode/text') {
+	        mode = getCustomMode(filename);
+	    }
+            // Apply computed syntax mode or default to 'ace/mode/text'
+            editor.session.setMode(mode);
+	}
+	// Initial Ace resize (in height)
+        resizeAce();
+	// Attach event handler to set new Ace height on browser resize
+        $(window).on('resize', function () {
+            resizeAce();
+        });
+    }
+});
+

--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -38,12 +38,13 @@ editor.setOptions({
 // Hook the little pencil glyph and apply Ace syntax mode based on file extension
 $('#fileList').on('click', '.glyphicon-pencil', function () {
     if ($('.edit-view').is(':visible')) {
+        var filename;
         try {
-            var filename = (window.viewModel.fileEdit.peek()).name();
+            filename = (window.viewModel.fileEdit.peek()).name();
         }
         catch (e) {
             if (typeof console == 'object') {
-                    console.log('Can\'t get filename. ' + e);
+                console.log('Can\'t get filename. ' + e);
             }
         }
         finally {

--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -38,22 +38,30 @@ editor.setOptions({
 // Hook the little pencil glyph and apply Ace syntax mode based on file extension
 $('#fileList').on('click', '.glyphicon-pencil', function () {
     if ($('.edit-view').is(':visible')) {
-        var filename = (window.viewModel.fileEdit.peek()).name();
-	if (typeof filename !== 'undefined') {
-            var modelist = ace.require('ace/ext/modelist');
-	    var mode = modelist.getModeForPath(filename).mode;
-            if (mode === 'ace/mode/text') {
-	        mode = getCustomMode(filename);
-	    }
-            // Apply computed syntax mode or default to 'ace/mode/text'
-            editor.session.setMode(mode);
-	}
-	// Initial Ace resize (in height)
-        resizeAce();
-	// Attach event handler to set new Ace height on browser resize
-        $(window).on('resize', function () {
+        try {
+            var filename = (window.viewModel.fileEdit.peek()).name();
+        }
+        catch (e) {
+            if (typeof console == 'object') {
+                    console.log('Can\'t get filename. ' + e);
+            }
+        }
+        finally {
+            if (typeof filename !== 'undefined') {
+                var modelist = ace.require('ace/ext/modelist');
+                var mode = modelist.getModeForPath(filename).mode;
+                if (mode === 'ace/mode/text') {
+                    mode = getCustomMode(filename);
+                }
+                // Apply computed syntax mode or default to 'ace/mode/text'
+                editor.session.setMode(mode);
+            }
+            // Set Ace height
             resizeAce();
-        });
+            // Attach event handler to set new Ace height on browser resize
+            $(window).on('resize', function () {
+                resizeAce();
+            });
+        }
     }
 });
-

--- a/Kudu.Services.Web/Content/Scripts/knockout-ace.js
+++ b/Kudu.Services.Web/Content/Scripts/knockout-ace.js
@@ -1,0 +1,75 @@
+// Based on Knockout Bindings for TinyMCE
+// https://github.com/SteveSanderson/knockout/wiki/Bindings---tinyMCE
+// Initial version by Ryan Niemeyer. Updated by Scott Messinger, Frederik Raabye, Thomas Hallock, Drew Freyling, and Shane Carr.
+
+(function() {
+  var instances_by_id = {} // needed for referencing instances during updates.
+  , init_id = 0;           // generated id increment storage
+
+  ko.bindingHandlers.ace = {
+    init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+
+      var options = allBindingsAccessor().aceOptions || {};
+      var value = ko.utils.unwrapObservable(valueAccessor());
+
+      // Ace attaches to the element by DOM id, so we need to make one for the element if it doesn't have one already.
+      if (!element.id) {
+        element.id = 'knockout-ace-' + init_id;
+        init_id = init_id + 1;
+      }
+
+      var editor = ace.edit( element.id );
+
+      if ( options.theme ) editor.setTheme("ace/theme/" + options.theme);
+      if ( options.mode ) editor.getSession().setMode("ace/mode/" + options.mode);
+      if ( options.readOnly ) editor.setReadOnly(true);
+
+      editor.setValue(value);
+      editor.gotoLine( 0 );
+
+      editor.getSession().on("change",function(delta){
+        if (ko.isWriteableObservable(valueAccessor())) {
+          valueAccessor()( editor.getValue() );
+        }
+      });
+
+      instances_by_id[element.id] = editor;
+
+      // destroy the editor instance when the element is removed
+      ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+        editor.destroy();
+        delete instances_by_id[element.id];
+      });
+    },
+    update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+      var value = ko.utils.unwrapObservable(valueAccessor());
+      var id = element.id;
+
+      //handle programmatic updates to the observable
+      // also makes sure it doesn't update it if it's the same.
+      // otherwise, it will reload the instance, causing the cursor to jump.
+      if (id !== undefined && id !== '' && instances_by_id.hasOwnProperty(id)) {
+        var editor = instances_by_id[id];
+        var content = editor.getValue();
+        if (content !== value) {
+          editor.setValue(value);
+          editor.gotoLine( 0 );
+        }
+      }
+    }
+  };
+
+  ko.aceEditors = {
+    resizeAll: function(){
+      for (var id in instances_by_id) {
+        if (!instances_by_id.hasOwnProperty(id)) continue;
+        var editor = instances_by_id[id];
+        editor.resize();
+      }
+    },
+    get: function(id){
+      return instances_by_id[id];
+    }
+  };
+}());
+

--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -6,6 +6,10 @@
 @section PageHead {
     <link href="~/content/styles/filebrowser.css" rel="stylesheet" />
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.2/css/font-awesome.css" rel="stylesheet" />
+    <script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-2.2.1.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.9/ace.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.9/ext-modelist.js" type="text/javascript"></script>
+    <script src="~/content/scripts/knockout-ace.js" type="text/javascript"></script>
 }
 
 <div id="main" class="container">
@@ -55,6 +59,10 @@
                                     <a data-bind="attr: { href: url() }" target="_blank">
                                         <i class="glyphicon glyphicon-download-alt" title="Download"></i>
                                     </a>
+                                    <!--
+					 Ace hooks an event handler on glyphicon-pencil.
+                                         See ~/content/scripts/ace-init.js
+				    -->
                                     <span data-bind="if: !isDirectory()">
                                         <a data-bind="click: editItem" href="#">
                                             <i class="glyphicon glyphicon-pencil" title="Edit"></i>
@@ -97,19 +105,16 @@
         <div class="form-group">
             <form role="form">
                 <p>
-                    &nbsp;
-                    <button class="btn btn-primary btn-default" data-bind="click: function () { return fileEdit().saveItem(); }">Save</button>
-                    &nbsp;
-                    <button class="btn" data-bind="click: cancelEdit">Cancel</button>
+                    <button class="btn btn-primary btn-default" style="margin-right: 10px" data-bind="click: function () { return fileEdit().saveItem(); }">Save</button>
+                    <button class="btn" style="margin-right: 10px" data-bind="click: cancelEdit">Cancel</button>
                 </p>
-                <pre>
-                    <textarea class="span12 form-control" rows="20" id="txtarea" data-bind="value: editText, valueUpdate: 'afterkeydown'" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
-                </pre>
+                <!-- Ace editor starts -->
+                <div id="editor" data-bind="ace: editText" style="position: relative; width: inherit"></div>
+                <!-- Ace editor ends -->
             </form>
         </div>
     </div>
 </div>
-<script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-2.2.1.js"></script>
 <script src="~/content/scripts/jquery.signalR-2.1.1.min.js"></script>
 <script src="~/content/scripts/kuduexec.js"></script>
 <script src="~/content/scripts/kuduexecV2.js"></script>
@@ -117,3 +122,4 @@
 <script src="~/content/scripts/vkbeautify.0.99.00.beta.js"></script>
 <script src="~/content/scripts/filebrowser.js"></script>
 <script src="~/content/scripts/jquery-console/jquery.console.js"></script>
+<script src="~/content/scripts/ace-init.js"></script>

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -162,6 +162,8 @@
     <Content Include="Content\Styles\ProcessExplorer.css" />
     <Content Include="Content\Styles\SiteExtensions.css" />
     <Content Include="Content\Scripts\jquery.signalR-2.1.1.min.js" />
+    <Content Include="Content\Scripts\knockout-ace.js" />
+    <Content Include="Content\Scripts\ace-init.js" />
     <Content Include="Web.config">
       <SubType>Designer</SubType>
     </Content>


### PR DESCRIPTION
Ace (http://ace.c9.io/) is now the code editor in `/DebugConsole`. Replaces the basic `<textarea>` editor.

__Preview:__
![kuduace](https://cloud.githubusercontent.com/assets/6472374/8645272/8d8999fa-294e-11e5-9775-e063bb93363e.PNG)

Taking new external dependency for `ace.js`:
`https://cdnjs.cloudflare.com`

Uses __knockout-ace.js__ bindings from https://github.com/probonogeek/knockout-ace
(loads them from local storage, `~/content/scripts`)