### PR TITLE
Added status bar to Ace editor

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -1,6 +1,6 @@
-﻿// Custom status bar for Ace
-var statusbar;
-statusbar = {
+// Custom status bar for Ace (aka Project Wunderbar)
+var azure = '#5bc0de';
+var statusbar = {
     showFilename:
         function () {
             var filename;
@@ -8,32 +8,35 @@ statusbar = {
                 filename = viewModel.fileEdit.peek().name();
             }
             catch(e) {
-                filename = e;
+                filename = 'Can not get filename. See console for details.';
+                if (typeof console == 'object') {
+                    console.log('Can not get filename: %s', e);
+                }
             }
             finally {
                 $('#statusbar').text(filename);
-                $('#statusbar').css('border-left-color', '#5bc0de');
+                $('#statusbar').css('border-left-color', azure);
             }
         },
     reset:
-    function () {
+        function () {
             $('#statusbar').text('');
-            $('#statusbar').css('border-left-color', '#5bc0de')
+            $('#statusbar').css('border-left-color', azure);
         },
     SavingChanges:
-    function () {
+        function () {
             $('#statusbar').text('Saving changes...');
             $('#statusbar').prepend('<i class="glyphicon glyphicon-cloud-upload" style="margin-right: 6px"></i>');
          },
     FetchingChanges:
         function () {
-            $('#statusbar').css('border-left-color', '#5bc0de')
+            $('#statusbar').css('border-left-color', azure);
             $('#statusbar').text('Fetching changes...');
             $('#statusbar').prepend('<i class="glyphicon glyphicon-cloud-download" style="margin-right: 6px"></i>');
         }
 }
 
-statusbarObj = Object.create(statusbar);
+var statusbarObj = Object.create(statusbar);
 
 $.connection.hub.url = appRoot + "api/filesystemhub";
 var fileSystemHub = $.connection.fileSystemHub;

--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -257,8 +257,8 @@ $.connection.hub.start().done(function () {
             fileEdit: ko.observable(null),
             editText: ko.observable(""),
             cancelEdit: function () {
-            viewModel.fileEdit(null);
-            statusbarObj.reset();
+                viewModel.fileEdit(null);
+                statusbarObj.reset();
             },
             selectSpecialDir: function (name) {
                 var item = viewModel.specialDirsIndex()[name];

--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -35,6 +35,12 @@ editor.setOptions({
 });
 
 
+// Show a red bar if content has changed
+editor.on('change', function() {
+   $('#statusbar').css('border-left-color', '#f14');
+});
+
+
 // Hook the little pencil glyph and apply Ace syntax mode based on file extension
 $('#fileList').on('click', '.glyphicon-pencil', function () {
     if ($('.edit-view').is(':visible')) {

--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -108,13 +108,13 @@ div.console {
         animation: blink 1s steps(5, start) infinite;
         -webkit-animation: blink 1s steps(5, start) infinite;
     }
-    
+
     @-webkit-keyframes blink {
        to {
             visibility: hidden;
         }
     }
-    
+
     @keyframes blink {
        to {
             visibility: hidden;
@@ -171,4 +171,15 @@ textarea {
 
 .right {
     float: right;
+}
+
+.statusbar {
+    padding: 7px 18px;
+    margin-left: 40px;
+    margin-bottom: 0;
+    border: 2px solid #eee;
+    border-radius: 4px;
+    border-left-width: 4px;
+    border-left-color: #5bc0de;
+    vertical-align: middle;
 }

--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -182,4 +182,9 @@ textarea {
     border-left-width: 4px;
     border-left-color: #5bc0de;
     vertical-align: middle;
+    display: inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    /* text-overflow: ellipsis; */
+    max-width: 800px;
 }

--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -60,9 +60,9 @@
                                         <i class="glyphicon glyphicon-download-alt" title="Download"></i>
                                     </a>
                                     <!--
-					 Ace hooks an event handler on glyphicon-pencil.
-                                         See ~/content/scripts/ace-init.js
-				    -->
+                                        Ace hooks an event handler on glyphicon-pencil.
+                                        See ~/content/scripts/ace-init.js
+                                    -->
                                     <span data-bind="if: !isDirectory()">
                                         <a data-bind="click: editItem" href="#">
                                             <i class="glyphicon glyphicon-pencil" title="Edit"></i>
@@ -107,6 +107,7 @@
                 <p>
                     <button class="btn btn-primary btn-default" style="margin-right: 10px" data-bind="click: function () { return fileEdit().saveItem(); }">Save</button>
                     <button class="btn" style="margin-right: 10px" data-bind="click: cancelEdit">Cancel</button>
+                    <span id="statusbar" class="statusbar"></span>
                 </p>
                 <!-- Ace editor starts -->
                 <div id="editor" data-bind="ace: editText" style="position: relative; width: inherit"></div>


### PR DESCRIPTION
Added a status bar to Ace editor next to `Save`  /  `Cancel`.

#### Here's how it looks: ####

Consider the file name: __some.json__

When file is untouched:
![barblue](https://cloud.githubusercontent.com/assets/6472374/8875534/910489a0-3222-11e5-9315-4ca3d0eccfee.PNG)

When content has changed:
![barred](https://cloud.githubusercontent.com/assets/6472374/8875537/a0421b26-3222-11e5-9bb3-9879c2cc5d4b.PNG)

Bonus, cloudy glyphs for Save and Fetch:
![barsaving](https://cloud.githubusercontent.com/assets/6472374/8875588/ff965a56-3222-11e5-806b-f0684da1dc02.png)

Not entirely sure about the placement and the styling, but i consider it quite useful.

__Tested OK in__:
>IE11 (Win10 build 10240)
>IE10 (Win8 6.2.9200)
>Chrome 43 (wasn't it 42 yesterday? What is this, a pedometer?)
>MS Edge (Win10 build 10240)
>Firefox 39