### PR TITLE
Type conversion unnecessary

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -172,7 +172,7 @@ $.connection.hub.start().done(function () {
             var that = this;
             viewModel.editText("Fetching changes...");
             viewModel.fileEdit(this);
-            if(this.mime == "text/xml")
+            if(this.mime === "text/xml")
             {
                 Vfs.getContent(this)
                    .done(function (data) {


### PR DESCRIPTION
`if(this.mime == "text/xml)`

Credits to @shrimpy.
https://github.com/projectkudu/kudu/pull/1635#issuecomment-124707732