### PR TITLE
Fix Ace editor focus after load

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -65,6 +65,7 @@ $('#fileList').on('click', '.glyphicon-pencil', function () {
             }
             // Set Ace height
             resizeAce();
+            editor.focus();
             // Attach event handler to set new Ace height on browser resize
             $(window).on('resize', function () {
                 resizeAce();

--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -174,10 +174,10 @@ textarea {
 }
 
 .statusbar {
-    padding: 7px 18px;
-    margin-left: 40px;
+    padding: 6px 18px;
+    margin-left: 35px;
     margin-bottom: 0;
-    border: 2px solid #eee;
+    border: 1px solid #eee;
     border-radius: 4px;
     border-left-width: 4px;
     border-left-color: #5bc0de;


### PR DESCRIPTION
Ace editor now comes into focus after loading: `editor.focus()`. Thanks @davidebbo 
Also, the statusbar padding was 1px off.