### PR TITLE
Replacing XmlLogger with StructuredTextLogger for deployment logs to improve performance

### DIFF
--- a/Kudu.Contracts/Deployment/IDetailedLogger.cs
+++ b/Kudu.Contracts/Deployment/IDetailedLogger.cs
@@ -1,0 +1,15 @@
+﻿using Kudu.Core.Deployment;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kudu.Core.Deployment
+{
+    public interface IDetailedLogger : ILogger
+    {
+        IEnumerable<LogEntry> GetLogEntries();
+        IEnumerable<LogEntry> GetLogEntryDetails(string entryId);
+    }
+}

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Deployment\IDeploymentManagerFactory.cs" />
     <Compile Include="Deployment\IDeploymentStatusManager.cs" />
     <Compile Include="Deployment\IDeploymentStatusFile.cs" />
+    <Compile Include="Deployment\IDetailedLogger.cs" />
     <Compile Include="Deployment\ILogger.cs" />
     <Compile Include="Deployment\LogEntry.cs" />
     <Compile Include="Deployment\LogEntryType.cs" />

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -119,6 +119,8 @@
     <Compile Include="Settings\DeploymentSettingsPrioritiesTests.cs" />
     <Compile Include="Settings\SettingsProvidersTests.cs" />
     <Compile Include="SSHKeyManagerFacts.cs" />
+    <Compile Include="StructuredTextDocumentFacts.cs" />
+    <Compile Include="StructuredTextLoggerFacts.cs" />
     <Compile Include="Tracing\XmlTracerTests.cs" />
     <Compile Include="Tracing\SiteExtensionLogManagerTests.cs" />
     <Compile Include="TraceModuleFacts.cs" />

--- a/Kudu.Core.Test/MockFileSystem.cs
+++ b/Kudu.Core.Test/MockFileSystem.cs
@@ -49,6 +49,11 @@ namespace Kudu.Core.Test
                             return reader.ReadToEnd();
                         }
                     });
+            fileBase.Setup(f => f.ReadAllLines(It.IsAny<string>()))
+                    .Returns((string path) =>
+                    {
+                        return fileBase.Object.ReadAllText(path).Split(new[] { System.Environment.NewLine }, StringSplitOptions.None);
+                    });
 
             dirInfoFactory.Setup(d => d.FromDirectoryName(It.IsAny<string>()))
                           .Returns(dirInfoBase.Object);

--- a/Kudu.Core.Test/StructuredTextDocumentFacts.cs
+++ b/Kudu.Core.Test/StructuredTextDocumentFacts.cs
@@ -1,0 +1,107 @@
+﻿using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
+using Moq;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using Xunit;
+
+namespace Kudu.Core.Test
+{
+    public class StructuredTextDocumentFacts
+    {
+        public T Id<T>(T obj)
+        {
+            return obj;
+        }
+
+        [Theory]
+        [InlineData("\tInvalid log entry that starts with \\t")]
+        [InlineData("Invalid log entry \n that contains a \\n")]
+        public void StructuredDocumentThrowsAFormatExceptionForInvalidLogEntries(string logEntry)
+        {
+            //Arrange
+            Exception exception = null;
+            var structuredDocument = new StructuredTextDocument<string>(@"x:\deployment\log.log", Id, Id);
+
+            //Act
+            try
+            {
+                structuredDocument.Write(logEntry, 0);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            //Assert
+            Assert.IsType(typeof(FormatException), exception);
+            Assert.Contains("Serialized log of type", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("log entry 1", 0)]
+        [InlineData("log entry 2", 5)]
+        [InlineData("log entry 3", 11)]
+        public void StructuredDocumentLogsWithCorrectDepth(string logEntry, int depth)
+        {
+            //Arrange
+            var fileSystem = new Mock<IFileSystem>();
+            var fileBase = new Mock<FileBase>();
+            var stream = new TestMemoryStream();
+            var structuredDocument = new StructuredTextDocument<string>(@"x:\log.log", Id, Id);
+            fileSystem.Setup(f => f.File).Returns(fileBase.Object);
+
+            fileBase.Setup(f => f.Open(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()))
+                    .Returns(stream);
+            FileSystemHelpers.Instance = fileSystem.Object;
+
+            //Act
+            structuredDocument.Write(logEntry, depth);
+
+            //Assert
+            Assert.True(stream.Position > 0, "must write data");
+            stream.Position = 0;
+            var result = new StreamReader(stream).ReadToEnd();
+            var writtenDepth = StructuredTextDocument.GetEntryDepth(result);
+            Assert.Equal(depth, writtenDepth);
+            Assert.Equal(string.Concat(logEntry, System.Environment.NewLine), result.Substring(writtenDepth));
+            stream.RealDispose();
+        }
+
+        [Fact]
+        public void StructuredDocumentParsingTest()
+        {
+            //Arrange
+            FileSystemHelpers.Instance = MockFileSystem.GetMockFileSystem(@"x:\log.log", () => "Message 1\r\nmessage 2\r\nmessage 3\r\n\tsub message 3.1\r\n\tsub message 3.2\r\n\tsub message 3.3\r\nmessage 4\r\n\tsub message 4.1");
+            var ExpectedContent = new int[] { 0, 0, 3 , 1 };
+            var structuredDocument = new StructuredTextDocument<string>(@"x:\log.log", Id, Id);
+
+            //Act
+            var parsed = structuredDocument.GetDocument().ToArray();
+
+            //Assert
+            Assert.Equal(4, parsed.Length);
+            for (var i = 0; i < parsed.Count(); i++)
+            {
+                Assert.Equal(ExpectedContent[i], parsed[i].Children.Count());
+            }
+        }
+
+        internal class TestMemoryStream : MemoryStream
+        {
+            public void RealDispose()
+            {
+                base.Dispose();
+            }
+
+            [SuppressMessage("Microsoft.Usage", "CA2215", Justification = "We need the stream to still be readable after using statement")] 
+            protected override void Dispose(bool disposing)
+            {
+                //no-op for testing
+            }
+        }
+    }
+}

--- a/Kudu.Core.Test/StructuredTextLoggerFacts.cs
+++ b/Kudu.Core.Test/StructuredTextLoggerFacts.cs
@@ -1,0 +1,80 @@
+﻿using Kudu.Core.Deployment;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
+using Moq;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using Xunit;
+
+namespace Kudu.Core.Test
+{
+    public class StructuredTextLoggerFacts
+    {
+        [Theory]
+        [InlineData("This message is clean from any illegal characters", LogEntryType.Message)]
+        [InlineData("This message has \"double quotes\" in it.", LogEntryType.Error)]
+        [InlineData("This message has \n new lines \r\n in it", LogEntryType.Warning)]
+        public void StructuredTextLoggerLogFunction(string message, LogEntryType type)
+        {
+            //Arrange
+            var fileSystem = new Mock<IFileSystem>();
+            var fileBase = new Mock<FileBase>();
+            var stream = new TestMemoryStream();
+            var analytics = new Mock<IAnalytics>();
+            var logger = new StructuredTextLogger(@"x:\log.log", analytics.Object);
+
+            fileSystem.Setup(f => f.File).Returns(fileBase.Object);
+
+            fileBase.Setup(f => f.Open(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()))
+                    .Returns(stream);
+            fileBase.Setup(f => f.OpenRead(It.IsAny<string>()))
+                    .Returns((string path) => 
+                    {
+                        stream.Position = 0;
+                        return stream;
+                    });
+            fileBase.Setup(f => f.ReadAllText(It.IsAny<string>()))
+                    .Returns((string path) =>
+                    {
+                        using (var reader = new StreamReader(fileBase.Object.OpenRead(path)))
+                        {
+                            return reader.ReadToEnd();
+                        }
+                    });
+            fileBase.Setup(f => f.ReadAllLines(It.IsAny<string>()))
+                    .Returns((string path) =>
+                    {
+                        return fileBase.Object.ReadAllText(path).Split(new[] { System.Environment.NewLine }, StringSplitOptions.None);
+                    });
+
+            FileSystemHelpers.Instance = fileSystem.Object;
+
+            //Act
+            logger.Log(message, type);
+            var entries = logger.GetLogEntries();
+
+            //Assert
+            Assert.Equal(1, entries.Count());
+            Assert.Equal(message, entries.First().Message);
+            Assert.Equal(type, entries.First().Type);
+            stream.RealDispose();
+        }
+
+        internal class TestMemoryStream : MemoryStream
+        {
+            public void RealDispose()
+            {
+                base.Dispose();
+            }
+
+            [SuppressMessage("Microsoft.Usage", "CA2215", Justification = "We need the stream to still be readable after using statement")] 
+            protected override void Dispose(bool disposing)
+            {
+                //no-op for testing
+            }
+        }
+    }
+}

--- a/Kudu.Core/Deployment/StructuredTextDocument.cs
+++ b/Kudu.Core/Deployment/StructuredTextDocument.cs
@@ -1,0 +1,129 @@
+﻿using Kudu.Core.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kudu.Core.Deployment
+{
+    public class StructuredTextDocument<T>
+    {
+        private const string LogTemplate = "{0}{1}";
+        private readonly string _path;
+        private readonly Func<T, string> _serializer;
+        private readonly Func<string, T> _deserializer;
+
+        public StructuredTextDocument(string path, Func<T, string> serializer, Func<string, T> deserializer)
+        {
+            _path = path;
+            _serializer = serializer;
+            _deserializer = deserializer;
+        }
+
+        public IEnumerable<StructuredTextDocumentEntry<T>> GetDocument()
+        {
+            return ParseLines(FileSystemHelpers.ReadAllLines(_path), startIndex: 0, depth: 0);
+        }
+
+        /// <summary>
+        /// Write uses the serializer that was specified in the constructor to convert T into a string
+        /// then logs it with the correct depth.
+        /// The depth determines how many \t are there in front of the log message. Which implies the
+        /// Parent/Child relationship between the log entries.
+        /// Here is an example of how the log looks like with 1 level of depth
+        /// 0000-00-00T00:00:00.0000000Z,Message 1,00000000-0000-0000-0000-000000000000,0
+        /// 0000-00-00T00:00:00.0000000Z,Message 2,00000000-0000-0000-0000-000000000000,0
+        /// \t0000-00-00T00:00:00.0000000Z,Message 2.1,,0
+        /// \t0000-00-00T00:00:00.0000000Z,Message 2.2,,0
+        /// 0000-00-00T00:00:00.0000000Z,Message 3,00000000-0000-0000-0000-000000000000,0
+        /// </summary>
+        /// <param name="value">Object to be serialized and logged in the StructuredTextDocument</param>
+        /// <param name="depth">Determines the Parent/Child relationship between log entries. depth = 0 is parent for depth = 1</param>
+        public void Write(T value, int depth)
+        {
+            var stringValue = _serializer(value);
+            ValidateStringMessage(stringValue);
+
+            var stringDepth = string.Concat(Enumerable.Range(0, depth).Select(_ => StructuredTextDocument.LeadingCharacter));
+            var logEntry = string.Format(LogTemplate, stringDepth, stringValue);
+            Log(logEntry);
+        }
+
+        private IEnumerable<StructuredTextDocumentEntry<T>> ParseLines(string[] lines, int startIndex, int depth)
+        {
+            List<StructuredTextDocumentEntry<T>> collection = new List<StructuredTextDocumentEntry<T>>();
+            StructuredTextDocumentEntry<T> logEntry = null;
+            for (var i = startIndex; i < lines.Length; i++)
+            {
+                //skip empty lines
+                if (string.IsNullOrWhiteSpace(lines[i]))
+                    continue;
+
+                var entryDepth = StructuredTextDocument.GetEntryDepth(lines[i]);
+                if (entryDepth == depth)
+                {
+                    logEntry = new StructuredTextDocumentEntry<T>
+                    {
+                        LogEntry = _deserializer(lines[i].Substring(depth)),
+                        Children = Enumerable.Empty<StructuredTextDocumentEntry<T>>()
+                    };
+                    collection.Add(logEntry);
+                }
+                else if (entryDepth > depth)
+                {
+                    if (logEntry == null)
+                    {
+                        throw new FormatException(string.Format("log file '{0}' is in an invalid format", _path));
+                    }
+
+                    logEntry.Children = ParseLines(lines, i, entryDepth);
+                    i += (logEntry.Children.Count() - 1);
+                }
+                else if (entryDepth < depth)
+                {
+                    return collection;
+                }
+            }
+            return collection;
+        }
+
+        private void Log(string logEntry)
+        {
+            FileSystemHelpers.AppendAllTextToFile(_path, string.Concat(logEntry, System.Environment.NewLine));
+        }
+
+        private static void ValidateStringMessage(string message)
+        {
+            if (message.StartsWith(StructuredTextDocument.LeadingCharacter, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new FormatException(
+                    string.Format("Serialized log of type '{0}' => '{1}' can't start with character '{2}'",
+                    typeof(T).Name,
+                    message,
+                    StructuredTextDocument.PrintableLeadingCharacter));
+            }
+
+            foreach (var pair in StructuredTextDocument.NotAllowedSequances)
+            {
+                if (message.IndexOf(pair.Key, StringComparison.OrdinalIgnoreCase) != -1)
+                {
+                    throw new FormatException(
+                        string.Format("Serialized log of type '{0}' => '{1}' contains an invalid sequance '{2}' for a logEntry in a StructuredTextDocument",
+                        typeof(T).Name,
+                        message,
+                        pair.Value));
+                }
+            }
+        }
+    }
+
+    public static class StructuredTextDocument
+    {
+        public const string LeadingCharacter = "\t";
+        public const string PrintableLeadingCharacter = "\\t";
+        public static readonly IDictionary<string, string> NotAllowedSequances = new Dictionary<string, string> {  { "\r\n", "\\r\\n" }, { "\r", "\\r" }, { "\n", "\\n" }};
+        public static int GetEntryDepth(string entry)
+        {
+            return entry.TakeWhile(c => LeadingCharacter.Equals(c.ToString())).Count();
+        }
+    }
+}

--- a/Kudu.Core/Deployment/StructuredTextDocumentEntry.cs
+++ b/Kudu.Core/Deployment/StructuredTextDocumentEntry.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kudu.Core.Deployment
+{
+    public class StructuredTextDocumentEntry<T>
+    {
+        public T LogEntry { get; set; }
+        public IEnumerable<StructuredTextDocumentEntry<T>> Children { get; set; }
+    }
+}

--- a/Kudu.Core/Deployment/StructuredTextLogger.cs
+++ b/Kudu.Core/Deployment/StructuredTextLogger.cs
@@ -1,0 +1,127 @@
+﻿using Kudu.Core.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kudu.Core.Deployment
+{
+    public class StructuredTextLogger : IDetailedLogger
+    {
+        private readonly static object DocumentLock = new object();
+        private readonly IAnalytics _analytics;
+        private int _depth;
+        private readonly string _path;
+        private const string LogEntrySeparator = ",";
+        private readonly StructuredTextDocument<LogEntry> _structuredTextDocument;
+
+        private static IEnumerable<KeyValuePair<string, string>> EscapeChars = new Dictionary<string, string>
+        {
+            { ",", "&comma;" }
+        }
+        .Union(StructuredTextDocument.NotAllowedSequances);
+
+        public StructuredTextLogger(string path, IAnalytics analytics)
+        {
+            _depth = 0;
+            _path = path;
+            _analytics = analytics;
+            _structuredTextDocument = new StructuredTextDocument<LogEntry>(path,
+                // DateTime.ToString("o") => "2015-08-04T00:08:38.5489308Z"
+                e => string.Join(LogEntrySeparator, e.LogTime.ToString("o"), e.Message, e.Id, (int)e.Type),
+                str =>
+                {
+                    var splitted = str.Split(new[] { LogEntrySeparator }, StringSplitOptions.None);
+                    if (splitted.Length == 4)
+                    {
+                        var time = DateTime.Parse(splitted[0]).ToUniversalTime();
+                        var message = UnsanitizeValue(splitted[1]);
+                        var id = splitted[2];
+                        var type = (LogEntryType)Int32.Parse(splitted[3]);
+                        return new LogEntry(time, id, message, type);
+                    }
+                    else
+                    {
+                        throw new FormatException(string.Format("the log line \"{0}\" is in an invalid format", str));
+                    }
+                });
+        }
+
+        public ILogger Log(string value, LogEntryType type)
+        {
+            try
+            {
+                value = SanitizeValue(value);
+                lock(DocumentLock)
+                {
+                    var logId = _depth == 0 ? Guid.NewGuid().ToString() : string.Empty;
+                    _structuredTextDocument.Write(new LogEntry(DateTime.UtcNow, logId, value, type), _depth);
+                }
+
+                return new StructuredTextLogger(_path, _analytics)
+                {
+                    _depth = _depth + 1
+                };
+            }
+            catch(Exception e)
+            {
+                _analytics.UnexpectedException(e);
+                throw;
+            }
+        }
+
+        public IEnumerable<LogEntry> GetLogEntries()
+        {
+            try
+            {
+                return _structuredTextDocument.GetDocument().Select(e => e.LogEntry);
+            }
+            catch(Exception e)
+            {
+                _analytics.UnexpectedException(e);
+                throw;
+            }
+        }
+
+        public IEnumerable<LogEntry> GetLogEntryDetails(string entryId)
+        {
+            try
+            {
+                var entry = _structuredTextDocument.GetDocument().FirstOrDefault(s => s.LogEntry.Id.Equals(entryId, StringComparison.OrdinalIgnoreCase));
+                return entry == null
+                    ? Enumerable.Empty<LogEntry>()
+                    : entry.Children.Select(e => e.LogEntry);
+            }
+            catch(Exception e)
+            {
+                _analytics.UnexpectedException(e);
+                throw;
+            }
+        }
+
+        private static string SanitizeValue(string value)
+        {
+            foreach (var pair in EscapeChars)
+            {
+                if (value.Contains(pair.Key))
+                {
+                    value = value.Replace(pair.Key, pair.Value);
+                }
+            }
+
+            return value;
+        }
+
+        private static string UnsanitizeValue(string value)
+        {
+            foreach (var pair in EscapeChars)
+            {
+                if (value.Contains(pair.Value))
+                {
+                    value = value.Replace(pair.Value, pair.Key);
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/Kudu.Core/Deployment/XmlLogger.cs
+++ b/Kudu.Core/Deployment/XmlLogger.cs
@@ -9,7 +9,7 @@ using Kudu.Core.Tracing;
 
 namespace Kudu.Core.Deployment
 {
-    public class XmlLogger : ILogger
+    public class XmlLogger : IDetailedLogger
     {
         private readonly static object LogLock = new object();
         private readonly string _path;

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -96,6 +96,11 @@ namespace Kudu.Core.Infrastructure
             return Instance.File.ReadAllText(path);
         }
 
+        public static string[] ReadAllLines(string path)
+        {
+            return Instance.File.ReadAllLines(path);
+        }
+
         /// <summary>
         /// Replaces File.ReadAllText,
         /// Will do the same thing only this can work on files that are already open (and share read/write).

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -147,6 +147,9 @@
     <Compile Include="Deployment\Generator\NodeSiteBuilder.cs" />
     <Compile Include="Deployment\Generator\NodeSiteEnabler.cs" />
     <Compile Include="Deployment\Generator\SiteBuilderFactory.cs" />
+    <Compile Include="Deployment\StructuredTextDocument.cs" />
+    <Compile Include="Deployment\StructuredTextDocumentEntry.cs" />
+    <Compile Include="Deployment\StructuredTextLogger.cs" />
     <Compile Include="Hooks\WebHooksManager.cs" />
     <Compile Include="Infrastructure\AspNet5Helper.cs" />
     <Compile Include="Infrastructure\InstanceIdUtility.cs" />


### PR DESCRIPTION
Fixes #1622
With the following `deploy.cmd`

``` batch
@ECHO OFF
REM this prints 5,000 lines
FOR /L %%i in (1,1,5000) do echo "Iteration %%i"
```

_| XmlLogger | StructuredTextLogger
--- | --- | ---
Time | 00:**10:26** | 00:00:**55**
File Name | `log.xml` | `log.log`
File Size | `768 KB` | `572 KB`
Parsing Time | ~`25 msec` for `XDocument.Load()` |~~`240 msec`~~ ~`120 msec`

Log format looks like

```
message="Updating branch 'master'." time="8/3/2015 9:43:09 PM" id="0884ef1a-d1f9-40a1-80af-43d27dbbb988" type="0"
message="Updating submodules." time="8/3/2015 9:43:09 PM" id="72566408-30a1-4e13-a15d-0734ab5c7e6e" type="0"
message="Preparing deployment for commit id '7fefd88f08'." time="8/3/2015 9:43:09 PM" id="c71756ba-729d-49f5-90cf-cf958a71ba24" type="0"
message="Running custom deployment command..." time="8/3/2015 9:43:10 PM" id="c4c96196-32eb-4b90-a82a-fecc161f8be5" type="0"
message="Running deployment command..." time="8/3/2015 9:43:10 PM" id="fbd0ebf5-2587-47e9-afd5-70db8242d163" type="0"
	message="Command: deploy.cmd" time="8/3/2015 9:43:10 PM" id="b0aff723-2a12-4df2-99b7-c0fdff5d360f" type="0"
	message="&quot;Iteration 1&quot;" time="8/3/2015 9:43:11 PM" id="1cb3dd5e-37b7-4652-b849-0d86bce1c83c" type="0"
	message="&quot;Iteration 2&quot;" time="8/3/2015 9:43:11 PM" id="577e0fdb-9070-4bc0-9093-c4532fb2c131" type="0"
	message="&quot;Iteration 3&quot;" time="8/3/2015 9:43:11 PM" id="4c7c460f-c111-4669-a73a-a73a4ca4b1d7" type="0"
	message="&quot;Iteration 4&quot;" time="8/3/2015 9:43:11 PM" id="aa17724c-e1df-459c-8e0d-b93a02bef249" type="0"
...
message="Deployment successful." time="8/3/2015 9:43:53 PM" id="234e947a-4d78-4c76-a53d-2b3d6e619c8a" type="0"
```
**Unlike** the `XmlLogger`, this logger doesn't support out-of-order logging.

**Update** with 0084c729ed3be8ec6428c58c4b29020128256c54 the current format is 
note the removal of logId `if depth > 0`

```
2015-08-04T22:08:27.2522415Z,Updating branch 'master'.,5da51d61-0b80-410e-b7a0-97e9b2f961a3,0
2015-08-04T22:08:27.5491152Z,Updating submodules.,4db90cb9-0ba1-4829-986c-81b5182a03c3,0
2015-08-04T22:08:27.6116162Z,Preparing deployment for commit id '1fd0c85025'.,360561a0-ff2c-4619-ae3a-2c72f8aeef54,0
2015-08-04T22:08:27.9553831Z,Generating deployment script.,7f2d1293-3095-42a1-83c0-288145845b67,0
	2015-08-04T22:08:28.2991456Z,Using the following command to generate deployment script: 'azure site deploymentscript -y --no-dot-deployment -r "D:\home\site\repository" -o "D:\home\site\deployments\tools" --aspNet5 "D:\home\site\repository\src\HelloWeb\project.json" --aspNet5Version "1.0.0-beta5" --aspNet5Runtime "CLR" --aspNet5Architecture "x86"'.,,0
	2015-08-04T22:08:29.1585510Z,Project file path: .\src\HelloWeb\project.json,,0
	2015-08-04T22:08:29.1741795Z,Generating deployment script for ASP.NET 5 Application,,0
2015-08-04T22:08:29.2835620Z,Running deployment command...,26f2008f-98a5-49dc-b9b9-9497073436f9,0
	2015-08-04T22:08:29.2991817Z,Command: "D:\home\site\deployments\tools\deploy.cmd",,0
	2015-08-04T22:08:30.4547876Z,Handling ASP.NET 5 Web Application deployment.,,0
...
2015-08-04T22:09:06.5465687Z,Deployment successful.,8037065c-0e94-4c2c-898b-20cf8155fc49,0
```