### PR TITLE
Allow any characters in URL to support complex vfs file names

### DIFF
--- a/Kudu.FunctionalTests/Vfs/VfsControllerBaseTest.cs
+++ b/Kudu.FunctionalTests/Vfs/VfsControllerBaseTest.cs
@@ -69,7 +69,9 @@ namespace Kudu.FunctionalTests
             string dirAddress = BaseAddress + _segmentDelimiter + dir;
             string dirAddressWithTerminatingSlash = dirAddress + _segmentDelimiter;
 
-            string file = Guid.NewGuid().ToString("N") + ".txt";
+            // The %2520 is there to test that we can accept those characters. Here, %2520 is the URL encoded form,
+            // and the actual file name has %20 (and not a space character!)
+            string file = Guid.NewGuid().ToString("N") + "%2520" + ".txt";
             string fileAddress = dirAddressWithTerminatingSlash + file;
             string fileAddressWithTerminatingSlash = fileAddress + _segmentDelimiter;
 

--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -13,7 +13,7 @@
   <system.web>
     <customErrors mode="Off" />
     <compilation debug="true" targetFramework="4.5" />
-    <httpRuntime targetFramework="4.5" maxRequestLength="4194304" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" />
+    <httpRuntime targetFramework="4.5" maxRequestLength="4194304" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" requestPathInvalidCharacters="" />
     <pages controlRenderingCompatibilityVersion="4.0" />
   </system.web>
   <location path="." inheritInChildApplications="false">
@@ -37,7 +37,7 @@
   </location>
   <system.webServer>
     <security>
-      <requestFiltering>
+      <requestFiltering allowDoubleEscaping="true">
         <requestLimits maxAllowedContentLength="4294967295" />
         <fileExtensions allowUnlisted="true">
           <remove fileExtension=".asa" />


### PR DESCRIPTION
I don't think those restrictions have any security value in Kudu, because:
- the site is always authenticated
- if someone can get through authentication, they already own the site regardless of these restrictions