### PR TITLE
Don't replace \\r and \\n when reading the log file

### DIFF
--- a/Kudu.Core/Deployment/StructuredTextDocument.cs
+++ b/Kudu.Core/Deployment/StructuredTextDocument.cs
@@ -102,7 +102,7 @@ namespace Kudu.Core.Deployment
                     StructuredTextDocument.PrintableLeadingCharacter));
             }
 
-            foreach (var pair in StructuredTextDocument.NotAllowedSequances)
+            foreach (var pair in StructuredTextDocument.NotAllowedSequences)
             {
                 if (message.IndexOf(pair.Key, StringComparison.OrdinalIgnoreCase) != -1)
                 {
@@ -120,7 +120,7 @@ namespace Kudu.Core.Deployment
     {
         public const string LeadingCharacter = "\t";
         public const string PrintableLeadingCharacter = "\\t";
-        public static readonly IDictionary<string, string> NotAllowedSequances = new Dictionary<string, string> {  { "\r\n", "\\r\\n" }, { "\r", "\\r" }, { "\n", "\\n" }};
+        public static readonly IDictionary<string, string> NotAllowedSequences = new Dictionary<string, string> {  { "\r\n", "\\r\\n" }, { "\r", "\\r" }, { "\n", "\\n" }};
         public static int GetEntryDepth(string entry)
         {
             return entry.TakeWhile(c => LeadingCharacter.Equals(c.ToString())).Count();

--- a/Kudu.Core/Deployment/StructuredTextLogger.cs
+++ b/Kudu.Core/Deployment/StructuredTextLogger.cs
@@ -17,8 +17,7 @@ namespace Kudu.Core.Deployment
         private static IEnumerable<KeyValuePair<string, string>> EscapeChars = new Dictionary<string, string>
         {
             { ",", "&comma;" }
-        }
-        .Union(StructuredTextDocument.NotAllowedSequances);
+        };
 
         public StructuredTextLogger(string path, IAnalytics analytics)
         {
@@ -100,7 +99,7 @@ namespace Kudu.Core.Deployment
 
         private static string SanitizeValue(string value)
         {
-            foreach (var pair in EscapeChars)
+            foreach (var pair in EscapeChars.Union(StructuredTextDocument.NotAllowedSequences))
             {
                 if (value.Contains(pair.Key))
                 {


### PR DESCRIPTION
Originally the text logger would replace all `["\r", "\n", "\r\n"] => ["\\r", "\\n", "\\r\\n"]` when writing the file, then replace them back when reading the file. This makes strings like `"C:\\Program Files\\npm\\"` become `"C:\\Program Files\npm\\"` which is of course wrong (note the new line inserted in the middle of the path to replace `"\\n"`