### PR TITLE
Adds the TriggeredJobFinished event to the WebHooks form

### DIFF
--- a/Kudu.Services.Web/WebHooks.cshtml
+++ b/Kudu.Services.Web/WebHooks.cshtml
@@ -6,7 +6,7 @@
 <div class="container">
     <h3>About</h3>
     Urls can be registered as web hooks. Information is posted to them when events occur.<br />
-    Only "PostDeployment" event is supported for now.
+    Only the "PostDeployment" and "TriggeredJobFinished" events are supported for now.
 </div>
 
 <div class="container">
@@ -15,6 +15,10 @@
         <div class="form-group" id="urlInput">
             <input type="url" class="form-control" id="urlTextBox" placeholder="Subscriber Url"
                    data-bind="value: newHookUrl">
+            <select class="form-control" id="eventDropdown" data-bind="value: newHookEvent">
+                <option>PostDeployment</option>
+                <option>TriggeredJobFinished</option>
+            </select>
         </div>
         <button type="button" class="btn btn-default" data-bind="click: addHook">Add Url</button>
     </form>
@@ -54,6 +58,7 @@
         var self = this;
         self.hooks = ko.observableArray([]);
         self.newHookUrl = ko.observable();
+        self.newHookEvent = ko.observable();
 
         // Operations
         self.populateHooks = function () {
@@ -77,7 +82,7 @@
                 type: "POST",
                 url: "hooks",
                 contentType: "application/json",
-                data: JSON.stringify({ url: self.newHookUrl(), event: "PostDeployment" }),
+                data: JSON.stringify({ url: self.newHookUrl(), event: self.newHookEvent() }),
                 success: function () {
                     self.newHookUrl("");
                 },


### PR DESCRIPTION
Based on issue #1648 this PR adds a dropdown to the WebHooks form, which has both the `PostDeployment` and `TriggeredJobFinished`events available to choose when creating new webhooks.

This is tested locally, and seems to work fine. But had some issues running the build, as some tests (unrelated to this PR) were failing.