### PR TITLE
Fix clear search box between sessions (Ace)

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -23,6 +23,11 @@ var statusbar = {
             $('#statusbar').removeClass('statusbar-red');
             // Flag from ace-init.js
             contentHasChanged = false;
+            // Clear search box
+            if (editor.searchBox) {
+                editor.searchBox.activeInput.value = '';
+                editor.searchBox.hide();
+            }
         },
     SavingChanges:
         function () {


### PR DESCRIPTION
CTRL-F Search box
<img width="796" alt="searchboxon" src="https://cloud.githubusercontent.com/assets/6472374/9290784/380fcb4c-43a8-11e5-9167-966538a645d9.PNG">

Without hitting CTRL-F, search box is visible again on next file opened in Ace. Same input.
<img width="798" alt="searchboxonagain" src="https://cloud.githubusercontent.com/assets/6472374/9290785/38104e3c-43a8-11e5-9a92-b886b3ad545d.PNG">

Fixed by clearing and hiding the search box on both __Save/Cancel__ events.