### PR TITLE
Fix Profiling tooltip for Free/Shared SKUs

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -354,10 +354,10 @@ var Process = (function () {
         }, false);
         $(profilingButton).css("width", "138px");
         if (Process.prototype.WebSiteSku === "Free" || Process.prototype.WebSiteSku === "Shared") {
-            $(profilingButton).attr("disabled", true);
-            $(profilingButton).addClass("ui-state-disabled");
+            $(profilingButton).css("opacity", "0.5");
+            $(profilingButton).off("click");
             $(profilingButton).attr("title", "Profiling is not supported for Free/Shared sites.");
-            $(profilingButton).tooltip();
+            $(profilingButton).tooltip().show();
         }
         tr.appendChild(Utilities.ToTd(profilingButton));
         return $(tr);


### PR DESCRIPTION
__"Profiling is not supported for Free/Shared sites."__

Tiny fix for the `Start Profiling` button tooltip. The (current) default tooltip only comes up onMouseOver, after mouse is still for 2 seconds. This is bad for discover-ability (i spent 20 minutes poking around in WebApp settings trying to make the button light up, only to rest my mouse accidentaly on top of the button. There might be others out there..).

Here's my fix proposal:

#### Before: ####
![b4](https://cloud.githubusercontent.com/assets/6472374/9616108/33b439b4-50b1-11e5-93d4-56f2f7ac815b.gif)

#### After: ####
![after](https://cloud.githubusercontent.com/assets/6472374/9616102/2d5641fc-50b1-11e5-824d-367b08fb836b.gif)

I had to "fake" the `disabled` property on the button, because disabled elements ignore mouse events and `pointer-events` is a strange fellow (https://developer.mozilla.org/en/docs/Web/CSS/pointer-events).

```javascript
    $(profilingButton).css("opacity", "0.5");
    $(profilingButton).off("click");
````

This also fixes an Edge bug `(20.10240.something)`, where the `disabled` button was still clickable, even when dim:
![image](https://cloud.githubusercontent.com/assets/6472374/9616437/fca8ca00-50b2-11e5-9b48-dbc64cecb430.png)
