### PR TITLE
Force set webpages:Enabled=true

### DIFF
--- a/Kudu.Services.Web/applicationHost.xdt
+++ b/Kudu.Services.Web/applicationHost.xdt
@@ -10,4 +10,12 @@
       </site>
     </sites>
   </system.applicationHost>
+  <system.webServer>
+    <runtime xdt:Transform="InsertIfMissing">
+      <environmentVariables xdt:Transform="InsertIfMissing">
+        <!-- Force set this to make sure Kudu isn't taken down by a site App Setting that sets it to false -->
+        <add name="APPSETTING_webpages:Enabled" value="true" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
+      </environmentVariables>
+    </runtime>
+  </system.webServer>
 </configuration>


### PR DESCRIPTION
This is to make sure Kudu isn't taken down by a site App Setting that
sets it to false.

https://social.msdn.microsoft.com/Forums/en-US/986ff298-0ad9-4580-9e91-b1525df4e27c/no-route-registered-for-of-scm-site?forum=windowsazurewebsitespreview