### PR TITLE
Allow Kudu PowerShell console to execute scripts

### DIFF
--- a/Kudu.Services/Commands/PersistentCommandController.cs
+++ b/Kudu.Services/Commands/PersistentCommandController.cs
@@ -109,7 +109,7 @@ namespace Kudu.Services
             if (shell.Equals("powershell", StringComparison.OrdinalIgnoreCase))
             {
                 startInfo.FileName = System.Environment.ExpandEnvironmentVariables(@"%windir%\System32\WindowsPowerShell\v1.0\powershell.exe");
-                startInfo.Arguments = "-File -";
+                startInfo.Arguments = "-ExecutionPolicy RemoteSigned -File -";
             }
             else
             {


### PR DESCRIPTION
This is the same flag we already pass when executing PowerShell WebJobs.