### PR TITLE
Change the WebJobs invalidation logic to look at latest time

### DIFF
--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -130,6 +130,15 @@ namespace Kudu.Core.Infrastructure
             return Instance.File.GetLastWriteTimeUtc(path);
         }
 
+        // Get the latest LastWriteTime of all the files in a folder
+        public static DateTime GetFolderLatestWriteTimeUtc(string path)
+        {
+            DirectoryInfoBase jobBinariesDirectory = DirectoryInfoFromDirectoryName(path);
+            FileInfoBase[] files = jobBinariesDirectory.GetFiles("*.*", SearchOption.AllDirectories);
+
+            return files.Select(f => f.LastWriteTimeUtc).OrderByDescending(t => t).FirstOrDefault();
+        }
+
         public static void WriteAllBytes(string path, byte[] contents)
         {
             Instance.File.WriteAllBytes(path, contents);


### PR DESCRIPTION
Previous logic was broken when a file was changed or added in the temp folder. In particular, the .exe.config file which we replace was almost guaranteed to be newer than the source, incorrectly causing the cache to be treated as invalid.