### PR TITLE
Fix search Find Handle dialog width

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -981,6 +981,7 @@ window.onload = function () {
     $("#dialog-form").dialog({
         autoOpen: false,
         height: 300,
+        width: 800,
         buttons: {
             "Search": function () {
                 return searchForHandle();


### PR DESCRIPTION
Added width property to `Find Handle` dialog in __/ProcessExplorer__

#### Before ####
![before](https://cloud.githubusercontent.com/assets/6472374/10072628/d8d7585a-62cb-11e5-87ad-39856ecd6182.PNG)

#### After ####
![after](https://cloud.githubusercontent.com/assets/6472374/10072649/f98307f2-62cb-11e5-910e-203d8cd3947e.PNG)
