### PR TITLE
Removed Content-Disposition header

### DIFF
--- a/Kudu.Services/Editor/VfsController.cs
+++ b/Kudu.Services/Editor/VfsController.cs
@@ -90,10 +90,6 @@ namespace Kudu.Services.Editor
 
                 // Set etag for the file
                 successFileResponse.SetEntityTagHeader(currentEtag, lastModified);
-                // When in DebugConsole, convince browsers to download files
-                // rather than rendering inline
-                // See https://github.com/projectkudu/kudu/issues/1634
-                successFileResponse.Content.Headers.Add("Content-Disposition", "attachment");
                 return Task.FromResult(successFileResponse);
             }
             catch (InvalidByteRangeException invalidByteRangeException)


### PR DESCRIPTION
Rolling back change until we have a better fix.
See issue https://github.com/projectkudu/kudu/issues/1716 and https://github.com/projectkudu/kudu/issues/1634