### PR TITLE
[Ace] Added Help and Save without closing (CTRL-S)

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -81,9 +81,24 @@ editor.on('change', function () {
         if (contentHasChanged) {
             return;
         }
+        $('#statusbar').removeClass('statusbar-saved');
         $('#statusbar').addClass('statusbar-red');
         // Let's be nice to jQuery and only .addClass() on first change
         contentHasChanged = true;
+    }
+});
+
+// Bind CTRL-S as Save without closing
+editor.commands.addCommand({
+    name: 'saveItem',
+    bindKey: {
+        win: 'Ctrl-S',
+        mac: 'Command-S',
+        sender: 'editor|cli'
+    },
+    // !!We probably don't need args!!
+    exec: function(env, args, request) {
+        viewModel.fileEdit().saveItem();
     }
 });
 

--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -197,3 +197,9 @@ div.editor {
 .statusbar-red {
     border-left-color: #f14000;
 }
+
+.statusbar-saved {
+    border-left-color: #00e166;
+    transition: border-left-color 0.35s ease;
+}
+

--- a/Kudu.Services.Web/DebugConsole/AceHelp.html
+++ b/Kudu.Services.Web/DebugConsole/AceHelp.html
@@ -1,0 +1,54 @@
+<table class="table table-striped">
+    <thead>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Save file without closing<br>(editor must be in focus)</td>
+            <td>CTRL + S</td>
+            <td>Command + S</td>
+        </tr>
+        <tr>
+            <td>Find</td>
+            <td>CTRL + F</td>
+            <td>Command + F</td>
+        </tr>
+        <tr>
+            <td>Replace</td>
+            <td>CTRL + H</td>
+            <td>Command + H</td>
+        </tr>
+        <tr>
+            <td>Go to matching bracket</td>
+            <td>CTRL + P</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td>Remove line</td>
+            <td>CTRL + D</td>
+            <td>Command + D</td>
+        </tr>
+        <tr>
+            <td>Move up current or selected lines</td>
+            <td>ALT + Up</td>
+            <td>Option + Up</td>
+        </tr>
+        <tr>
+            <td>Move down current or selected lines</td>
+            <td>ALT + Down</td>
+            <td>Option + Down</td>
+        </tr>
+        <tr>
+            <td>Show editor settings</td>
+            <td>CTRL + ,</td>
+            <td>Command + ,</td>
+        </tr>
+    </tbody>
+</table>
+
+<center>
+    <div id="more-combos" style="position: relative; margin-top: 40px;">
+        <a href="https://github.com/ajaxorg/ace/wiki/Default-Keyboard-Shortcuts"
+           target="_blank">Even more key combos on GitHub</a>
+    </div>
+</center>
+

--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -105,10 +105,31 @@
         <div class="form-group">
             <form role="form">
                 <p>
-                    <button class="btn btn-primary btn-default" style="margin-right: 10px" data-bind="click: function () { return fileEdit().saveItem(); }">Save</button>
+                    <button class="btn btn-primary btn-default"
+                        style="margin-right: 10px" data-bind="click: function () { return fileEdit().saveItemAndClose(); }">Save</button>
                     <button class="btn" style="margin-right: 10px" data-bind="click: cancelEdit">Cancel</button>
                     <span id="statusbar" class="statusbar"></span>
+                    <span id="acehelp" class="btn btn-info right" onclick="showAceHelpModal();">Help</span>
                 </p>
+
+                <!-- Ace Help Modal -->
+                <div class="modal fade" id="ace-help-modal" tabindex="-1" role="dialog" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header" style="border: 0">
+                                <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+                                <h4 class="modal-title">Keyboard Shortcuts</h4>
+                            </div>
+                            <div class="modal-body">
+                                Loading...
+                            </div>
+                            <div class="modal-footer" style="border: 0">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Ace editor starts -->
                 <div id="editor" data-bind="ace: editText"></div>
                 <!-- Ace editor ends -->

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -239,6 +239,7 @@
     <Content Include="DebugConsole\Default.cshtml">
       <SubType>Code</SubType>
     </Content>
+    <Content Include="DebugConsole\AceHelp.html" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="SiteExtensions\Default.cshtml" />


### PR DESCRIPTION
#### New feature - Save file without closing ####

The gif can't tell the full story, the status bar color turns green on a smooth half-second bezier curve. Really polished :)

![ctrls](https://cloud.githubusercontent.com/assets/6472374/10292625/ef416b1c-6bb8-11e5-9a35-92beb4890414.gif)

#### Better error handling for both CTRL+S and Save button ####
If you can't save (for whatever reason), your changes are not lost, you are dropped back into the editor.

![alert](https://cloud.githubusercontent.com/assets/6472374/10292639/05090266-6bb9-11e5-8c05-c80ff3df7464.gif)

#### Ace has some really great features. I've picked a few _seriously_ useful ones. Get Help! ####
![acehelpbutton](https://cloud.githubusercontent.com/assets/6472374/10292643/0b12322c-6bb9-11e5-86b0-c804476dd72a.gif)

Still on Ace 1.1.9.
1.2.0 is out for a month or so but i need to test it heavily before upgrading.

Not sure why the commit looks like i've completely re-written `Default.cshtml`, i've only added this modal here (line 115):

https://github.com/projectkudu/kudu/compare/acedev?expand=1#diff-b82317deb2356eb11b04b8758c5a1853R115

