### PR TITLE
Proper cleanup site contents before reusing the site

### DIFF
--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -360,9 +360,9 @@ namespace Kudu.Core.Infrastructure
             {
                 fileSystemInfo.Attributes = FileAttributes.Normal;
             }
-            catch
+            catch (Exception ex)
             {
-                if (!ignoreErrors) throw;
+                if (!ignoreErrors) throw new InvalidOperationException(String.Format("Set {0} attribute failed with {1}", fileSystemInfo.FullName, ex.Message), ex);
             }
 
             var directoryInfo = fileSystemInfo as DirectoryInfoBase;
@@ -372,18 +372,13 @@ namespace Kudu.Core.Infrastructure
                 DeleteDirectoryContentsSafe(directoryInfo, ignoreErrors);
             }
 
-            DoSafeAction(fileSystemInfo.Delete, ignoreErrors);
-        }
-
-        private static void DoSafeAction(Action action, bool ignoreErrors)
-        {
             try
             {
-                OperationManager.Attempt(action);
+                fileSystemInfo.Delete();
             }
-            catch
+            catch (Exception ex)
             {
-                if (!ignoreErrors) throw;
+                if (!ignoreErrors) throw new InvalidOperationException(String.Format("Delete {0} failed with {1}", fileSystemInfo.FullName, ex.Message), ex);
             }
         }
     }

--- a/Kudu.SiteManagement/ISiteManager.cs
+++ b/Kudu.SiteManagement/ISiteManager.cs
@@ -12,5 +12,8 @@ namespace Kudu.SiteManagement
         Task DeleteSiteAsync(string applicationName);
         bool AddSiteBinding(string applicationName, KuduBinding binding);
         bool RemoveSiteBinding(string applicationName, string siteBinding, SiteType siteType);
+
+        Task StartAppPool(string applicationName);
+        Task StopAppPool(string applicationName);
     }
 }

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -2,13 +2,12 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Security.AccessControl;
-using System.Threading;
 using System.Threading.Tasks;
+using Kudu.Core.Infrastructure;
 using Kudu.SiteManagement;
 using Kudu.SiteManagement.Certificates;
 using Kudu.SiteManagement.Configuration;
@@ -58,29 +57,28 @@ namespace Kudu.TestHarness
             string operationName = "SitePool.CreateApplicationInternal " + applicationName;
 
             var context = new KuduTestContext();
+            var root = context.Paths.GetApplicationPath(applicationName);
             var siteManager = GetSiteManager(context);
 
             Site site = siteManager.GetSite(applicationName);
             if (site != null)
             {
+                TestTracer.Trace("Stop app pool {0}", applicationName);
+                await siteManager.StopAppPool(applicationName);
+
+                CleanUpContents(root);
+
+                string wwwroot = Path.Combine(root, @"site\wwwroot");
+                FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(wwwroot));
+
+                TestTracer.Trace("Start app pool {0}", applicationName);
+                await siteManager.StartAppPool(applicationName);
+
                 TestTracer.Trace("{0} Site already exists at {1}. Reusing site", operationName, site.SiteUrl);
                 var appManager = new ApplicationManager(siteManager, site, applicationName)
                 {
                     SitePoolIndex = siteIndex
                 };
-
-                // In site reuse mode, clean out the existing site so we start clean
-                // Enumrate all w3wp processes and make sure to kill any process with an open handle to klr.host.dll
-                foreach (var process in (await appManager.ProcessManager.GetProcessesAsync()).Where(p => p.Name.Equals("w3wp", StringComparison.OrdinalIgnoreCase)))
-                {
-                    var extendedProcess = await appManager.ProcessManager.GetProcessAsync(process.Id);
-                    if (extendedProcess.OpenFileHandles.Any(h => h.IndexOf("dnx.host.dll", StringComparison.OrdinalIgnoreCase) != -1))
-                    {
-                        await appManager.ProcessManager.KillProcessAsync(extendedProcess.Id, throwOnError:false);
-                    }
-                }
-
-                await appManager.RepositoryManager.Delete(deleteWebRoot: true, ignoreErrors: true);
 
                 // Make sure we start with the correct default file as some tests expect it
                 WriteIndexHtml(appManager);
@@ -90,6 +88,9 @@ namespace Kudu.TestHarness
             }
             else
             {
+                // {root}\site\wwwroot creation taken care by siteManager.CreateSiteAsync
+                CleanUpContents(root);
+
                 TestTracer.Trace("{0} Creating new site", operationName);
                 lock (_createSiteLock)
                 {
@@ -123,7 +124,6 @@ namespace Kudu.TestHarness
                 };
             }
         }
-
 
         private static ISiteManager GetSiteManager(IKuduContext context)
         {
@@ -161,6 +161,23 @@ namespace Kudu.TestHarness
                 }
 
                 throw;
+            }
+        }
+
+        private static void CleanUpContents(string path)
+        {
+            TestTracer.Trace("Delete {0} folder contents", path);
+            try
+            {
+                // first cleanup and report errors
+                FileSystemHelpers.DeleteDirectoryContentsSafe(path, ignoreErrors: false);
+            }
+            catch (Exception ex)
+            {
+                TestTracer.Trace(ex.Message);
+
+                // retry ignore errors
+                FileSystemHelpers.DeleteDirectoryContentsSafe(path, ignoreErrors: true);
             }
         }
     }


### PR DESCRIPTION
This is up for debate.  

Every now and then (2 in the last 8 runs), one or two tests failed due to files being locked.   This was due to reusing dirty sites.  The fix is to cleanup more reliably by stopping app pool, cleanup site contents and restarting it.  

Pros is hopefully tests run more reliable.  Cons is it adds 5-10s more for each test (stop/start app pool and cold start Kudu).  Given roughly 200 functional tests, with 4 test in parallel, my calculation is we are looking at ~5-10 mins extra time for CI to complete.   Currently CI took 15-20mins.

Thought?

