### PR TITLE
fix #1737 NullRef GetTotalProcessorTime

### DIFF
--- a/Kudu.Core/Commands/CommandExecutor.cs
+++ b/Kudu.Core/Commands/CommandExecutor.cs
@@ -19,8 +19,9 @@ namespace Kudu.Core.Commands
         private readonly IDeploymentSettingsManager _settings;
         private readonly ITracer _tracer;
 
-        public CommandExecutor(string repositoryPath, IEnvironment environment, IDeploymentSettingsManager settings, ITracer tracer)
+        public CommandExecutor(IEnvironment environment, IDeploymentSettingsManager settings, ITracer tracer)
         {
+            var repositoryPath = environment.RootPath;
             _rootDirectory = repositoryPath;
             _environment = environment;
             _externalCommandFactory = new ExternalCommandFactory(environment, settings, repositoryPath);

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -304,8 +304,7 @@ namespace Kudu.Services.Web.App_Start
             kernel.Bind<ISiteExtensionManager>().To<SiteExtensionManager>().InRequestScope();
 
             // Command executor
-            kernel.Bind<ICommandExecutor>().ToMethod(context => GetCommandExecutor(environment, context))
-                                           .InRequestScope();
+            kernel.Bind<ICommandExecutor>().To<CommandExecutor>().InRequestScope();
 
             MigrateSite(environment, noContextDeploymentsSettingsManager);
             RemoveOldTracePath(environment);
@@ -654,16 +653,6 @@ namespace Kudu.Services.Web.App_Start
             }
 
             return null;
-        }
-
-        private static ICommandExecutor GetCommandExecutor(IEnvironment environment, IContext context)
-        {
-            if (System.String.IsNullOrEmpty(environment.RepositoryPath))
-            {
-                throw new HttpResponseException(HttpStatusCode.NotFound);
-            }
-
-            return new CommandExecutor(environment.RootPath, environment, context.Kernel.Get<IDeploymentSettingsManager>(), TraceServices.CurrentRequestTracer);
         }
 
         private static string GetSettingsPath(IEnvironment environment)


### PR DESCRIPTION
The culprit is ITracer being null (request from browser, assuming interactive, we will do no trace).  The fix simply simplifies the ninject binding and ITracer in such scenario will be taken care automagically.  New output is below (testing with idle notepad).

```
Kudu Remote Execution Console
Type 'exit' to reset this console.
C:\Kudu-Test-Files\KuduApps\TestRunnerSiteSUWATCHASUS011>notepad
Command 'starter.cmd notepad & echo. ...' was aborted due to no output nor CPU activity for 60 seconds. You can increase the SCM_COMMAND_IDLE_TIMEOUT app setting (or WEBJOBS_IDLE_TIMEOUT if this is a WebJob) if needed.

C:\Kudu-Test-Files\KuduApps\TestRunnerSiteSUWATCHASUS011> 
```