### PR TITLE
fix #1744 to avoid malformed diagnostics settings.json

### DIFF
--- a/Kudu.Core/Settings/DiagnosticsSettingsManager.cs
+++ b/Kudu.Core/Settings/DiagnosticsSettingsManager.cs
@@ -31,6 +31,13 @@ namespace Kudu.Core.Settings
             return ReadSettings();
         }
 
+        public void UpdateSetting(string key, object value)
+        {
+            DiagnosticsSettings diagnosticsSettings = ReadSettings();
+            diagnosticsSettings.SetSetting(key, value);
+            SaveSettings(diagnosticsSettings);
+        }
+
         public void UpdateSettings(DiagnosticsSettings settings)
         {
             DiagnosticsSettings diagnosticsSettings = ReadSettings();

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -96,8 +96,8 @@ namespace Kudu.Services.Performance
             {
                 _operationLock.LockOperation(() =>
                 {
-                    var settings = new JsonSettings(Path.Combine(_environment.DiagnosticsPath, Constants.SettingsJsonFile));
-                    settings.SetValue(AzureDriveEnabledKey, true);
+                    var diagnostics = new DiagnosticsSettingsManager(Path.Combine(_environment.DiagnosticsPath, Constants.SettingsJsonFile), _tracer);
+                    diagnostics.UpdateSetting(AzureDriveEnabledKey, true);
                 }, TimeSpan.FromSeconds(30));
             }
 


### PR DESCRIPTION
Fix is to read and write diagnostics settings file as a whole.   Perf degrade should be trivial.