### PR TITLE
Fix handle whitespace in Mercurial branch name

### DIFF
--- a/Kudu.FunctionalTests/HgRepositoryFacts.cs
+++ b/Kudu.FunctionalTests/HgRepositoryFacts.cs
@@ -79,7 +79,7 @@ namespace Kudu.FunctionalTests
                 File.WriteAllText(helloTextPath, "uncommitted changes");
 
                 // Act - 2
-                hgRepo.FetchWithoutConflict(remoteRepository, branchName: "test");
+                hgRepo.FetchWithoutConflict(remoteRepository, branchName: "branch with spaces");
 
                 // Assert - 2
                 Assert.Equal("This is a commit from test", File.ReadAllText(helloTextPath));


### PR DESCRIPTION
Fix for #1755.

#### Tested: ####
* Hook a fresh Web App to BitBucket hg branch "some white space" https://bitbucket.org/snobu/hgrepo/branches/

* New commit `-->` update deployment

![image](https://cloud.githubusercontent.com/assets/6472374/10741087/8ea491e0-7c2e-11e5-94ac-ee50a3f0bbfb.png)


First time i touch this part of Kudu, please don't hold back on feedback.