### PR TITLE
Procdump monitor

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -90,5 +90,7 @@ namespace Kudu
 
         //Setting for VC++ for node builds
         public const string VCVersion = "2015";
+
+        public const string CrashDumps = "CrashDumps";
     }
 }

--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -91,6 +91,6 @@ namespace Kudu
         //Setting for VC++ for node builds
         public const string VCVersion = "2015";
 
-        public const string CrashDumps = "CrashDumps";
+        public const string Dumps = "dumps";
     }
 }

--- a/Kudu.Contracts/Diagnostics/CrashDumpInfo.cs
+++ b/Kudu.Contracts/Diagnostics/CrashDumpInfo.cs
@@ -21,8 +21,8 @@ namespace Kudu.Contracts.Diagnostics
         [JsonProperty(PropertyName = "href", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Uri Href { get; set; }
 
-        [JsonProperty(PropertyName = "analyize_href", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public Uri AnalyizeHref { get; set; }
+        [JsonProperty(PropertyName = "analyze_href", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Uri AnalyzeHref { get; set; }
 
         [JsonProperty(PropertyName = "download_href", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Uri DownloadHref { get; set; }

--- a/Kudu.Contracts/Diagnostics/CrashDumpInfo.cs
+++ b/Kudu.Contracts/Diagnostics/CrashDumpInfo.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kudu.Contracts.Diagnostics
+{
+    public class CrashDumpInfo
+    {
+        [JsonProperty(PropertyName = "name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "timestamp", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DateTime Timestamp { get; set; }
+
+        [JsonProperty(PropertyName = "file_path", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string FilePath { get; set; }
+
+        [JsonProperty(PropertyName = "href", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Uri Href { get; set; }
+
+        [JsonProperty(PropertyName = "analyize_href", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Uri AnalyizeHref { get; set; }
+    }
+}

--- a/Kudu.Contracts/Diagnostics/CrashDumpInfo.cs
+++ b/Kudu.Contracts/Diagnostics/CrashDumpInfo.cs
@@ -23,5 +23,8 @@ namespace Kudu.Contracts.Diagnostics
 
         [JsonProperty(PropertyName = "analyize_href", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Uri AnalyizeHref { get; set; }
+
+        [JsonProperty(PropertyName = "download_href", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Uri DownloadHref { get; set; }
     }
 }

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -23,5 +23,6 @@
         string DataPath { get; }                // e.g. /data
         string JobsDataPath { get; }            // e.g. /data/jobs
         string JobsBinariesPath { get; }        // e.g. /site/wwwroot/app_data/jobs
+        string CrashDumpsPath { get; }           // e.g /data/CrashDumps
     }
 }

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -23,6 +23,6 @@
         string DataPath { get; }                // e.g. /data
         string JobsDataPath { get; }            // e.g. /data/jobs
         string JobsBinariesPath { get; }        // e.g. /site/wwwroot/app_data/jobs
-        string CrashDumpsPath { get; }           // e.g /data/CrashDumps
+        string CrashDumpsPath { get; }          // e.g /data/dumps
     }
 }

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Deployment\LogEntry.cs" />
     <Compile Include="Deployment\LogEntryType.cs" />
     <Compile Include="Diagnostics\ApplicationLogEntry.cs" />
+    <Compile Include="Diagnostics\CrashDumpInfo.cs" />
     <Compile Include="Diagnostics\ProcessInfo.cs" />
     <Compile Include="Diagnostics\ProcessModuleInfo.cs" />
     <Compile Include="Diagnostics\ProcessThreadInfo.cs" />

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -25,6 +25,7 @@ namespace Kudu.Core
         private readonly string _dataPath;
         private readonly string _jobsDataPath;
         private readonly string _jobsBinariesPath;
+        private readonly string _crashDumpsPath;
 
         // This ctor is used only in unit tests
         public Environment(
@@ -71,6 +72,7 @@ namespace Kudu.Core
             _tracePath = Path.Combine(rootPath, Constants.TracePath);
             _analyticsPath = Path.Combine(tempPath ?? _logFilesPath, Constants.SiteExtensionLogsDirectory);
             _deploymentTracePath = Path.Combine(rootPath, Constants.DeploymentTracePath);
+            _crashDumpsPath = Path.Combine(_dataPath, Constants.CrashDumps);
         }
 
         public Environment(
@@ -101,6 +103,7 @@ namespace Kudu.Core
             _dataPath = Path.Combine(rootPath, Constants.DataPath);
             _jobsDataPath = Path.Combine(_dataPath, Constants.JobsPath);
             _jobsBinariesPath = Path.Combine(_webRootPath, Constants.AppDataPath, Constants.JobsPath);
+            _crashDumpsPath = Path.Combine(_dataPath, Constants.CrashDumps);
         }
 
         public string RepositoryPath
@@ -269,6 +272,14 @@ namespace Kudu.Core
         public static bool IsAzureEnvironment()
         {
             return !String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"));
+        }
+
+        public string CrashDumpsPath
+        {
+            get
+            {
+                return FileSystemHelpers.EnsureDirectory(_crashDumpsPath);
+            }
         }
     }
 }

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -72,7 +72,7 @@ namespace Kudu.Core
             _tracePath = Path.Combine(rootPath, Constants.TracePath);
             _analyticsPath = Path.Combine(tempPath ?? _logFilesPath, Constants.SiteExtensionLogsDirectory);
             _deploymentTracePath = Path.Combine(rootPath, Constants.DeploymentTracePath);
-            _crashDumpsPath = Path.Combine(_dataPath, Constants.CrashDumps);
+            _crashDumpsPath = Path.Combine(_dataPath, Constants.Dumps);
         }
 
         public Environment(
@@ -103,7 +103,7 @@ namespace Kudu.Core
             _dataPath = Path.Combine(rootPath, Constants.DataPath);
             _jobsDataPath = Path.Combine(_dataPath, Constants.JobsPath);
             _jobsBinariesPath = Path.Combine(_webRootPath, Constants.AppDataPath, Constants.JobsPath);
-            _crashDumpsPath = Path.Combine(_dataPath, Constants.CrashDumps);
+            _crashDumpsPath = Path.Combine(_dataPath, Constants.Dumps);
         }
 
         public string RepositoryPath

--- a/Kudu.Services.Test/CrashDumpControllerFacts.cs
+++ b/Kudu.Services.Test/CrashDumpControllerFacts.cs
@@ -1,0 +1,71 @@
+﻿using Kudu.Contracts.Diagnostics;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.Tracing;
+using Kudu.Core;
+using Kudu.Core.Infrastructure;
+using Kudu.Services.Diagnostics;
+using Kudu.Services.Performance;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kudu.Services.Test
+{
+    public class CrashDumpControllerFacts
+    {
+        [Fact]
+        public void GetCrashDumpInfoFromFileInfoByName()
+        {
+            const string name = "test-name.dmp";
+            const string fullName = "X:\\dumps\\test-name.dmp";
+            const string baseUrl = "http://localhost/";
+            var timestamp = DateTime.Now;
+
+            var tracerMock = new Mock<ITracer>();
+            var environmentMock = new Mock<IEnvironment>();
+            environmentMock.Setup(e => e.CrashDumpsPath).Returns("X:\\dumps");
+
+            var deploymentSettingsManagerMock = new Mock<IDeploymentSettingsManager>();
+            using (var controller = new CrashDumpController(tracerMock.Object, environmentMock.Object, deploymentSettingsManagerMock.Object))
+            {
+                var fileSystemMock = new Mock<IFileSystem>();
+                var fileBaseMock = new Mock<FileBase>();
+                var fileInfoBaseMock = new Mock<FileInfoBase>();
+                var fileInfoFactoryMock = new Mock<IFileInfoFactory>();
+
+                fileSystemMock.Setup(f => f.FileInfo).Returns(fileInfoFactoryMock.Object);
+                fileSystemMock.Setup(f => f.File).Returns(fileBaseMock.Object);
+
+                fileInfoBaseMock.Setup(f => f.Name).Returns(name);
+                fileInfoBaseMock.Setup(f => f.LastWriteTime).Returns(timestamp);
+                fileInfoBaseMock.Setup(f => f.FullName).Returns(fullName);
+
+                fileInfoFactoryMock.Setup(f => f.FromFileName(It.IsAny<string>()))
+                    .Returns(fileInfoBaseMock.Object);
+
+                fileBaseMock.Setup(f => f.Exists(It.IsAny<string>()))
+                    .Returns((string path) => path == fullName);
+
+                FileSystemHelpers.Instance = fileSystemMock.Object;
+
+                controller.Request = new HttpRequestMessage(HttpMethod.Get, new Uri(baseUrl));
+
+                var crashInfoDump = controller.GetCrashDump(name);
+
+                Assert.Equal(name, crashInfoDump.Name);
+                Assert.Equal(fullName, crashInfoDump.FilePath);
+                Assert.Equal(timestamp, crashInfoDump.Timestamp);
+                Assert.Equal($"{baseUrl}api/crashdumps/{name}", crashInfoDump.Href.ToString());
+                Assert.Equal($"{baseUrl}api/crashdumps/{name}/analyze", crashInfoDump.AnalyizeHref.ToString());
+                Assert.Equal($"{baseUrl}api/vfs/data/{Constants.Dumps}/{name}", crashInfoDump.DownloadHref.ToString());
+            }
+        }
+    }
+}

--- a/Kudu.Services.Test/CrashDumpControllerFacts.cs
+++ b/Kudu.Services.Test/CrashDumpControllerFacts.cs
@@ -63,7 +63,7 @@ namespace Kudu.Services.Test
                 Assert.Equal(fullName, crashInfoDump.FilePath);
                 Assert.Equal(timestamp, crashInfoDump.Timestamp);
                 Assert.Equal($"{baseUrl}api/crashdumps/{name}", crashInfoDump.Href.ToString());
-                Assert.Equal($"{baseUrl}api/crashdumps/{name}/analyze", crashInfoDump.AnalyizeHref.ToString());
+                Assert.Equal($"{baseUrl}api/crashdumps/{name}/analyze", crashInfoDump.AnalyzeHref.ToString());
                 Assert.Equal($"{baseUrl}api/vfs/data/{Constants.Dumps}/{name}", crashInfoDump.DownloadHref.ToString());
             }
         }

--- a/Kudu.Services.Test/Kudu.Services.Test.csproj
+++ b/Kudu.Services.Test/Kudu.Services.Test.csproj
@@ -73,6 +73,7 @@
     <Compile Include="BitbucketDeployment\BitbucketHandlerFacts.cs" />
     <Compile Include="CodeBaseHqFacts.cs" />
     <Compile Include="CodePlexHandlerFacts.cs" />
+    <Compile Include="CrashDumpControllerFacts.cs" />
     <Compile Include="CustomGitRepositoryHandlerFacts.cs" />
     <Compile Include="DeploymentControllerFacts.cs" />
     <Compile Include="Diagnostics\ProcessControllerFacts.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -457,7 +457,13 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpProcessesRoute("one-process-thread", "/{processId}/threads/{threadId}", new { controller = "Process", action = "GetThread" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpProcessesRoute("all-modules", "/{id}/modules", new { controller = "Process", action = "GetAllModules" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpProcessesRoute("one-process-module", "/{id}/modules/{baseAddress}", new { controller = "Process", action = "GetModule" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("one-process-dump-on-crash", "/{id}/dump/oncrash", new { controller = "Process", action = "TakeMemoryDumpOnCrash" }, new { verb = new HttpMethodConstraint("POST") });
+
+            // Crash dumps
+            routes.MapHttpProcessesRoute("take-crashdump", "/{id}/crashdump", new { controller = "Process", action = "TakeCrashDump" }, new { verb = new HttpMethodConstraint("POST") });
+            routes.MapHttpRoute("list-crashdumps", "api/crashdumps", new { controller = "CrashDump", action = "List" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("get-crashdump", "api/crashdumps/{name}", new { controller = "CrashDump", action = "Get" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("delete-crashdump", "api/crashdumps/{name}", new { controller = "CrashDump", action = "Delete" }, new { verb = new HttpMethodConstraint("DELETE") });
+            routes.MapHttpRoute("analyze-crashdump", "api/crashdumps/{name}/analyze", new { controller = "CrashDump", action = "Analyze" }, new { verb = new HttpMethodConstraint("POST") });
 
             // Runtime
             routes.MapHttpRouteDual("runtime", "diagnostics/runtime", new { controller = "Runtime", action = "GetRuntimeVersions" }, new { verb = new HttpMethodConstraint("GET") });

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -457,6 +457,7 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpProcessesRoute("one-process-thread", "/{processId}/threads/{threadId}", new { controller = "Process", action = "GetThread" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpProcessesRoute("all-modules", "/{id}/modules", new { controller = "Process", action = "GetAllModules" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpProcessesRoute("one-process-module", "/{id}/modules/{baseAddress}", new { controller = "Process", action = "GetModule" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("one-process-dump-on-crash", "/{id}/dump/oncrash", new { controller = "Process", action = "TakeMemoryDumpOnCrash" }, new { verb = new HttpMethodConstraint("POST") });
 
             // Runtime
             routes.MapHttpRouteDual("runtime", "diagnostics/runtime", new { controller = "Runtime", action = "GetRuntimeVersions" }, new { verb = new HttpMethodConstraint("GET") });

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -503,6 +503,13 @@ var Process = (function () {
         });
     };
 
+    Process.prototype.enableCrashDump = function () {
+        return $.ajax({
+            url: appRoot + "api/processes/" + this._json.id + "/dump/oncrash",
+            type: "POST"
+        });
+    };
+
     Process.getIdFromHref = function (href) {
         return parseInt(href.substr(href.lastIndexOf("/") + 1));
     };
@@ -863,6 +870,14 @@ function overrideRightClickMenu() {
                     $("li")[0].click();
                     $("li").blur();
                     break;
+                case "crashdump":
+                    $("#proc-loading").show();
+                    process.enableCrashDump().done(function () {
+                        return processExplorerSetupAsync();
+                    }).fail(function () {
+                        return processExplorerSetupAsync();
+                    });
+                    break;
             }
         },
         items: {
@@ -874,6 +889,7 @@ function overrideRightClickMenu() {
                     "dump2": { name: "Full Dump" }
                 }
             },
+            "crashdump": { name: "Enable Crash Dump" },
             "sep1": "---------",
             "properties": { name: "Properties" }
         },

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -505,7 +505,7 @@ var Process = (function () {
 
     Process.prototype.enableCrashDump = function () {
         return $.ajax({
-            url: appRoot + "api/processes/" + this._json.id + "/dump/oncrash",
+            url: appRoot + "api/processes/" + this._json.id + "/crashdump",
             type: "POST"
         });
     };

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -872,9 +872,7 @@ function overrideRightClickMenu() {
                     break;
                 case "crashdump":
                     $("#proc-loading").show();
-                    process.enableCrashDump().done(function () {
-                        return processExplorerSetupAsync();
-                    }).fail(function () {
+                    process.enableCrashDump().always(function () {
                         return processExplorerSetupAsync();
                     });
                     break;

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -503,9 +503,9 @@ var Process = (function () {
         });
     };
 
-    Process.prototype.enableCrashDump = function () {
+    Process.prototype.enableCrashDump = function (includeMemory) {
         return $.ajax({
-            url: appRoot + "api/processes/" + this._json.id + "/crashdump",
+            url: appRoot + "api/processes/" + this._json.id + "/crashdump?includeMemory=" + includeMemory,
             type: "POST"
         });
     };
@@ -870,9 +870,10 @@ function overrideRightClickMenu() {
                     $("li")[0].click();
                     $("li").blur();
                     break;
-                case "crashdump":
+                case "crashdump1":
+                case "crashdump2":
                     $("#proc-loading").show();
-                    process.enableCrashDump().always(function () {
+                    process.enableCrashDump(key === "crashdump2").always(function () {
                         return processExplorerSetupAsync();
                     });
                     break;
@@ -887,7 +888,13 @@ function overrideRightClickMenu() {
                     "dump2": { name: "Full Dump" }
                 }
             },
-            "crashdump": { name: "Enable Crash Dump" },
+            "crashdump": {
+                name: "Enable Crash Dump",
+                "items": {
+                    "crashdump1": { name: "Mini Dump" },
+                    "crashdump2": { name: "Full Dump" }
+                }
+            },
             "sep1": "---------",
             "properties": { name: "Properties" }
         },

--- a/Kudu.Services/Diagnostics/CrashDumpController.cs
+++ b/Kudu.Services/Diagnostics/CrashDumpController.cs
@@ -106,7 +106,7 @@ namespace Kudu.Services.Diagnostics
                 Name = fileInfo.Name,
                 Timestamp = fileInfo.LastWriteTime,
                 Href = new Uri($"{baseUrl}/api/crashdumps/{fileInfo.Name}"),
-                AnalyizeHref = new Uri($"{baseUrl}/api/crashdumps/{fileInfo.Name}/analyze"),
+                AnalyzeHref = new Uri($"{baseUrl}/api/crashdumps/{fileInfo.Name}/analyze"),
                 DownloadHref = new Uri($"{baseUrl}/api/vfs/data/{Constants.Dumps}/{fileInfo.Name}"),
                 FilePath = fileInfo.FullName
             };

--- a/Kudu.Services/Diagnostics/CrashDumpController.cs
+++ b/Kudu.Services/Diagnostics/CrashDumpController.cs
@@ -73,7 +73,7 @@ namespace Kudu.Services.Diagnostics
                 using (MemoryStream outputStream = new MemoryStream(), errorStream = new MemoryStream())
                 {
                     // ExecuteAsync could deadlock if called from an ASP.NET thread
-                    var exitCode = await Task.Run(async () => await exe.ExecuteAsync(_tracer, $"-c \"!analyze -v;q\" -z \"{crashDump.FilePath}\"", outputStream, errorStream));
+                    var exitCode = await Task.Run(async () => await exe.ExecuteAsync(_tracer, $"-c \".symfix;.reload;.loadby sos clr;~*k;!analyze -v;q\" -z \"{crashDump.FilePath}\"", outputStream, errorStream));
                     if (exitCode == 0)
                     {
                         return Request.CreateResponse(HttpStatusCode.OK, new { output = outputStream.AsString() });

--- a/Kudu.Services/Diagnostics/CrashDumpController.cs
+++ b/Kudu.Services/Diagnostics/CrashDumpController.cs
@@ -1,0 +1,110 @@
+﻿using Kudu.Contracts.Diagnostics;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.Tracing;
+using Kudu.Core;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
+using Kudu.Services.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace Kudu.Services.Diagnostics
+{
+    class CrashDumpController : ApiController
+    {
+        private readonly ITracer _tracer;
+        private readonly IEnvironment _environment;
+        private readonly IDeploymentSettingsManager _settings;
+
+        public CrashDumpController(ITracer tracer,
+                                 IEnvironment environment,
+                                 IDeploymentSettingsManager settings)
+        {
+            _tracer = tracer;
+            _environment = environment;
+            _settings = settings;
+        }
+
+        [HttpGet]
+        public IEnumerable<CrashDumpInfo> List()
+        {
+            using (_tracer.Step("CrashDumpController.List"))
+            {
+                return FileSystemHelpers.GetFiles(_environment.CrashDumpsPath, "*.dmp")
+                    .Select(FileSystemHelpers.FileInfoFromFileName)
+                    .Select(f => GetCrashDumpInfoFromFile(f, Request.RequestUri.GetLeftPart(UriPartial.Path).TrimEnd('/')));
+            }
+        }
+
+        [HttpGet]
+        public HttpResponseMessage Get(string name)
+        {
+            using (_tracer.Step($"CrashDumpController.Get({name})"))
+            {
+                return Request.CreateResponse(HttpStatusCode.OK, GetCrashDump(name));
+            }
+        }
+
+        [HttpDelete]
+        public HttpResponseMessage Delete(string name)
+        {
+            using (_tracer.Step($"CrashDumpController.Delete({name})"))
+            {
+                var crashDump = GetCrashDump(name);
+                FileSystemHelpers.DeleteFile(crashDump.FilePath);
+                return Request.CreateResponse(HttpStatusCode.OK);
+            }
+        }
+
+        [HttpPost]
+        public async Task<HttpResponseMessage> Analyze(string name)
+        {
+            using (_tracer.Step($"CrashDumpController.Analyze({name})"))
+            {
+                var crashDump = GetCrashDump(name);
+                var exe = new Executable(ResolveCdbPath(), _environment.RootPath, _settings.GetCommandIdleTimeout());
+                var outputStream = new MemoryStream();
+                var errorStream = new MemoryStream();
+                var exitCode = await exe.ExecuteAsync(_tracer, $"-c \"!analyze -v;q\" -z \"{crashDump.FilePath}\"", outputStream, errorStream);
+                var returnStatusCode = exitCode != 0 ? HttpStatusCode.InternalServerError : HttpStatusCode.OK;
+                return Request.CreateResponse(returnStatusCode, new { output = outputStream.AsString(), error = errorStream.AsString() });
+            }
+        }
+
+        private CrashDumpInfo GetCrashDump(string name)
+        {
+            var path = Path.Combine(_environment.CrashDumpsPath, name, ".dmp");
+            if (FileSystemHelpers.FileExists(path))
+            {
+                var fileInfo = FileSystemHelpers.FileInfoFromFileName(path);
+                return GetCrashDumpInfoFromFile(fileInfo, Request.RequestUri.GetLeftPart(UriPartial.Path).TrimEnd('/'));
+            }
+            throw new HttpResponseException(HttpStatusCode.NotFound);
+        }
+
+        private static CrashDumpInfo GetCrashDumpInfoFromFile(FileInfoBase fileInfo, string href)
+        {
+            return new CrashDumpInfo
+            {
+                Name = fileInfo.Name,
+                Timestamp = fileInfo.LastWriteTime,
+                Href = new Uri(href),
+                AnalyizeHref = new Uri($"{href}/{fileInfo.Name}"),
+                FilePath = fileInfo.FullName
+            };
+        }
+
+        private static string ResolveCdbPath()
+        {
+            var programFiles = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ProgramFilesX86);
+            return Path.Combine(programFiles, "Windows Kits", "8.1", "Debuggers", "x64", "cdb.exe");
+        }
+    }
+}

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -277,7 +277,7 @@ namespace Kudu.Services.Performance
         }
 
         [HttpPost]
-        public HttpResponseMessage TakeCrashDump(int id, [FromUri] bool includeMemory = false)
+        public HttpResponseMessage TakeCrashDump(int id, bool includeMemory = false)
         {
             using (_tracer.Step("ProcessController.TakeCrashDump"))
             {

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -277,7 +277,7 @@ namespace Kudu.Services.Performance
         }
 
         [HttpPost]
-        public HttpResponseMessage TakeCrashDump(int id, bool includeMemory = false)
+        public HttpResponseMessage TakeCrashDump(int id, [FromUri] bool includeMemory = false)
         {
             using (_tracer.Step("ProcessController.TakeCrashDump"))
             {
@@ -285,15 +285,13 @@ namespace Kudu.Services.Performance
                 {
                     var process = GetProcessById(id);
                     var exe = new Executable(ResolveProcDumpPath(), _environment.CrashDumpsPath, TimeSpan.MaxValue);
-                    var outputStream = new MemoryStream();
-                    var errorStream = new MemoryStream();
                     var memoryFlag = includeMemory ? "-ma" : string.Empty;
 
-                    Task.Run(() =>exe.ExecuteReturnExitCode(_tracer, s => _tracer.Trace(s), s => _tracer.TraceError(s), $"-accepteula -t {id} -e -g {memoryFlag}"));
+                    Task.Run(() => exe.ExecuteReturnExitCode(_tracer, s => _tracer.Trace(s), s => _tracer.TraceError(s), $"-accepteula -t {process.Id} -e -g {memoryFlag}"));
 
                     return Request.CreateResponse(HttpStatusCode.Accepted);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     _tracer.TraceError(ex);
                     return Request.CreateErrorResponse(HttpStatusCode.InternalServerError, ex);

--- a/Kudu.Services/Infrastructure/MemoryStreamExtensions.cs
+++ b/Kudu.Services/Infrastructure/MemoryStreamExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Net.Http;
+using System.Text;
 
 namespace Kudu.Services.Infrastructure
 {
@@ -8,6 +9,16 @@ namespace Kudu.Services.Infrastructure
         public static HttpContent AsContent(this MemoryStream stream)
         {
             return new ByteArrayContent(stream.GetBuffer(), 0, (int)stream.Length);
+        }
+
+        public static string AsString(this MemoryStream stream, Encoding encoding = null)
+        {
+            if (stream.Length > 0)
+            {
+                encoding = encoding ?? Encoding.UTF8;
+                return encoding.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+            }
+            return string.Empty;
         }
     }
 }

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Commands\CommandsNativeMethods.cs" />
     <Compile Include="Commands\PersistentCommandController.cs" />
     <Compile Include="Deployment\DeploymentController.cs" />
+    <Compile Include="Diagnostics\CrashDumpController.cs" />
     <Compile Include="Diagnostics\LogStreamHandler.cs" />
     <Compile Include="Diagnostics\LogStreamManager.cs" />
     <Compile Include="Diagnostics\ProfileManager.cs" />

--- a/Kudu.TestHarness/TestEnvironment.cs
+++ b/Kudu.TestHarness/TestEnvironment.cs
@@ -129,5 +129,11 @@ namespace Kudu.TestHarness
             get;
             set;
         }
+
+        public string CrashDumpsPath
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
Added APIs

```
POST /api/processes/{id}/crashdump?includeMemory=true|false  # default is false
GET /api/crashdumps
GET /api/crashdumps/{name}
POST /api/crashdumps/{name}/analyze
```

POCO looks like this

```json
{
    "name": "cmd.exe_151109_220040.dmp",
    "timestamp": "2015-11-09T22:00:42.3817021+00:00",
    "file_path": "D:\\home\\data\\dumps\\cmd.exe_151109_220040.dmp",
    "href": "https://sitename.scm.azurewebsites.net/api/crashdumps/cmd.exe_151109_220040.dmp",
    "analyze_href": "https://siteName.scm.azurewebsites.net/api/crashdumps/cmd.exe_151109_220040.dmp/analyze",
    "download_href": "https://siteName.scm.azurewebsites.net/api/vfs/data/dumps/cmd.exe_151109_220040.dmp"
}
```

the `/analyze` route runs `!analyze -v` using `cdb`, but I'm not sure how useful it is without the symbols. I don't think the results make any sense.

I'll squash the extra commits before merging