### PR TITLE
VFS API: return file/directory created time `crtime`

### DIFF
--- a/Kudu.Contracts/Editor/VfsStatEntry.cs
+++ b/Kudu.Contracts/Editor/VfsStatEntry.cs
@@ -18,6 +18,9 @@ namespace Kudu.Contracts.Editor
         [JsonProperty(PropertyName = "mtime")]
         public DateTimeOffset MTime { get; set; }
 
+        [JsonProperty(PropertyName = "crtime")]
+        public DateTimeOffset CRTime { get; set; }
+
         [JsonProperty(PropertyName = "mime")]
         public string Mime { get; set; }
 

--- a/Kudu.Services/Infrastructure/VfsControllerBase.cs
+++ b/Kudu.Services/Infrastructure/VfsControllerBase.cs
@@ -362,6 +362,7 @@ namespace Kudu.Services.Infrastructure
                 {
                     Name = fileSysInfo.Name,
                     MTime = fileSysInfo.LastWriteTimeUtc,
+                    CRTime = fileSysInfo.CreationTimeUtc,
                     Mime = mime,
                     Size = size,
                     Href = (baseAddress + Uri.EscapeUriString(unescapedHref) + query).EscapeHashCharacter(),

--- a/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
+++ b/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
@@ -69,6 +69,7 @@ namespace Kudu.Services.Infrastructure
                 {
                     Name = SystemDriveFolder,
                     MTime = dir.LastWriteTimeUtc,
+                    CRTime = dir.CreationTimeUtc,
                     Mime = "inode/shortcut",
                     Href = baseAddress + Uri.EscapeUriString(SystemDriveFolder + VfsControllerBase.UriSegmentSeparator) + query,
                     Path = dir.FullName
@@ -82,6 +83,7 @@ namespace Kudu.Services.Infrastructure
                 {
                     Name = LocalSiteRootFolder,
                     MTime = dir.LastWriteTimeUtc,
+                    CRTime = dir.CreationTimeUtc,
                     Mime = "inode/shortcut",
                     Href = baseAddress + Uri.EscapeUriString(LocalSiteRootFolder + VfsControllerBase.UriSegmentSeparator) + query,
                     Path = dir.FullName


### PR DESCRIPTION
Note it's not `ctime` as that has different semantics (See http://www.linux-faqs.info/general/difference-between-mtime-ctime-and-atime "A common mistake is that ctime is the file creation time ...")