### PR TITLE
Initial attempt of Extending the logstream #1638

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -55,6 +55,11 @@ namespace Kudu.Contracts.Settings
             return GetTimeSpan(settings, SettingsKeys.LogStreamTimeout, DefaultLogStreamTimeout);
         }
 
+        public static string GetCustomLogStreamPath(this IDeploymentSettingsManager settings, string streamKey)
+        {
+            return String.Concat(SettingsKeys.LogStreamCustomLog, streamKey.ToUpperInvariant());
+        }
+
         public static string GetPostDeploymentActionsDir(this IDeploymentSettingsManager settings, string defaultPath)
         {
             string value = settings.GetValue(SettingsKeys.PostDeploymentActionsDirectory);
@@ -140,7 +145,7 @@ namespace Kudu.Contracts.Settings
             string repositoryPath = settings.GetValue(SettingsKeys.RepositoryPath);
             if (!String.IsNullOrEmpty(repositoryPath))
             {
-                return System.Environment.ExpandEnvironmentVariables(repositoryPath);
+                return Environment.ExpandEnvironmentVariables(repositoryPath);
             }
 
             // in case of no repository, we will default to webroot (preferring inplace).
@@ -157,7 +162,7 @@ namespace Kudu.Contracts.Settings
             string targetPath = settings.GetValue(SettingsKeys.TargetPath);
             if (!String.IsNullOrEmpty(targetPath))
             {
-                return System.Environment.ExpandEnvironmentVariables(targetPath);
+                return Environment.ExpandEnvironmentVariables(targetPath);
             }
 
             return null;

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -13,6 +13,7 @@
         public const string TraceLevel = "SCM_TRACE_LEVEL";
         public const string CommandIdleTimeout = "SCM_COMMAND_IDLE_TIMEOUT";
         public const string LogStreamTimeout = "SCM_LOGSTREAM_TIMEOUT";
+        public const string LogStreamCustomLog = "SCM_LOGSTREAM_";
         public const string GitUsername = "SCM_GIT_USERNAME";
         public const string GitEmail = "SCM_GIT_EMAIL";
         public const string ScmType = "ScmType";
@@ -35,9 +36,5 @@
         public const string SiteExtensionsFeedUrl = "SCM_SITEEXTENSIONS_FEED_URL";
         public const string DisableDeploymentOnPush = "SCM_DISABLE_DEPLOY_ON_PUSH";
         public const string TouchWebConfigAfterDeployment = "SCM_TOUCH_WEBCONFIG_AFTER_DEPLOYMENT";
-        public static string CustomLogStream(string streamKey)
-        {
-            return string.Concat("SCM_LOGSTREAM_", streamKey.ToUpperInvariant());
-        }
     }
 }

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -35,5 +35,9 @@
         public const string SiteExtensionsFeedUrl = "SCM_SITEEXTENSIONS_FEED_URL";
         public const string DisableDeploymentOnPush = "SCM_DISABLE_DEPLOY_ON_PUSH";
         public const string TouchWebConfigAfterDeployment = "SCM_TOUCH_WEBCONFIG_AFTER_DEPLOYMENT";
+        public static string CustomLogStream(string streamKey)
+        {
+            return string.Concat("SCM_LOGSTREAM_", streamKey.ToUpperInvariant());
+        }
     }
 }

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -15,10 +15,8 @@ using Kudu.Core.Infrastructure;
 using Kudu.Core.Settings;
 using Kudu.Core.Tracing;
 using Kudu.Services.Infrastructure;
-
-using Environment = System.Environment;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Policy;
+using Environment = System.Environment;
 
 namespace Kudu.Services.Performance
 {
@@ -298,8 +296,10 @@ namespace Kudu.Services.Performance
                 return Path.Combine(_logPath, routePath);
             }
 
-            // in case a custom log file path exist
-            string path = _settings.GetValue(SettingsKeys.CustomLogStream(firstPath));
+            // Given that SCM_LOGSTREAM_MYLOG is used in "appsettings"
+            // And the value for the key supplies a relative path like "site\wwwroot\app_data\logs\"
+            // Then return the custom log path: env root path + custom log path => D:\home + site\wwwroot\app_data\logs\
+            string path = _settings.GetValue(_settings.GetCustomLogStreamPath(firstPath));
             if (!string.IsNullOrEmpty(path))
             {
                 var customLogPath = Path.Combine(_environment.RootPath, path.TrimStart('\\'));

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -18,6 +18,7 @@ using Kudu.Services.Infrastructure;
 
 using Environment = System.Environment;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Policy;
 
 namespace Kudu.Services.Performance
 {
@@ -48,6 +49,7 @@ namespace Kudu.Services.Performance
 
         private ShutdownDetector _shutdownDetector;
         private CancellationTokenRegistration _cancellationTokenRegistration;
+        private IDeploymentSettingsManager _settings;
 
         public LogStreamManager(string logPath, 
                                 IEnvironment environment,
@@ -60,6 +62,7 @@ namespace Kudu.Services.Performance
             _tracer = tracer;
             _environment = environment;
             _shutdownDetector = shutdownDetector;
+            _settings = settings;
             _timeout = settings.GetLogStreamTimeout();
             _operationLock = operationLock;
             _results = new List<ProcessRequestAsyncResult>();
@@ -279,21 +282,29 @@ namespace Kudu.Services.Performance
                 return _logPath;
             }
 
-            // in case of application or http log, we ensure directory
+            // find the first part after /logstream/ which can be application, http or a custom defined path.
             string firstPath = routePath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries)[0];
             bool isApplication = String.Equals(firstPath, "Application", StringComparison.OrdinalIgnoreCase);
             if (isApplication)
             {
                 _enableTrace = true;
-                FileSystemHelpers.EnsureDirectory(Path.Combine(_logPath, firstPath));
             }
-            else
+
+            // in case of application or http log, we ensure directory
+            bool isHttp = String.Equals(firstPath, "http", StringComparison.OrdinalIgnoreCase);
+            if (isHttp || isApplication)
             {
-                bool isHttp = String.Equals(firstPath, "http", StringComparison.OrdinalIgnoreCase);
-                if (isHttp)
-                {
-                    FileSystemHelpers.EnsureDirectory(Path.Combine(_logPath, firstPath));
-                }
+                FileSystemHelpers.EnsureDirectory(Path.Combine(_logPath, firstPath));
+                return Path.Combine(_logPath, routePath);
+            }
+
+            // in case a custom log file path exist
+            string path = _settings.GetValue(SettingsKeys.CustomLogStream(firstPath));
+            if (!string.IsNullOrEmpty(path))
+            {
+                var customLogPath = Path.Combine(_environment.RootPath, path.TrimStart('\\'));
+                FileSystemHelpers.EnsureDirectory(customLogPath);
+                return customLogPath;
             }
 
             return Path.Combine(_logPath, routePath);


### PR DESCRIPTION
This PR implements the idea of extending the logstream as discussed in https://github.com/projectkudu/kudu/issues/1638

With this in place I can add an AppSetting with Key `SCM_LOGSTREAM_UMBRACO` and Value `site\wwwroot\app_data\logs`, which enables the endpoint `/api/logstream/umbraco` and a logstream that outputs everything from the logfiles within the `logs` folder.

I still have issues getting the functional tests to run as per #1765 so I haven't added any functional tests (yet). Out of the 3 `LogStreamManager` tests only the "NotFound" one works on my machine. I'd be happy to add a test for this scenario, but I'd need a bit of guidance on what to include and how to specify setting keys as part of a test.
