### PR TITLE
Fix logo height issue with edge 13

### DIFF
--- a/Kudu.Services.Web/_Layout.cshtml
+++ b/Kudu.Services.Web/_Layout.cshtml
@@ -38,7 +38,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="~/" style="padding-top: 13px"><img src="/Content/Images/kudu.svg" style="width: 50px"></a>
+                <a class="navbar-brand" href="~/" style="padding-top: 13px"><img src="/Content/Images/kudu.svg" style="width: 50px; height: 18px"></a>
             </div>
             <div class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
Issue with Edge 13 (Windows 10 TH2) And I think the Edge of the problem...

![kudu_logo](https://cloud.githubusercontent.com/assets/1356444/11291245/4251e368-8f81-11e5-81ea-39c891708b25.png)
