### PR TITLE
[Ace] Version up to 1.2.2 and code cleanup

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -145,7 +145,7 @@ var copyObjectsManager = {
         }
 
         return perc;
-    }, 
+    },
     removeAtIndex: function(index) {
         delete this._copyProgressObjects[index];
     },
@@ -156,7 +156,6 @@ var copyObjectsManager = {
     }
 }
 
-var statusbarObj = Object.create(statusbar);
 copyObjectsManager.init();
 
 $.connection.hub.url = appRoot + "api/filesystemhub";
@@ -344,15 +343,15 @@ $.connection.hub.start().done(function () {
         this.editItem = function () {
             var that = this;
             // Blank out the editor before fetching new content
-            viewModel.editText(null);
-            statusbarObj.fetchingContents();
+            viewModel.editText('');
+            statusbar.fetchingContents();
             viewModel.fileEdit(this);
             if(this.mime === "text/xml")
             {
                 Vfs.getContent(this)
                    .done(function (data) {
                        viewModel.editText(vkbeautify.xml(data));
-                       statusbarObj.showFilename();
+                       statusbar.showFilename();
                        // Editor h-scroll workaround
                        editor.session.setScrollLeft(-1);
                    }).fail(showError);
@@ -361,7 +360,7 @@ $.connection.hub.start().done(function () {
                 Vfs.getContent(this)
                    .done(function (data) {
                        viewModel.editText(data);
-                       statusbarObj.showFilename();
+                       statusbar.showFilename();
                        // Editor h-scroll workaround
                        editor.session.setScrollLeft(-1);
                    }).fail(showError);
@@ -370,23 +369,23 @@ $.connection.hub.start().done(function () {
 
         this.saveItem = function () {
             var text = viewModel.editText();
-            statusbarObj.savingChanges();
+            statusbar.savingChanges();
             Vfs.setContent(this, text)
                 .done(function () {
-                    statusbarObj.acknowledgeSave();
+                    statusbar.acknowledgeSave();
                 }).fail(function (error) {
                     showErrorAsAlert(error);
-                    statusbarObj.errorState.set();
+                    statusbar.errorState.set();
                 });
         }
 
         this.saveItemAndClose = function () {
             var text = viewModel.editText();
-            statusbarObj.savingChanges();
+            statusbar.savingChanges();
             Vfs.setContent(this, text)
                 .done(function () {
                     viewModel.fileEdit(null);
-                    statusbarObj.reset();
+                    statusbar.reset();
                 }).fail(function (error) {
                     showErrorAsAlert(error);
                     statusbar.errorState.set()
@@ -408,7 +407,7 @@ $.connection.hub.start().done(function () {
             isTransferInProgress: ko.observable(false),
             cancelEdit: function () {
                 viewModel.fileEdit(null);
-                statusbarObj.reset();
+                statusbar.reset();
             },
             selectSpecialDir: function (name) {
                 var item = viewModel.specialDirsIndex()[name];

--- a/Kudu.Services.Web/DebugConsole/Default.cshtml
+++ b/Kudu.Services.Web/DebugConsole/Default.cshtml
@@ -7,8 +7,8 @@
     <link href="~/content/styles/filebrowser.css" rel="stylesheet" />
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.2/css/font-awesome.css" rel="stylesheet" />
     <script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-2.2.1.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.9/ace.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.9/ext-modelist.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ext-modelist.js" type="text/javascript"></script>
 }
 
 <div id="main" class="container">


### PR DESCRIPTION
### [Ace] Version up to 1.2.2 and code cleanup ###

`editor.setValue()` now expects a string - changed that accordingly.

Removed `var statusbarObj = Object.create(statusbar)` - no need to newup a statusbarObj, we can use `statusbar` directly.

#### What's new in Ace 1.2.2 that at least two people care about: ####

- Updated LESS and CSS modes
- Vim mode enhancements
- Fix CTRL-F now binds to `Find` - no longer cycles between `Find` and `Find and Replace` - See https://github.com/ajaxorg/ace/issues/2653. I already know two people who care about this one!

Passes my PhantomJS functional tests - which given that nobody else knows what they are - isn't saying much :) I'll make them public soon.

#### Question for the Kudu audience: ####
Should i implement a CTRL-R as "Reload this file in the editor"? Might do wonders for log files that otherwise you'd need to tail with `tail -f php_error.log`.