### PR TITLE
Add DataTransferItem feature detection for Edge

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -750,9 +750,10 @@ $.connection.hub.start().done(function () {
 
     function _getInputFiles(evt) {
         var dt = evt.originalEvent.dataTransfer,
-            items = evt.originalEvent.dataTransfer.items;
+            items = evt.originalEvent.dataTransfer.items,
+            isSupportedGetAsEntry = typeof DataTransferItem !== "undefined" && !!(DataTransferItem.prototype.webkitGetAsEntry || DataTransferItem.prototype.getAsEntry);
 
-        if (items && items.length) {
+        if (items && items.length && isSupportedGetAsEntry) {
             return whenArray($.map(items, function (item) {
                 if (item.kind === 'file') {
                     var entry = (item.webkitGetAsEntry || item.getAsEntry).apply(item);


### PR DESCRIPTION
Fixed a problem that can't upload files using Microsoft Edge #1705 
I confirmed in IE11/Edge25/Chrome47 browsers :smile_cat: 