### PR TITLE
Fixes #1833, Support for Powershell execution in Post deployment action

### DIFF
--- a/Kudu.Core/Scripts/postdeployment.cmd
+++ b/Kudu.Core/Scripts/postdeployment.cmd
@@ -3,10 +3,15 @@
 setlocal enabledelayedexpansion
 
 IF EXIST %POST_DEPLOYMENT_ACTIONS_DIR% (
-  FOR /F %%A IN ('dir /s /b %POST_DEPLOYMENT_ACTIONS_DIR%\*.cmd %POST_DEPLOYMENT_ACTIONS_DIR%\*.bat') DO (
+  FOR /F %%A IN ('dir /s /b %POST_DEPLOYMENT_ACTIONS_DIR%\*.cmd %POST_DEPLOYMENT_ACTIONS_DIR%\*.bat %POST_DEPLOYMENT_ACTIONS_DIR%\*.ps1') DO (
     set CURRENT_SCRIPT_FILE=%%A
     echo Executing - '!CURRENT_SCRIPT_FILE!'
-    call !CURRENT_SCRIPT_FILE!
+    :: Get last four chars and check if file end with '.ps1' (powershell file)
+    IF /I "!CURRENT_SCRIPT_FILE:~-4!"==".ps1" (
+        call PowerShell -NoProfile -NoLogo -ExecutionPolicy RemoteSigned "!CURRENT_SCRIPT_FILE!"
+    ) else (
+        call "!CURRENT_SCRIPT_FILE!"
+    )
     IF !ERRORLEVEL! NEQ 0 goto error
     echo '!CURRENT_SCRIPT_FILE!' executed successfully
   )

--- a/Kudu.FunctionalTests/DeploymentActionsTests.cs
+++ b/Kudu.FunctionalTests/DeploymentActionsTests.cs
@@ -16,6 +16,8 @@ namespace Kudu.FunctionalTests
             string testName = "PostDeploymentActionsShouldBeCalledOnSuccessfulDeployment";
             string testLine1 = "test script 1 is running";
             string testLine2 = "test script 2 is running too";
+            string psTestLine1 = "ps test script 1 is running";
+            string psTestLine2 = "ps test script 2 is running too";
 
             const string testCommitIdPrefix = @"SCM_COMMIT_ID = ";
             const string testCommitIdVariable = @"%SCM_COMMIT_ID%";
@@ -48,6 +50,14 @@ namespace Kudu.FunctionalTests
                             @"@echo off
                               echo " + testCommitIdPrefix + testCommitIdVariable);
 
+                        appManager.VfsManager.WriteAllText(
+                            @"site\deployments\tools\PostDeploymentActions\ps_script_1.ps1",
+                            "write-output '" + psTestLine1 + "'");
+
+                        appManager.VfsManager.WriteAllText(
+                            @"site\deployments\tools\PostDeploymentActions\ps_script_2.ps1",
+                            "write-output '" + psTestLine2 + "'");
+
                         TestTracer.Trace("Deploy test app");
                         appManager.GitDeploy(appRepository.PhysicalPath);
 
@@ -56,7 +66,7 @@ namespace Kudu.FunctionalTests
                         Assert.Equal(1, deploymentResults.Count);
                         Assert.Equal(DeployStatus.Success, deploymentResults[0].Status);
 
-                        KuduAssert.VerifyLogOutput(appManager, deploymentResults[0].Id, testLine1, testLine2);
+                        KuduAssert.VerifyLogOutput(appManager, deploymentResults[0].Id, testLine1, testLine2, psTestLine1, psTestLine2);
                         KuduAssert.VerifyLogOutput(appManager, deploymentResults[0].Id, testCommitIdPrefix + deploymentResults[0].Id);
                     }
                 });


### PR DESCRIPTION
Partial deployment logs for verification

````
remote: .........
remote: Executing CMD/BAT - 'D:\home\site\deployments\tools\PostDeploymentActions\test.cmd'
remote: 'D:\home\site\deployments\tools\PostDeploymentActions\test.cmd' executed successfully
remote: Executing PS - 'D:\home\site\deployments\tools\PostDeploymentActions\test.ps1'
remote: 'D:\home\site\deployments\tools\PostDeploymentActions\test.ps1' executed successfully
remote: Finished successfully.
remote: Deployment successful.
````