### PR TITLE
Use Consolas as the command window font

### DIFF
--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -86,7 +86,7 @@ div.upload-unzip-show {
 }
 
 div.zip-upload-text {
-    font-family: 'Lucida Console', Consolas, 'Courier New', monospace;
+    font-family: Consolas, 'Lucida Console', 'Courier New', monospace;
     font-size: large;
     position: relative;
     text-align: center;
@@ -94,7 +94,7 @@ div.zip-upload-text {
 }
 
 div.console {
-    font-family: 'Lucida Console', Consolas, 'Courier New', monospace;
+    font-family: Consolas, 'Lucida Console', 'Courier New', monospace;
     height: 100%;
     margin: auto;
     white-space: pre-wrap;


### PR DESCRIPTION
Put Consolas in font-family list before Lucida Console, since Lucida Console is an ugly font, and Consolas is beautiful.