### PR TITLE
fix #1922 tracing issue in bgthread sync triggers

### DIFF
--- a/Kudu.Contracts/Functions/IFunctionManager.cs
+++ b/Kudu.Contracts/Functions/IFunctionManager.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Kudu.Core.SourceControl;
+using Kudu.Contracts.Tracing;
 using Newtonsoft.Json.Linq;
 
 namespace Kudu.Core.Functions
 {
     public interface IFunctionManager
     {
-        Task SyncTriggersAsync();
+        Task SyncTriggersAsync(ITracer tracer = null);
         Task<FunctionEnvelope> CreateOrUpdateAsync(string name, FunctionEnvelope functionEnvelope, Action setConfigChanged);
         Task<IEnumerable<FunctionEnvelope>> ListFunctionsConfigAsync();
         Task<FunctionEnvelope> GetFunctionConfigAsync(string name);

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -287,6 +287,13 @@ namespace Kudu.Core
                 var url = HttpContext.Current?.Request?.Url?.GetLeftPart(UriPartial.Authority);
                 if (string.IsNullOrEmpty(url))
                 {
+                    // if call is not done in Request context (eg. in BGThread), fall back to %host%
+                    var host = System.Environment.GetEnvironmentVariable(Constants.HttpHost);
+                    if (!string.IsNullOrEmpty(host))
+                    {
+                        return $"https://{host}";
+                    }
+
                     throw new InvalidOperationException("There is no request context");
                 }
                 return url;

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -22,9 +22,9 @@ namespace Kudu.Core.Functions
             _traceFactory = traceFactory;
         }
 
-        public async Task SyncTriggersAsync()
+        public async Task SyncTriggersAsync(ITracer tracer = null)
         {
-            var tracer = _traceFactory.GetTracer();
+            tracer = tracer ?? _traceFactory.GetTracer();
             using (tracer.Step("FunctionManager.SyncTriggers"))
             {
                 if (!IsFunctionEnabled)

--- a/Kudu.Core/Infrastructure/OperationClient.cs
+++ b/Kudu.Core/Infrastructure/OperationClient.cs
@@ -39,7 +39,7 @@ namespace Kudu.Core.Infrastructure
             }
 
             var host = System.Environment.GetEnvironmentVariable(Constants.HttpHost);
-            if (String.IsNullOrEmpty(jwt))
+            if (String.IsNullOrEmpty(host))
             {
                 throw new InvalidOperationException("Missing HTTP_HOST env!");
             }
@@ -48,11 +48,12 @@ namespace Kudu.Core.Infrastructure
             {
                 using (var client = ClientHandler != null ? new HttpClient(ClientHandler) : new HttpClient())
                 {
-                    client.BaseAddress = new Uri("https://" + host);
+                    client.BaseAddress = new Uri($"https://{host}");
                     client.DefaultRequestHeaders.UserAgent.Add(_userAgent.Value);
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
 
                     HttpResponseMessage response = await client.PostAsJsonAsync(path, content);
+                    _tracer.Trace("Response: " + response.StatusCode);
                     response.EnsureSuccessStatusCode();
                     return response;
                 }


### PR DESCRIPTION
The logfile samples

```
2016-03-10T18-31-45_5d985b_008_PUT_api-functions-SampleTimerTrigger_201_0s.xml
2016-03-10T18-31-45_5d985b_009_Background_POST_api-functions-synctriggers_0s.xml
```

The content of the BGThread logfile

```xml
<step title="BackgroundTrace" date="2016-03-10T18:31:45.446" instance="5d985b" url="/api/functions/synctriggers" method="POST" >
    <step title="FunctionManager.SyncTriggers" date="2016-03-10T18:31:45.446" >
        <step title="Sync queueTrigger of SampleQueueTrigger" date="2016-03-10T18:31:45.467" />
        <!-- duration: 16ms -->
        <step title="Sync timerTrigger of SampleTimerTrigger" date="2016-03-10T18:31:45.483" />
        <!-- duration: 0ms -->
        <step title="POST /operations/settriggers" date="2016-03-10T18:31:45.499" >
            <step title="Response: OK" date="2016-03-10T18:31:45.686" />
            <!-- duration: 16ms -->
        </step>
        <!-- duration: 219ms -->
    </step>
    <!-- duration: 271ms -->
</step>
<!-- duration: 271ms -->
```