### PR TITLE
fix initial put function may not have host.json

### DIFF
--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -51,10 +51,14 @@ namespace Kudu.Core.Functions
             }
         }
 
-        private bool IsFunctionEnabled
+        private static bool IsFunctionEnabled
         {
-            // this should read appSettings instead
-            get { return FileSystemHelpers.FileExists(HostJsonPath); }
+            get 
+            {
+                var functionVersion = System.Environment.GetEnvironmentVariable("FUNCTIONS_EXTENSION_VERSION");
+                return !String.IsNullOrEmpty(functionVersion) &&
+                    !String.Equals("disabled", functionVersion, StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         private async Task<JArray> GetTriggerInputsAsync(ITracer tracer)


### PR DESCRIPTION
host.json is created by runtime.  During initial put of function, it may not exist.  As a result, no trigger is synched.   Change to use env instead.