### PR TITLE
webjob startup issue led to no job running

### DIFF
--- a/Kudu.Core/Infrastructure/OperationManager.cs
+++ b/Kudu.Core/Infrastructure/OperationManager.cs
@@ -80,5 +80,17 @@ namespace Kudu.Core.Infrastructure
 
             return default(TVal);
         }
+
+        public static void SafeExecute(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch
+            {
+                // no-op
+            }
+        }
     }
 }

--- a/Kudu.Core/Jobs/ContinuousJobRunner.cs
+++ b/Kudu.Core/Jobs/ContinuousJobRunner.cs
@@ -94,11 +94,13 @@ namespace Kudu.Core.Jobs
 
                         _continuousJobLogger.StartingNewRun();
 
+                        var tracer = TraceFactory.GetTracer();
+                        using (tracer.Step("Run {0} {1}", continuousJob.JobType, continuousJob.Name))
                         using (new Timer(LogStillRunning, null, TimeSpan.FromHours(1), TimeSpan.FromHours(12)))
                         {
                             InitializeJobInstance(continuousJob, _continuousJobLogger);
                             WebJobPort = GetAvailableJobPort();
-                            RunJobInstance(continuousJob, _continuousJobLogger, String.Empty, String.Empty, WebJobPort);
+                            RunJobInstance(continuousJob, _continuousJobLogger, String.Empty, String.Empty, tracer, WebJobPort);
                         }
 
                         if (_started == 1 && !IsDisabled)

--- a/Kudu.Core/Jobs/JobsFileWatcher.cs
+++ b/Kudu.Core/Jobs/JobsFileWatcher.cs
@@ -108,6 +108,9 @@ namespace Kudu.Core.Jobs
                         return;
                     }
 
+                    // dispose existing _fileSystemWatcher in case of exception and retry
+                    DisposeWatcher();
+
                     // Start file system watcher
                     _fileSystemWatcher = _filter != null ? new FileSystemWatcher(_watchedDirectoryPath, _filter) : new FileSystemWatcher(_watchedDirectoryPath);
                     _fileSystemWatcher.Created += OnChanged;

--- a/Kudu.Core/Jobs/TriggeredJobsScheduler.cs
+++ b/Kudu.Core/Jobs/TriggeredJobsScheduler.cs
@@ -17,14 +17,16 @@ namespace Kudu.Core.Jobs
         private readonly ITriggeredJobsManager _triggeredJobsManager;
         private readonly ITraceFactory _traceFactory;
         private readonly IEnvironment _environment;
+        private readonly IAnalytics _analytics;
 
         private readonly Dictionary<string, TriggeredJobSchedule> _triggeredJobsSchedules = new Dictionary<string, TriggeredJobSchedule>(StringComparer.OrdinalIgnoreCase);
 
-        public TriggeredJobsScheduler(ITriggeredJobsManager triggeredJobsManager, ITraceFactory traceFactory, IEnvironment environment)
+        public TriggeredJobsScheduler(ITriggeredJobsManager triggeredJobsManager, ITraceFactory traceFactory, IEnvironment environment, IAnalytics analytics)
         {
             _triggeredJobsManager = triggeredJobsManager;
             _traceFactory = traceFactory;
             _environment = environment;
+            _analytics = analytics;
 
             _triggeredJobsManager.RegisterExtraEventHandlerForFileChange(OnJobChanged);
         }
@@ -51,7 +53,7 @@ namespace Kudu.Core.Jobs
                     {
                         if (triggeredJobSchedule == null)
                         {
-                            triggeredJobSchedule = new TriggeredJobSchedule(triggeredJob, OnSchedule, logger);
+                            triggeredJobSchedule = new TriggeredJobSchedule(triggeredJob, OnSchedule, logger, _analytics);
                             _triggeredJobsSchedules[jobName] = triggeredJobSchedule;
                         }
 

--- a/Kudu.Core/Tracing/Analytics.cs
+++ b/Kudu.Core/Tracing/Analytics.cs
@@ -48,6 +48,16 @@ namespace Kudu.Core.Tracing
                 NullToEmptyString(trigger));
         }
 
+        public void JobEvent(string jobName, string message, string jobType, string error)
+        {
+            KuduEventSource.Log.WebJobEvent(
+                _serverConfiguration.ApplicationName,
+                NullToEmptyString(jobName),
+                NullToEmptyString(message),
+                NullToEmptyString(jobType),
+                NullToEmptyString(error));
+        }
+
         public void UnexpectedException(Exception exception, bool trace = true)
         {
             KuduEventSource.Log.KuduUnexpectedException(

--- a/Kudu.Core/Tracing/IAnalytics.cs
+++ b/Kudu.Core/Tracing/IAnalytics.cs
@@ -8,6 +8,8 @@ namespace Kudu.Core.Tracing
 
         void JobStarted(string jobName, string scriptExtension, string jobType, string siteMode, string error, string trigger);
 
+        void JobEvent(string jobName, string message, string jobType, string error);
+
         void UnexpectedException(Exception ex, bool trace = true);
 
         void UnexpectedException(Exception ex, string method, string path, string result, string message, bool trace = true);

--- a/Kudu.Core/Tracing/KuduEventSource.cs
+++ b/Kudu.Core/Tracing/KuduEventSource.cs
@@ -61,5 +61,14 @@ namespace Kudu.Core.Tracing
                 WriteEvent(65511, siteName, method, path, result, deploymentDurationInMilliseconds, Message);
             }
         }
+
+        [Event(65513, Level = EventLevel.Informational, Message = "WebJob {1} event for site {0}", Channel = EventChannel.Operational)]
+        public void WebJobEvent(string siteName, string jobName, string message, string jobType, string error)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(65513, siteName, jobName, message, jobType, error);
+            }
+        }
     }
 }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -238,25 +238,25 @@ namespace Kudu.Services.Web.App_Start
             kernel.Bind<ITriggeredJobsManager>().ToConstant(triggeredJobsManager)
                                              .InTransientScope();
 
+            TriggeredJobsScheduler triggeredJobsScheduler = new TriggeredJobsScheduler(
+                triggeredJobsManager,
+                noContextTraceFactory,
+                environment,
+                kernel.Get<IAnalytics>());
+            kernel.Bind<TriggeredJobsScheduler>().ToConstant(triggeredJobsScheduler)
+                                             .InTransientScope();
+
             IContinuousJobsManager continuousJobManager = new ContinuousJobsManager(
                 noContextTraceFactory,
                 kernel.Get<IEnvironment>(),
                 kernel.Get<IDeploymentSettingsManager>(),
                 kernel.Get<IAnalytics>());
 
-            triggeredJobsManager.CleanupDeletedJobs();
-            continuousJobManager.CleanupDeletedJobs();
+            OperationManager.SafeExecute(triggeredJobsManager.CleanupDeletedJobs);
+            OperationManager.SafeExecute(continuousJobManager.CleanupDeletedJobs);
 
             kernel.Bind<IContinuousJobsManager>().ToConstant(continuousJobManager)
                                  .InTransientScope();
-
-            TriggeredJobsScheduler triggeredJobsScheduler = new TriggeredJobsScheduler(
-                triggeredJobsManager,
-                noContextTraceFactory,
-                environment);
-
-            kernel.Bind<TriggeredJobsScheduler>().ToConstant(triggeredJobsScheduler)
-                                             .InTransientScope();
 
             kernel.Bind<ILogger>().ToMethod(context => GetLogger(environment, context.Kernel))
                                              .InRequestScope();
@@ -585,7 +585,7 @@ namespace Kudu.Services.Web.App_Start
 
         private static void EnsureNpmGlobalDirectory()
         {
-            try
+            OperationManager.SafeExecute(() =>
             {
                 string appData = System.Environment.GetEnvironmentVariable("APPDATA");
                 FileSystemHelpers.EnsureDirectory(Path.Combine(appData, "npm"));
@@ -594,25 +594,17 @@ namespace Kudu.Services.Web.App_Start
                 // this is to work around below issue with the very first npm install 
                 // npm ERR! uid must be an unsigned int
                 FileSystemHelpers.EnsureDirectory(Path.Combine(appData, "npm-cache"));
-            }
-            catch
-            {
-                // no op
-            }
+            });
         }
 
         private static void EnsureUserProfileDirectory()
         {
-            try
+            OperationManager.SafeExecute(() =>
             {
                 //this is for gulp 3.9.0 which fails if UserProfile is not there
                 string userProfile = System.Environment.GetEnvironmentVariable("USERPROFILE");
                 FileSystemHelpers.EnsureDirectory(userProfile);
-            }
-            catch
-            {
-                // no op
-            }
+            });
         }
 
         private static ITracer GetTracer(IEnvironment environment, IKernel kernel)


### PR DESCRIPTION
The key fix is to throw if IOException when building job.   This caused the start up codes in JobsFileWatcher to retry.    The rest of the fix is to add traces to help investigate future issue.