### PR TITLE
use capital case for Message to show up in MDS

### DIFF
--- a/Kudu.Core/Tracing/KuduEventSource.cs
+++ b/Kudu.Core/Tracing/KuduEventSource.cs
@@ -63,11 +63,11 @@ namespace Kudu.Core.Tracing
         }
 
         [Event(65513, Level = EventLevel.Informational, Message = "WebJob {1} event for site {0}", Channel = EventChannel.Operational)]
-        public void WebJobEvent(string siteName, string jobName, string message, string jobType, string error)
+        public void WebJobEvent(string siteName, string jobName, string Message, string jobType, string error)
         {
             if (IsEnabled())
             {
-                WriteEvent(65513, siteName, jobName, message, jobType, error);
+                WriteEvent(65513, siteName, jobName, Message, jobType, error);
             }
         }
     }


### PR DESCRIPTION
Caught while verifying in production and message didn't show up at the right column.   This is consistent pattern with other event (see KuduException for instance).