### PR TITLE
handle corrupted job status file

### DIFF
--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -422,7 +422,7 @@ namespace Kudu.Core.Jobs
 
         protected TJobStatus GetStatus<TJobStatus>(string statusFilePath) where TJobStatus : class, IJobStatus, new()
         {
-            return JobLogger.ReadJobStatusFromFile<TJobStatus>(TraceFactory, statusFilePath) ?? new TJobStatus();
+            return JobLogger.ReadJobStatusFromFile<TJobStatus>(TraceFactory, statusFilePath);
         }
 
         protected Uri BuildJobsUrl(string relativeUrl)

--- a/Kudu.Core/Jobs/TriggeredJobsManager.cs
+++ b/Kudu.Core/Jobs/TriggeredJobsManager.cs
@@ -172,6 +172,11 @@ namespace Kudu.Core.Jobs
 
             var triggeredJobStatus = GetStatus<TriggeredJobStatus>(statusFilePath);
 
+            if (triggeredJobStatus == null)
+            {
+                return null;
+            }
+
             if (triggeredJobStatus.Status == JobStatus.Running)
             {
                 if (isLatest)


### PR DESCRIPTION
Treat corrupted job status file as initial job run state (as if no job status at all).