### PR TITLE
adding lock object to JobmanagerBase ListJobs to fix a possible race Condition

### DIFF
--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -50,6 +50,8 @@ namespace Kudu.Core.Jobs
 
         private string _lastKnownAppBaseUrlPrefix;
 
+        internal static object jobsListCacheLockObj = new object();
+
         protected IEnvironment Environment { get; private set; }
 
         protected IDeploymentSettingsManager Settings { get; private set; }
@@ -112,10 +114,13 @@ namespace Kudu.Core.Jobs
         public IEnumerable<TJob> ListJobs(bool forceRefreshCache)
         {
             var jobList = JobListCache;
-            if (jobList == null || forceRefreshCache)
+            lock (jobsListCacheLockObj)
             {
-                jobList = ListJobsInternal();
-                JobListCache = jobList;
+                if (jobList == null || forceRefreshCache)
+                {
+                    jobList = ListJobsInternal();
+                    JobListCache = jobList;
+                }
             }
             return jobList;
         }


### PR DESCRIPTION
if 2 requests come in while the cache is null, both will run in parallel and because listjobsInternal is a long running call (up to 20 seconds) the variation in the time the call finishes is big. Thus a new change induced call could finish earlier than another old change induced call, which will make the cache have an invalid state. Locking makes sure only one runs at a time, which simplifies the problem and makes sure no such race conditions happen. also locking is happening per site so no fear of it consuming a lot of time or slowing responses very much. 