### PR TITLE
Better handling of invalid host.json

### DIFF
--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -205,9 +205,28 @@ namespace Kudu.Core.Functions
 
         public async Task<JObject> GetHostConfigAsync()
         {
-            return FileSystemHelpers.FileExists(HostJsonPath)
-                ? JObject.Parse(await FileSystemHelpers.ReadAllTextFromFileAsync(HostJsonPath))
-                : new JObject();
+            var host = await TryGetHostConfigAsync();
+            if (host == null)
+            {
+                throw new FileNotFoundException("Host.json is invalid");
+            }
+            return host;
+        }
+
+        private async Task<JObject> TryGetHostConfigAsync()
+        {
+            try
+            {
+                return FileSystemHelpers.FileExists(HostJsonPath)
+                    ? JObject.Parse(await FileSystemHelpers.ReadAllTextFromFileAsync(HostJsonPath))
+                    : new JObject();
+            }
+            catch
+            {
+                // no-op
+            }
+
+            return null;
         }
 
         public async Task<JObject> PutHostConfigAsync(JObject content)


### PR DESCRIPTION
Fixes issue #1984 - gracefully handles host.json file having invalid json with a cleaner error message as opposed to what is shown in the issue, that boils up to the portal in Azure. Now user will explicitly see that they are seeing issues because their host.json is invalid.