### PR TITLE
Fixes #1987, Improve the error handling when site extension installs fail via ARM

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -84,8 +84,6 @@ namespace Kudu
 
         // TODO: need localization?
         public const string SiteExtensionProvisioningStateNotFoundMessageFormat = "'{0}' not found.";
-        public const string SiteExtensionProvisioningStateDownloadFailureMessageFormat = "'{0}' download failure.";
-        public const string SiteExtensionProvisioningStateInvalidPackageMessageFormat = "Invalid '{0}' package.";
 
         public const string FreeSKU = "Free";
         public const string BasicSKU = "Basic";


### PR DESCRIPTION
````
{
  "id": "/subscriptions/fb2c25dc-6bab-45c4-8cc9-cece7c42a95a/resourceGroups/Default-Web-EastUS/providers/Microsoft.Web/sites/kudutry/siteextensions/filecounter",
  "name": "kudutry/filecounter",
  "type": "Microsoft.Web/sites/siteextensions",
  "location": "East US",
  "properties": {
    "id": "filecounter",
    "title": null,
    "type": "Gallery",
    "summary": null,
    "description": null,
    "version": null,
    "extension_url": null,
    "project_url": null,
    "icon_url": null,
    "license_url": null,
    "feed_url": null,
    "authors": null,
    "published_date_time": null,
    "download_count": 0,
    "local_is_latest_version": null,
    "local_path": null,
    "installed_date_time": null,
    "provisioningState": "Failed",
    "comment": "System.IO.FileNotFoundException: Test FileNotFoundException\r\n   at Kudu.Core.SiteExtensions.SiteExtensionManager.<TryInstallExtension>d__27.MoveNext()"
  }
}
````

````
{
  "id": "/subscriptions/fb2c25dc-6bab-45c4-8cc9-cece7c42a95a/resourceGroups/Default-Web-EastUS/providers/Microsoft.Web/sites/kudutry/siteextensions/filecounter",
  "name": "kudutry/filecounter",
  "type": "Microsoft.Web/sites/siteextensions",
  "location": "East US",
  "properties": {
    "id": "filecounter",
    "title": null,
    "type": "Gallery",
    "summary": null,
    "description": null,
    "version": null,
    "extension_url": null,
    "project_url": null,
    "icon_url": null,
    "license_url": null,
    "feed_url": null,
    "authors": null,
    "published_date_time": null,
    "download_count": 0,
    "local_is_latest_version": null,
    "local_path": null,
    "installed_date_time": null,
    "provisioningState": "Failed",
    "comment": "System.Net.WebException: Test WebException\r\n   at Kudu.Core.SiteExtensions.SiteExtensionManager.<TryInstallExtension>d__27.MoveNext()"
  }
}
````

````
{
  "id": "/subscriptions/fb2c25dc-6bab-45c4-8cc9-cece7c42a95a/resourceGroups/Default-Web-EastUS/providers/Microsoft.Web/sites/kudutry/siteextensions/filecounter",
  "name": "kudutry/filecounter",
  "type": "Microsoft.Web/sites/siteextensions",
  "location": "East US",
  "properties": {
    "id": "filecounter",
    "title": null,
    "type": "Gallery",
    "summary": null,
    "description": null,
    "version": null,
    "extension_url": null,
    "project_url": null,
    "icon_url": null,
    "license_url": null,
    "feed_url": null,
    "authors": null,
    "published_date_time": null,
    "download_count": 0,
    "local_is_latest_version": null,
    "local_path": null,
    "installed_date_time": null,
    "provisioningState": "Failed",
    "comment": "Kudu.Contracts.SiteExtensions.InvalidEndpointException: Test InvalidEndpointException\r\n   at Kudu.Core.SiteExtensions.SiteExtensionManager.<TryInstallExtension>d__27.MoveNext()"
  }
}

````

````
{
  "id": "/subscriptions/fb2c25dc-6bab-45c4-8cc9-cece7c42a95a/resourceGroups/Default-Web-EastUS/providers/Microsoft.Web/sites/kudutry/siteextensions/filecounter",
  "name": "kudutry/filecounter",
  "type": "Microsoft.Web/sites/siteextensions",
  "location": "East US",
  "properties": {
    "id": "filecounter",
    "title": null,
    "type": "Gallery",
    "summary": null,
    "description": null,
    "version": null,
    "extension_url": null,
    "project_url": null,
    "icon_url": null,
    "license_url": null,
    "feed_url": null,
    "authors": null,
    "published_date_time": null,
    "download_count": 0,
    "local_is_latest_version": null,
    "local_path": null,
    "installed_date_time": null,
    "provisioningState": "Failed",
    "comment": "System.Exception: Test Exception\r\n   at Kudu.Core.SiteExtensions.SiteExtensionManager.<TryInstallExtension>d__27.MoveNext()"
  }
}
````