### PR TITLE
Return the run uri when invoking triggered WebJob

### DIFF
--- a/Kudu.Client/Jobs/RemoteJobsManager.cs
+++ b/Kudu.Client/Jobs/RemoteJobsManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -68,16 +69,19 @@ namespace Kudu.Client.Jobs
             await Client.PutJsonAsync<JobSettings, object>("continuouswebjobs/" + jobName + "/settings", jobSettings);
         }
 
-        public async Task InvokeTriggeredJobAsync(string jobName, string arguments = null)
+        public async Task<Uri> InvokeTriggeredJobAsync(string jobName, string arguments = null)
         {
+            HttpResponseMessage response;
             if (arguments != null)
             {
-                await Client.PostAsync("triggeredwebjobs/" + jobName + "/run?arguments=" + arguments);
+                response = await Client.PostAsync("triggeredwebjobs/" + jobName + "/run?arguments=" + arguments);
             }
             else
             {
-                await Client.PostAsync("triggeredwebjobs/" + jobName + "/run");
+                response = await Client.PostAsync("triggeredwebjobs/" + jobName + "/run");
             }
+
+            return new Uri(response.Headers.GetValues("Location").First());
         }
 
         public async Task CreateContinuousJobAsync(string jobName, string scriptFileName, string content = null)

--- a/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
+++ b/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
@@ -2,7 +2,7 @@
 {
     public interface ITriggeredJobsManager : IJobsManager<TriggeredJob>
     {
-        string InvokeTriggeredJob(string jobName, string arguments, string trigger);
+        System.Uri InvokeTriggeredJob(string jobName, string arguments, string trigger);
 
         TriggeredJobHistory GetJobHistory(string jobName, string etag, out string currentETag);
 

--- a/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
+++ b/Kudu.Contracts/Jobs/ITriggeredJobsManager.cs
@@ -2,7 +2,7 @@
 {
     public interface ITriggeredJobsManager : IJobsManager<TriggeredJob>
     {
-        void InvokeTriggeredJob(string jobName, string arguments, string trigger);
+        string InvokeTriggeredJob(string jobName, string arguments, string trigger);
 
         TriggeredJobHistory GetJobHistory(string jobName, string etag, out string currentETag);
 

--- a/Kudu.Core/Jobs/TriggeredJobRunner.cs
+++ b/Kudu.Core/Jobs/TriggeredJobRunner.cs
@@ -41,7 +41,7 @@ namespace Kudu.Core.Jobs
             get { return Settings.GetWebJobsIdleTimeout(); }
         }
 
-        public void StartJobRun(TriggeredJob triggeredJob, JobSettings jobSettings, string trigger, Action<string, string> reportAction)
+        public string StartJobRun(TriggeredJob triggeredJob, JobSettings jobSettings, string trigger, Action<string, string> reportAction)
         {
             JobSettings = jobSettings;
 
@@ -97,6 +97,9 @@ namespace Kudu.Core.Jobs
                 _lockFile.Release();
                 throw;
             }
+
+            // Return the run ID
+            return logger.Id;
         }
 
         protected override string RefreshShutdownNotificationFilePath(string jobName, string jobsTypePath)

--- a/Kudu.Core/Jobs/TriggeredJobsManager.cs
+++ b/Kudu.Core/Jobs/TriggeredJobsManager.cs
@@ -222,7 +222,7 @@ namespace Kudu.Core.Jobs
             return null;
         }
 
-        public void InvokeTriggeredJob(string jobName, string arguments, string trigger)
+        public string InvokeTriggeredJob(string jobName, string arguments, string trigger)
         {
             TriggeredJob triggeredJob = GetJob(jobName);
             if (triggeredJob == null)
@@ -244,8 +244,10 @@ namespace Kudu.Core.Jobs
 
             JobSettings jobSettings = triggeredJob.Settings;
 
-            triggeredJobRunner.StartJobRun(triggeredJob, jobSettings, trigger, ReportTriggeredJobFinished);
+            string runId = triggeredJobRunner.StartJobRun(triggeredJob, jobSettings, trigger, ReportTriggeredJobFinished);
             ClearJobListCache();
+
+            return runId;
         }
 
         private async void ReportTriggeredJobFinished(string jobName, string jobRunId)

--- a/Kudu.Core/Jobs/TriggeredJobsManager.cs
+++ b/Kudu.Core/Jobs/TriggeredJobsManager.cs
@@ -222,7 +222,7 @@ namespace Kudu.Core.Jobs
             return null;
         }
 
-        public string InvokeTriggeredJob(string jobName, string arguments, string trigger)
+        public Uri InvokeTriggeredJob(string jobName, string arguments, string trigger)
         {
             TriggeredJob triggeredJob = GetJob(jobName);
             if (triggeredJob == null)
@@ -247,7 +247,7 @@ namespace Kudu.Core.Jobs
             string runId = triggeredJobRunner.StartJobRun(triggeredJob, jobSettings, trigger, ReportTriggeredJobFinished);
             ClearJobListCache();
 
-            return runId;
+            return BuildJobsUrl("{0}/history/{1}".FormatInvariant(jobName, runId));
         }
 
         private async void ReportTriggeredJobFinished(string jobName, string jobRunId)

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -653,7 +653,9 @@ namespace Kudu.FunctionalTests.Jobs
         {
             if (!scheduledTriggeredJob)
             {
-                appManager.JobsManager.InvokeTriggeredJobAsync(jobName, arguments).Wait();
+                Uri runLocation = appManager.JobsManager.InvokeTriggeredJobAsync(jobName, arguments).Result;
+                Assert.Contains("api/triggeredwebjobs", runLocation.AbsoluteUri);
+                Assert.Contains("history", runLocation.AbsoluteUri);
             }
 
             try

--- a/Kudu.Services/Jobs/JobsController.cs
+++ b/Kudu.Services/Jobs/JobsController.cs
@@ -182,7 +182,8 @@ namespace Kudu.Services.Jobs
 
                 // Return a 200 in the ARM case, otherwise a 202 can cause it to poll on /run, which we don't support
                 // For non-ARM, stay with the 202 to reduce potential impact of change
-                return Request.CreateResponse(ArmUtils.IsArmRequest(Request) ? HttpStatusCode.OK : HttpStatusCode.Accepted);
+                return Request.CreateResponse(ArmUtils.IsArmRequest(Request) ? HttpStatusCode.OK : HttpStatusCode.Accepted,
+                    ArmUtils.AddEnvelopeOnArmRequest(_triggeredJobsManager.GetLatestJobRun(jobName), Request));
             }
             catch (JobNotFoundException)
             {

--- a/Kudu.Services/Jobs/JobsController.cs
+++ b/Kudu.Services/Jobs/JobsController.cs
@@ -178,12 +178,12 @@ namespace Kudu.Services.Jobs
         {
             try
             {
-                _triggeredJobsManager.InvokeTriggeredJob(jobName, arguments, "External - " + Request.Headers.UserAgent);
+                string runId = _triggeredJobsManager.InvokeTriggeredJob(jobName, arguments, "External - " + Request.Headers.UserAgent);
 
                 // Return a 200 in the ARM case, otherwise a 202 can cause it to poll on /run, which we don't support
                 // For non-ARM, stay with the 202 to reduce potential impact of change
                 return Request.CreateResponse(ArmUtils.IsArmRequest(Request) ? HttpStatusCode.OK : HttpStatusCode.Accepted,
-                    ArmUtils.AddEnvelopeOnArmRequest(_triggeredJobsManager.GetLatestJobRun(jobName), Request));
+                    ArmUtils.AddEnvelopeOnArmRequest(_triggeredJobsManager.GetJobRun(jobName, runId), Request));
             }
             catch (JobNotFoundException)
             {

--- a/Kudu.Services/Jobs/JobsController.cs
+++ b/Kudu.Services/Jobs/JobsController.cs
@@ -1,7 +1,6 @@
 ﻿using Kudu.Contracts;
 using Kudu.Contracts.Jobs;
 using Kudu.Contracts.Tracing;
-using Kudu.Core;
 using Kudu.Core.Hooks;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Jobs;

--- a/Kudu.Services/Jobs/JobsController.cs
+++ b/Kudu.Services/Jobs/JobsController.cs
@@ -185,7 +185,7 @@ namespace Kudu.Services.Jobs
                 // For non-ARM, stay with the 202 to reduce potential impact of change
                 var response = Request.CreateResponse(ArmUtils.IsArmRequest(Request) ? HttpStatusCode.OK : HttpStatusCode.Accepted);
 
-                // Add the run uri is the location so caller can get status
+                // Add the run uri in the location so caller can get status on the running job
                 response.Headers.Add("Location", runUri.AbsoluteUri);
 
                 return response;


### PR DESCRIPTION
Previously, starting a run returned an empty body. Now it returns the run object, letting the caller have the ID. I think the odd of someone making assumptions on the empty body is small enough that it is not a concern.