### PR TITLE
Missing request tracing on Mono

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -73,6 +73,7 @@ namespace Kudu.Services.Web.App_Start
         {
             HttpApplication.RegisterModule(typeof(OnePerRequestHttpModule));
             HttpApplication.RegisterModule(typeof(NinjectHttpModule));
+            HttpApplication.RegisterModule(typeof(TraceModule));
             _bootstrapper.Initialize(CreateKernel);
         }
 

--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -27,7 +27,6 @@
       <modules runAllManagedModulesForAllRequests="true">
         <remove name="WebDAVModule"/>
         <!--<add name="BlockLocalhostModule" type="Kudu.Services.Web.Security.BlockLocalhostModule"/>-->
-        <add name="TraceModule" type="Kudu.Services.Web.Tracing.TraceModule"/>
       </modules>
       <staticContent>
         <remove fileExtension=".svg"/>


### PR DESCRIPTION
**Issue:**
On mono, we will lost all request trace, e.g when perform a deployment we only see trace from kudu.exe, all **highlighted** trace will be missing since TraceModule is not invoked

**Solution:**
Register HttpModule via from code instead of Web.config

trace
        **├── 2016-05-20T21-44-17_abd311_002_GET_node3.git-info-refs_200_2s.xml
        ├── 2016-05-20T21-44-19_abd311_003_POST_node3.git-git-receive-pack_200_16s.xml**
        ├── 2016-05-20T21-44-23_abd311_001_kudu.exe_12s.xml
        **└── abd3118e3c27-04517727-330e-4ae0-ba00-71dcfdde45f9.txt**
