### PR TITLE
fix #1995 to provide info of lock file owner

### DIFF
--- a/Kudu.Contracts/Infrastructure/IOperationLock.cs
+++ b/Kudu.Contracts/Infrastructure/IOperationLock.cs
@@ -1,14 +1,28 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Kudu.Contracts.Infrastructure
 {
     public interface IOperationLock
     {
         bool IsHeld { get; }
-        bool Lock();
+        OperationLockInfo LockInfo { get; }
+        bool Lock(string operationName);
 
         // Waits until lock can be acquired after which the task completes.
-        Task LockAsync();
+        Task LockAsync(string operationName);
         void Release();
+    }
+
+    public class OperationLockInfo
+    {
+        public OperationLockInfo()
+        {
+            AcquiredDateTime = DateTime.UtcNow.ToString("o");
+        }
+
+        public string OperationName { get; set; }
+        public string AcquiredDateTime { get; set; }
+        public string StackTrace { get; set; }
     }
 }

--- a/Kudu.Contracts/Infrastructure/LockExtensions.cs
+++ b/Kudu.Contracts/Infrastructure/LockExtensions.cs
@@ -13,11 +13,12 @@ namespace Kudu.Contracts.Infrastructure
         // return true if lock acquired and operation executed
         public static bool TryLockOperation(this IOperationLock lockObj,
                                          Action operation,
+                                         string operationName,
                                          TimeSpan timeout)
         {
             var elapsed = TimeSpan.Zero;
 
-            while (!lockObj.Lock())
+            while (!lockObj.Lock(operationName))
             {
                 if (elapsed >= timeout)
                 {
@@ -41,9 +42,10 @@ namespace Kudu.Contracts.Infrastructure
 
         public static async Task<bool> TryLockOperationAsync(this IOperationLock lockObj,
                                                Func<Task> operation,
+                                               string operationName,
                                                TimeSpan timeout)
         {
-            bool isLocked = await WaitToLockAsync(lockObj, timeout);
+            bool isLocked = await WaitToLockAsync(lockObj, operationName, timeout);
             if (!isLocked)
             {
                 return false;
@@ -61,36 +63,58 @@ namespace Kudu.Contracts.Infrastructure
         }
 
         // acquire lock and then execute the operation
-        public static void LockOperation(this IOperationLock lockObj, Action operation, TimeSpan timeout)
+        public static void LockOperation(this IOperationLock lockObj, Action operation, string operationName, TimeSpan timeout)
         {
-            bool success = lockObj.TryLockOperation(operation, timeout);
+            bool success = lockObj.TryLockOperation(operation, operationName, timeout);
 
             if (!success)
             {
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, timeout.TotalSeconds));
+                var lockInfo = lockObj.LockInfo;
+                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
             }
         }
 
         // acquire lock and then execute the operation
-        public static T LockOperation<T>(this IOperationLock lockObj, Func<T> operation, TimeSpan timeout)
+        public static T LockOperation<T>(this IOperationLock lockObj, Func<T> operation, string operationName, TimeSpan timeout)
         {
             T result = default(T);
-            bool success = lockObj.TryLockOperation(() => result = operation(), timeout);
+            bool success = lockObj.TryLockOperation(() => result = operation(), operationName, timeout);
 
             if (!success)
             {
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, timeout.TotalSeconds));
+                var lockInfo = lockObj.LockInfo;
+                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
             }
 
             return result;
         }
 
-        public static async Task<T> LockOperationAsync<T>(this IOperationLock lockObj, Func<Task<T>> operation, TimeSpan timeout)
+        public static async Task LockOperationAsync(this IOperationLock lockObj, Func<Task> operation, string operationName, TimeSpan timeout)
         {
-            bool isLocked = await WaitToLockAsync(lockObj, timeout);
+            bool isLocked = await WaitToLockAsync(lockObj, operationName, timeout);
             if (!isLocked)
             {
-                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, timeout.TotalSeconds));
+                var lockInfo = lockObj.LockInfo;
+                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
+            }
+
+            try
+            {
+                await operation();
+            }
+            finally
+            {
+                lockObj.Release();
+            }
+        }
+
+        public static async Task<T> LockOperationAsync<T>(this IOperationLock lockObj, Func<Task<T>> operation, string operationName, TimeSpan timeout)
+        {
+            bool isLocked = await WaitToLockAsync(lockObj, operationName, timeout);
+            if (!isLocked)
+            {
+                var lockInfo = lockObj.LockInfo;
+                throw new LockOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_OperationLockTimeout, operationName, lockInfo.OperationName, lockInfo.AcquiredDateTime));
             }
 
             try
@@ -103,11 +127,11 @@ namespace Kudu.Contracts.Infrastructure
             }
         }
 
-        private static async Task<bool> WaitToLockAsync(IOperationLock lockObj, TimeSpan timeout)
+        private static async Task<bool> WaitToLockAsync(IOperationLock lockObj, string operationName, TimeSpan timeout)
         {
             var elapsed = TimeSpan.Zero;
 
-            while (!lockObj.Lock())
+            while (!lockObj.Lock(operationName))
             {
                 if (elapsed >= timeout)
                 {

--- a/Kudu.Contracts/Resources.Designer.cs
+++ b/Kudu.Contracts/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace Kudu.Contracts {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to acquire lock after {0:0} seconds.  Please retry operation later..
+        ///   Looks up a localized string similar to The &apos;{0}&apos; operation conflicts with the pending &apos;{1}&apos; operation started at {2}..
         /// </summary>
         internal static string Error_OperationLockTimeout {
             get {

--- a/Kudu.Contracts/Resources.resx
+++ b/Kudu.Contracts/Resources.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Error_OperationLockTimeout" xml:space="preserve">
-    <value>Unable to acquire lock after {0:0} seconds.  Please retry operation later.</value>
+    <value>The '{0}' operation conflicts with the pending '{1}' operation started at {2}.</value>
   </data>
 </root>

--- a/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
@@ -70,7 +70,7 @@ namespace Kudu.Core.Test.Deployment
             var deploymentPath = @"x:\sites\deployments";
             var environment = Mock.Of<IEnvironment>(e => e.DeploymentsPath == deploymentPath);
             var analytics = Mock.Of<IAnalytics>();
-            var statusLock = Mock.Of<IOperationLock>(l => l.Lock() == true);
+            var statusLock = Mock.Of<IOperationLock>(l => l.Lock(It.IsAny<string>()) == true);
             var stream = new Mock<MemoryStream> { CallBase = true };
             stream.Setup(s => s.Close());
 
@@ -120,7 +120,7 @@ namespace Kudu.Core.Test.Deployment
             var deploymentPath = @"x:\sites\deployments";
             var environment = Mock.Of<IEnvironment>(e => e.DeploymentsPath == deploymentPath);
             var analytics = Mock.Of<IAnalytics>();
-            var statusLock = Mock.Of<IOperationLock>(l => l.Lock() == true);
+            var statusLock = Mock.Of<IOperationLock>(l => l.Lock(It.IsAny<string>()) == true);
 
             var statusFile = Path.Combine(deploymentPath, id, "status.xml");
 

--- a/Kudu.Core.Test/Hooks/WebHooksManagerTests.cs
+++ b/Kudu.Core.Test/Hooks/WebHooksManagerTests.cs
@@ -196,7 +196,7 @@ namespace Kudu.Core.Test.Deployment
             hooksLockMock.SetupGet(l => l.IsHeld)
                          .Returns(() => locked);
 
-            hooksLockMock.Setup(l => l.Lock())
+            hooksLockMock.Setup(l => l.Lock(It.IsAny<string>()))
                          .Returns(() => locked = true);
 
             hooksLockMock.Setup(l => l.Release())

--- a/Kudu.Core.Test/LockFileTests.cs
+++ b/Kudu.Core.Test/LockFileTests.cs
@@ -26,14 +26,14 @@ namespace Kudu.Core.Test
             {
                 // Acquire
                 Assert.Equal(false, lockFile.IsHeld);
-                Assert.Equal(true, lockFile.Lock());
+                Assert.Equal(true, lockFile.Lock("operationName"));
 
                 // Test
                 Assert.Equal(true, lockFile.IsHeld);
-                Assert.Equal(false, lockFile.Lock());
+                Assert.Equal(false, lockFile.Lock("operationName"));
 
                 Assert.Equal(true, lockFile2.IsHeld);
-                Assert.Equal(false, lockFile2.Lock());
+                Assert.Equal(false, lockFile2.Lock("operationName"));
 
                 // Release
                 lockFile.Release();
@@ -69,7 +69,7 @@ namespace Kudu.Core.Test
                             Assert.Contains("at Kudu.Core.Test.LockFileTests", reader.ReadToEnd());
                         }
 
-                    }, TimeSpan.FromSeconds(60));
+                    }, "operationName", TimeSpan.FromSeconds(60));
                 }
             });
 
@@ -107,10 +107,10 @@ namespace Kudu.Core.Test
 
             // Test
             lockFile.RepositoryFactory = repositoryFactory.Object;
-            var locked = lockFile.Lock();
+            var locked = lockFile.Lock("operationName");
 
             // Assert
-            Assert.True(locked, "lock should be successfule!");
+            Assert.True(locked, "lock should be successful!");
             repository.Verify(r => r.ClearLock(), Times.Once);
         }
 
@@ -166,10 +166,10 @@ namespace Kudu.Core.Test
             var lockFile = new FailOnLockAcquiredLock(file);
 
             // 1st attempt lock unsuccessful since OnLockAcquired failed
-            Assert.False(lockFile.Lock());
+            Assert.False(lockFile.Lock("operationName"));
 
             // Next attempt successful
-            Assert.True(lockFile.Lock());
+            Assert.True(lockFile.Lock("operationName"));
             lockFile.Release();
 
             FileSystemHelpers.DeleteFileSafe(file);

--- a/Kudu.Core/Deployment/DeploymentStatusFile.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusFile.cs
@@ -79,7 +79,7 @@ namespace Kudu.Core.Deployment
                     // it is ok to return null as callers already handle null.
                     return null;
                 }
-            }, DeploymentStatusManager.LockTimeout);
+            }, "Open Deployment Status File", DeploymentStatusManager.LockTimeout);
         }
 
         private void Initialize(XDocument document)
@@ -191,7 +191,7 @@ namespace Kudu.Core.Deployment
                 {
                     FileSystemHelpers.WriteAllText(_activeFile, String.Empty);
                 }
-            }, DeploymentStatusManager.LockTimeout);
+            }, "Update Deployment Status File", DeploymentStatusManager.LockTimeout);
         }
 
         private static string GetOptionalElementValue(XElement element, string localName, string namespaceName = null)

--- a/Kudu.Core/Deployment/DeploymentStatusManager.cs
+++ b/Kudu.Core/Deployment/DeploymentStatusManager.cs
@@ -53,7 +53,7 @@ namespace Kudu.Core.Deployment
                 {
                     FileSystemHelpers.WriteAllText(_activeFile, String.Empty);
                 }
-            }, LockTimeout);
+            }, "Delete Deployment Status File", LockTimeout);
         }
 
         public IOperationLock Lock
@@ -73,11 +73,11 @@ namespace Kudu.Core.Deployment
                     }
 
                     return null;
-                }, LockTimeout);
+                }, "Get Active Deployment Id", LockTimeout);
             }
             set
             {
-                _statusLock.LockOperation(() => FileSystemHelpers.WriteAllText(_activeFile, value), LockTimeout);
+                _statusLock.LockOperation(() => FileSystemHelpers.WriteAllText(_activeFile, value), "Set Active Deployment Id", LockTimeout);
             }
         }
 
@@ -96,7 +96,7 @@ namespace Kudu.Core.Deployment
                     {
                         return DateTime.MinValue;
                     }
-                }, LockTimeout);
+                }, "Get Last Deployment Modified Time", LockTimeout);
             }
         }
     }

--- a/Kudu.Core/Hooks/WebHooksManager.cs
+++ b/Kudu.Core/Hooks/WebHooksManager.cs
@@ -56,12 +56,10 @@ namespace Kudu.Core.Hooks
                 {
                     IEnumerable<WebHook> webHooks = null;
 
-                    bool lockAcquired = _hooksLock.TryLockOperation(() =>
+                    _hooksLock.LockOperation(() =>
                     {
                         webHooks = ReadWebHooksFromFile();
-                    }, LockTimeout);
-
-                    VerifyLockAcquired(lockAcquired);
+                    }, "Read Web Hooks", LockTimeout);
 
                     return webHooks;
                 }
@@ -79,7 +77,7 @@ namespace Kudu.Core.Hooks
 
                 WebHook createdWebHook = null;
 
-                bool lockAcquired = _hooksLock.TryLockOperation(() =>
+                _hooksLock.LockOperation(() =>
                 {
                     var webHooks = new List<WebHook>(ReadWebHooksFromFile());
                     WebHook existingWebHook = webHooks.FirstOrDefault(h => String.Equals(h.HookAddress, webHook.HookAddress, StringComparison.OrdinalIgnoreCase));
@@ -103,9 +101,7 @@ namespace Kudu.Core.Hooks
                         // if web hook exists but with a different hook event type then throw a conflict exception
                         throw new ConflictException();
                     }
-                }, LockTimeout);
-
-                VerifyLockAcquired(lockAcquired);
+                }, "Add Web Hook", LockTimeout);
 
                 return createdWebHook;
             }
@@ -115,12 +111,10 @@ namespace Kudu.Core.Hooks
         {
             using (_tracer.Step("WebHooksManager.RemoveWebHook"))
             {
-                bool lockAcquired = _hooksLock.TryLockOperation(() =>
+                _hooksLock.LockOperation(() =>
                 {
                     RemoveWebHookNotUnderLock(hookId);
-                }, LockTimeout);
-
-                VerifyLockAcquired(lockAcquired);
+                }, "Remove Web Hook", LockTimeout);
             }
         }
 
@@ -138,12 +132,10 @@ namespace Kudu.Core.Hooks
             {
                 string jsonString = JsonConvert.SerializeObject(eventContent, JsonSerializerSettings);
 
-                bool lockAcquired = await _hooksLock.TryLockOperationAsync(async () =>
+                await _hooksLock.LockOperationAsync(async () =>
                 {
                     await PublishToHooksAsync(jsonString, hookEventType);
-                }, LockTimeout);
-
-                VerifyLockAcquired(lockAcquired);
+                }, "Publish Event", LockTimeout);
             }
         }
 
@@ -156,14 +148,6 @@ namespace Kudu.Core.Hooks
         {
             IEnumerable<WebHook> hooks = ReadWebHooksFromFile();
             SaveHooksToFile(hooks.Where(h => !String.Equals(h.Id, hookId, StringComparison.OrdinalIgnoreCase)));
-        }
-
-        private static void VerifyLockAcquired(bool lockAcquired)
-        {
-            if (!lockAcquired)
-            {
-                throw new LockOperationException("Failed to acquire lock");
-            }
         }
 
         private async Task PublishToHookAsync(WebHook webHook, string jsonString)

--- a/Kudu.Core/Jobs/ContinuousJobRunner.cs
+++ b/Kudu.Core/Jobs/ContinuousJobRunner.cs
@@ -193,7 +193,7 @@ namespace Kudu.Core.Jobs
                 return true;
             }
 
-            if (_singletonLock.Lock())
+            if (_singletonLock.Lock("ContinuousJobSingleton"))
             {
                 return true;
             }

--- a/Kudu.Core/Jobs/TriggeredJobRunner.cs
+++ b/Kudu.Core/Jobs/TriggeredJobRunner.cs
@@ -50,7 +50,7 @@ namespace Kudu.Core.Jobs
                 throw new WebJobsStoppedException();
             }
 
-            if (!_lockFile.Lock())
+            if (!_lockFile.Lock(String.Format("Start Triggered Job {0}", triggeredJob.Name)))
             {
                 throw new ConflictException();
             }

--- a/Kudu.Core/Settings/JsonSettings.cs
+++ b/Kudu.Core/Settings/JsonSettings.cs
@@ -95,7 +95,7 @@ namespace Kudu.Core.Settings
                     writer.Formatting = Formatting.Indented;
                     json.WriteTo(writer);
                 }
-            }, _timeout);
+            }, "Save Setting File", _timeout);
         }
 
         public override string ToString()
@@ -121,7 +121,7 @@ namespace Kudu.Core.Settings
                 {
                     return JObject.Load(reader);
                 }
-            }, _timeout);
+            }, "Read Setting File", _timeout);
         }
     }
 }

--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -290,7 +290,7 @@ namespace Kudu.Core.SiteExtensions
                     return await installationLock.LockOperationAsync<SiteExtensionInfo>(async () =>
                     {
                         return await TryInstallExtension(id, version, feedUrl, type, tracer);
-                    }, TimeSpan.Zero);
+                    }, "Install SiteExtension", TimeSpan.Zero);
                 }
             }
             catch (Exception ex)

--- a/Kudu.Core/SourceControl/Git/GitExeServer.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeServer.cs
@@ -104,7 +104,7 @@ namespace Kudu.Core.SourceControl.Git
                     {
                         InitializeRepository();
                     }
-                }, InitTimeout);
+                }, "Initialize Repository", InitTimeout);
             }
         }
 

--- a/Kudu.Services.Test/DeploymentControllerFacts.cs
+++ b/Kudu.Services.Test/DeploymentControllerFacts.cs
@@ -30,7 +30,7 @@ namespace Kudu.Services.Test
             var repoFactory = new Mock<IRepositoryFactory>();
             repoFactory.Setup(r => r.GetRepository()).Returns((IRepository)null);
             var opLock = new Mock<IOperationLock>();
-            opLock.Setup(f => f.Lock()).Returns(true);
+            opLock.Setup(f => f.Lock(It.IsAny<string>())).Returns(true);
             var controller = new DeploymentController(Mock.Of<ITracer>(), Mock.Of<IEnvironment>(), Mock.Of<IAnalytics>(), Mock.Of<IDeploymentManager>(), Mock.Of<IDeploymentStatusManager>(),
                                                       opLock.Object, repoFactory.Object, Mock.Of<IAutoSwapHandler>());
             controller.Request = GetRequest();
@@ -53,7 +53,7 @@ namespace Kudu.Services.Test
             var repoFactory = new Mock<IRepositoryFactory>();
             repoFactory.Setup(r => r.GetRepository()).Returns(repository.Object);
             var opLock = new Mock<IOperationLock>();
-            opLock.Setup(f => f.Lock()).Returns(true);
+            opLock.Setup(f => f.Lock(It.IsAny<string>())).Returns(true);
             var controller = new DeploymentController(Mock.Of<ITracer>(), Mock.Of<IEnvironment>(), Mock.Of<IAnalytics>(), Mock.Of<IDeploymentManager>(), Mock.Of<IDeploymentStatusManager>(),
                                                       opLock.Object, repoFactory.Object, Mock.Of<IAutoSwapHandler>());
             controller.Request = GetRequest();

--- a/Kudu.Services.Test/InfoRefsControllerFacts.cs
+++ b/Kudu.Services.Test/InfoRefsControllerFacts.cs
@@ -347,7 +347,7 @@ namespace Kudu.Services.Test
             var initLock = new Mock<IOperationLock>();
             initLock.SetupGet(l => l.IsHeld)
                     .Returns(() => locked);
-            initLock.Setup(l => l.Lock())
+            initLock.Setup(l => l.Lock(It.IsAny<string>()))
                     .Returns(() => locked = true);
             initLock.Setup(l => l.Release())
                     .Callback(() => locked = false);

--- a/Kudu.Services.Test/SSHKeyControllerTests.cs
+++ b/Kudu.Services.Test/SSHKeyControllerTests.cs
@@ -20,7 +20,7 @@ namespace Kudu.Services.Test
                          .Verifiable();
             var tracer = Mock.Of<ITracer>();
             var operationLock = new Mock<IOperationLock>();
-            operationLock.Setup(l => l.Lock()).Returns(true);
+            operationLock.Setup(l => l.Lock(It.IsAny<string>())).Returns(true);
             var controller = new SSHKeyController(tracer, sshKeyManager.Object, operationLock.Object);
 
             // Act
@@ -44,7 +44,7 @@ namespace Kudu.Services.Test
                          .Verifiable();
             var tracer = Mock.Of<ITracer>();
             var operationLock = new Mock<IOperationLock>();
-            operationLock.Setup(l => l.Lock()).Returns(true);
+            operationLock.Setup(l => l.Lock(It.IsAny<string>())).Returns(true);
             var controller = new SSHKeyController(tracer, sshKeyManager.Object, operationLock.Object);
 
             // Act

--- a/Kudu.Services.Test/SettingsControllerFacts.cs
+++ b/Kudu.Services.Test/SettingsControllerFacts.cs
@@ -18,8 +18,10 @@ namespace Kudu.Services.Test
             var operationLock = new Mock<IOperationLock>();
 
             // setup
-            operationLock.Setup(l => l.Lock())
+            operationLock.Setup(l => l.Lock(It.IsAny<string>()))
                          .Returns(false);
+            operationLock.Setup(l => l.LockInfo)
+                         .Returns(new OperationLockInfo());
 
             var controller = new SettingsController(settings, operationLock.Object)
             {

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -78,7 +78,7 @@ namespace Kudu.Services.Deployment
                     {
                         throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.Conflict, ex));
                     }
-                });
+                }, "Delete Deployment");
             }
         }
 
@@ -158,7 +158,7 @@ namespace Kudu.Services.Deployment
                     {
                         throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.NotFound, ex));
                     }
-                });
+                }, "Perform Deployment");
 
                 return response;
             }

--- a/Kudu.Services/Diagnostics/LogStreamManager.cs
+++ b/Kudu.Services/Diagnostics/LogStreamManager.cs
@@ -95,7 +95,7 @@ namespace Kudu.Services.Performance
                 {
                     var diagnostics = new DiagnosticsSettingsManager(Path.Combine(_environment.DiagnosticsPath, Constants.SettingsJsonFile), _tracer);
                     diagnostics.UpdateSetting(AzureDriveEnabledKey, true);
-                }, TimeSpan.FromSeconds(30));
+                }, "Update Diagnostics Setting File", TimeSpan.FromSeconds(30));
             }
 
             return result;

--- a/Kudu.Services/GitServer/InfoRefsController.cs
+++ b/Kudu.Services/GitServer/InfoRefsController.cs
@@ -193,7 +193,7 @@ namespace Kudu.Services.GitServer
 
                 repository.Commit("Initial Commit", authorName: null, emailAddress: null);
 
-            }, GitExeServer.InitTimeout);
+            }, "Initial Clone", GitExeServer.InitTimeout);
         }
     }
 }

--- a/Kudu.Services/Infrastructure/LockExtensions.cs
+++ b/Kudu.Services/Infrastructure/LockExtensions.cs
@@ -9,24 +9,30 @@ namespace Kudu.Services.Infrastructure
 {
     internal static class LockExtensions
     {
-        public static void LockHttpOperation(this IOperationLock lockObj, Action action)
+        public static void LockHttpOperation(this IOperationLock lockObj, Action action, string operationName)
         {
-            bool acquired = lockObj.TryLockOperation(action, TimeSpan.Zero);
-            if (!acquired)
+            try
+            {
+                lockObj.LockOperation(action, operationName, TimeSpan.Zero);
+            }
+            catch (LockOperationException ex)
             {
                 var response = new HttpResponseMessage(HttpStatusCode.Conflict);
-                response.Content = new StringContent(Resources.Error_DeploymentInProgess);
+                response.Content = new StringContent(ex.Message);
                 throw new HttpResponseException(response);
             }
         }
 
-        public static async Task LockHttpOperationAsync(this IOperationLock lockObj, Func<Task> action)
+        public static async Task LockHttpOperationAsync(this IOperationLock lockObj, Func<Task> action, string operationName)
         {
-            bool acquired = await lockObj.TryLockOperationAsync(action, TimeSpan.Zero);
-            if (!acquired)
+            try
+            {
+                await lockObj.LockOperationAsync(action, operationName, TimeSpan.Zero);
+            }
+            catch (LockOperationException ex)
             {
                 var response = new HttpResponseMessage(HttpStatusCode.Conflict);
-                response.Content = new StringContent(Resources.Error_DeploymentInProgess);
+                response.Content = new StringContent(ex.Message);
                 throw new HttpResponseException(response);
             }
         }

--- a/Kudu.Services/SSHKey/SSHKeyController.cs
+++ b/Kudu.Services/SSHKey/SSHKeyController.cs
@@ -70,7 +70,7 @@ namespace Kudu.Services.SSHKey
                         {
                             throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.Conflict, ex));
                         }
-                    }, TimeSpan.FromSeconds(LockTimeoutSecs));
+                    }, "Set SSH key", TimeSpan.FromSeconds(LockTimeoutSecs));
                 }
                 catch (LockOperationException ex)
                 {
@@ -97,7 +97,7 @@ namespace Kudu.Services.SSHKey
                         {
                             throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.Conflict, ex));
                         }
-                    }, TimeSpan.FromSeconds(LockTimeoutSecs));
+                    }, "Get SSH Key", TimeSpan.FromSeconds(LockTimeoutSecs));
                 }
                 catch (LockOperationException ex)
                 {
@@ -123,7 +123,7 @@ namespace Kudu.Services.SSHKey
                         {
                             throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.Conflict, ex));
                         }
-                    }, TimeSpan.FromSeconds(LockTimeoutSecs));
+                    }, "Delete SSH Key", TimeSpan.FromSeconds(LockTimeoutSecs));
                 }
                 catch (LockOperationException ex)
                 {

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -168,20 +168,22 @@ namespace Kudu.Services
                 }
 
                 _tracer.Trace("Attempting to fetch target branch {0}", targetBranch);
-                bool acquired = await _deploymentLock.TryLockOperationAsync(async () =>
+                try
                 {
-                    if (_autoSwapHandler.IsAutoSwapOngoing())
+                    await _deploymentLock.LockOperationAsync(async () =>
                     {
-                        context.Response.StatusCode = (int)HttpStatusCode.Conflict;
-                        context.Response.Write(Resources.Error_AutoSwapDeploymentOngoing);
-                        context.ApplicationInstance.CompleteRequest();
-                        return;
-                    }
+                        if (_autoSwapHandler.IsAutoSwapOngoing())
+                        {
+                            context.Response.StatusCode = (int)HttpStatusCode.Conflict;
+                            context.Response.Write(Resources.Error_AutoSwapDeploymentOngoing);
+                            context.ApplicationInstance.CompleteRequest();
+                            return;
+                        }
 
-                    await PerformDeployment(deployInfo);
-                }, TimeSpan.Zero);
-
-                if (!acquired)
+                        await PerformDeployment(deployInfo);
+                    }, "Continuous Deployment", TimeSpan.Zero);
+                }
+                catch (LockOperationException)
                 {
                     // Create a marker file that indicates if there's another deployment to pull
                     // because there was a deployment in progress.
@@ -426,13 +428,15 @@ namespace Kudu.Services
                     var deploymentManager = new DeploymentManager(siteBuilderFactory, environment, traceFactory, analytics, settings, deploymentStatusManager, deploymentLock, NullLogger.Instance, webHooksManager, autoSwapHandler, functionManager);
                     var fetchHandler = new FetchHandler(tracer, deploymentManager, settings, deploymentStatusManager, deploymentLock, environment, null, repositoryFactory, null);
 
-                    // Perform deployment
-                    var acquired = deploymentLock.TryLockOperation(() =>
+                    try
                     {
-                        fetchHandler.PerformDeployment(deployInfo, tempDeployment, tempChangeSet).Wait();
-                    }, TimeSpan.Zero);
-
-                    if (!acquired)
+                        // Perform deployment
+                        deploymentLock.LockOperation(() =>
+                        {
+                            fetchHandler.PerformDeployment(deployInfo, tempDeployment, tempChangeSet).Wait();
+                        }, "Continuous Deployment", TimeSpan.Zero);
+                    }
+                    catch (LockOperationException)
                     {
                         if (tempDeployment != null)
                         {

--- a/Kudu.Services/Settings/SettingsController.cs
+++ b/Kudu.Services/Settings/SettingsController.cs
@@ -64,7 +64,7 @@ namespace Kudu.Services.Settings
                     }
 
                     return Request.CreateResponse(HttpStatusCode.NoContent);
-                }, TimeSpan.Zero);
+                }, "Set Setting", TimeSpan.FromSeconds(5));
             }
             catch (LockOperationException ex)
             {
@@ -91,7 +91,7 @@ namespace Kudu.Services.Settings
                     _settingsManager.DeleteValue(key);
 
                     return Request.CreateResponse(HttpStatusCode.NoContent);
-                }, TimeSpan.Zero);
+                }, "Delete Setting", TimeSpan.Zero);
             }
             catch (LockOperationException ex)
             {

--- a/Kudu.Services/SiteExtensions/SiteExtensionController.cs
+++ b/Kudu.Services/SiteExtensions/SiteExtensionController.cs
@@ -413,33 +413,40 @@ namespace Kudu.Services.SiteExtensions
 
                 bool isAnyUpdate = false;
 
-                bool islocked = batchUpdateLock.TryLockOperation(() =>
+                try
                 {
-                    string[] packageDirs = FileSystemHelpers.GetDirectories(_environment.SiteExtensionSettingsPath);
-                    foreach (var dir in packageDirs)
+                    batchUpdateLock.LockOperation(() =>
                     {
-                        var dirInfo = new DirectoryInfo(dir);   // arm setting folder name is same as package id
-                        SiteExtensionStatus armSettings = new SiteExtensionStatus(_environment.SiteExtensionSettingsPath, dirInfo.Name, tracer);
-                        if (string.Equals(armSettings.Operation, Constants.SiteExtensionOperationInstall, StringComparison.OrdinalIgnoreCase)
-                            && string.Equals(armSettings.ProvisioningState, Constants.SiteExtensionProvisioningStateSucceeded, StringComparison.OrdinalIgnoreCase))
+                        string[] packageDirs = FileSystemHelpers.GetDirectories(_environment.SiteExtensionSettingsPath);
+                        foreach (var dir in packageDirs)
                         {
-                            try
+                            var dirInfo = new DirectoryInfo(dir);   // arm setting folder name is same as package id
+                            SiteExtensionStatus armSettings = new SiteExtensionStatus(_environment.SiteExtensionSettingsPath, dirInfo.Name, tracer);
+                            if (string.Equals(armSettings.Operation, Constants.SiteExtensionOperationInstall, StringComparison.OrdinalIgnoreCase)
+                                && string.Equals(armSettings.ProvisioningState, Constants.SiteExtensionProvisioningStateSucceeded, StringComparison.OrdinalIgnoreCase))
                             {
-                                armSettings.Operation = null;
-                                isAnyUpdate = true;
-                                tracer.Trace("Updated {0}", dir);
-                            }
-                            catch (Exception ex)
-                            {
-                                tracer.TraceError(ex);
-                                // no-op
+                                try
+                                {
+                                    armSettings.Operation = null;
+                                    isAnyUpdate = true;
+                                    tracer.Trace("Updated {0}", dir);
+                                }
+                                catch (Exception ex)
+                                {
+                                    tracer.TraceError(ex);
+                                    // no-op
+                                }
                             }
                         }
-                    }
 
-                }, TimeSpan.FromSeconds(5));
+                    }, "Update SiteExtension Success Installation", TimeSpan.FromSeconds(5));
 
-                return islocked && isAnyUpdate;
+                    return isAnyUpdate;
+                }
+                catch (LockOperationException)
+                {
+                    return false;
+                }
             }
         }
 

--- a/Kudu.Services/SourceControl/LiveScmController.cs
+++ b/Kudu.Services/SourceControl/LiveScmController.cs
@@ -61,84 +61,86 @@ namespace Kudu.Services.SourceControl
         [HttpDelete]
         public void Delete(int deleteWebRoot = 0, int ignoreErrors = 0)
         {
-            // Fail if a deployment is in progress
-            bool acquired = _deploymentLock.TryLockOperation(() =>
+            try
             {
-                using (_tracer.Step("Deleting repository"))
+                // Fail if a deployment is in progress
+                _deploymentLock.LockOperation(() =>
                 {
-                    string repositoryPath = Path.Combine(_environment.SiteRootPath, Constants.RepositoryPath);
-                    if (String.Equals(repositoryPath, _environment.RepositoryPath, StringComparison.OrdinalIgnoreCase))
+                    using (_tracer.Step("Deleting repository"))
                     {
-                        // Delete the repository
-                        FileSystemHelpers.DeleteDirectorySafe(_environment.RepositoryPath, ignoreErrors != 0);
+                        string repositoryPath = Path.Combine(_environment.SiteRootPath, Constants.RepositoryPath);
+                        if (String.Equals(repositoryPath, _environment.RepositoryPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Delete the repository
+                            FileSystemHelpers.DeleteDirectorySafe(_environment.RepositoryPath, ignoreErrors != 0);
+                        }
+                        else
+                        {
+                            // Just delete .git folder
+                            FileSystemHelpers.DeleteDirectorySafe(Path.Combine(_environment.RepositoryPath, ".git"), ignoreErrors != 0);
+
+                            FileSystemHelpers.DeleteDirectorySafe(Path.Combine(_environment.RepositoryPath, ".hg"), ignoreErrors != 0);
+                        }
+                    }
+
+                    using (_tracer.Step("Delete auto swap lock file"))
+                    {
+                        FileSystemHelpers.DeleteFileSafe(Path.Combine(_environment.LocksPath, AutoSwapHandler.AutoSwapLockFile));
+                    }
+
+                    using (_tracer.Step("Deleting ssh key"))
+                    {
+                        // Delete the ssh key
+                        FileSystemHelpers.DeleteDirectorySafe(_environment.SSHKeyPath, ignoreErrors != 0);
+                    }
+
+                    if (deleteWebRoot != 0)
+                    {
+                        // This logic is primarily used to help with site reuse during test.
+                        // The flag is not documented for general use.
+
+                        using (_tracer.Step("Deleting web root"))
+                        {
+                            // Delete the wwwroot folder
+                            FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.WebRootPath, ignoreErrors != 0);
+                        }
+
+                        using (_tracer.Step("Deleting diagnostics"))
+                        {
+                            // Delete the diagnostic log. This is a slight abuse of deleteWebRoot, but the
+                            // real semantic is more to reset the site to a fully clean state
+                            FileSystemHelpers.DeleteDirectorySafe(_environment.DiagnosticsPath, ignoreErrors != 0);
+                        }
+
+                        using (_tracer.Step("Deleting ASP.NET 5 approot"))
+                        {
+                            // Delete the approot folder used by ASP.NET 5 apps
+                            FileSystemHelpers.DeleteDirectorySafe(Path.Combine(_environment.SiteRootPath, "approot"), ignoreErrors != 0);
+                        }
+
+                        // Delete first deployment manifest since it is no longer needed
+                        FileSystemHelpers.DeleteFileSafe(Path.Combine(_environment.SiteRootPath, Constants.FirstDeploymentManifestFileName));
                     }
                     else
                     {
-                        // Just delete .git folder
-                        FileSystemHelpers.DeleteDirectorySafe(Path.Combine(_environment.RepositoryPath, ".git"), ignoreErrors != 0);
-
-                        FileSystemHelpers.DeleteDirectorySafe(Path.Combine(_environment.RepositoryPath, ".hg"), ignoreErrors != 0);
+                        using (_tracer.Step("Updating initial deployment manifest"))
+                        {
+                            // The active deployment manifest becomes the baseline initial deployment manifest
+                            // When SCM is reconnected, the new deployment will use this manifest to clean the wwwroot
+                            SaveInitialDeploymentManifest();
+                        }
                     }
-                }
 
-                using (_tracer.Step("Delete auto swap lock file"))
-                {
-                    FileSystemHelpers.DeleteFileSafe(Path.Combine(_environment.LocksPath, AutoSwapHandler.AutoSwapLockFile));
-                }
-
-                using (_tracer.Step("Deleting ssh key"))
-                {
-                    // Delete the ssh key
-                    FileSystemHelpers.DeleteDirectorySafe(_environment.SSHKeyPath, ignoreErrors != 0);
-                }
-
-                if (deleteWebRoot != 0)
-                {
-                    // This logic is primarily used to help with site reuse during test.
-                    // The flag is not documented for general use.
-
-                    using (_tracer.Step("Deleting web root"))
+                    using (_tracer.Step("Deleting deployment cache"))
                     {
-                        // Delete the wwwroot folder
-                        FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.WebRootPath, ignoreErrors != 0);
+                        // Delete the deployment cache
+                        FileSystemHelpers.DeleteDirectorySafe(_environment.DeploymentsPath, ignoreErrors != 0);
                     }
-
-                    using (_tracer.Step("Deleting diagnostics"))
-                    {
-                        // Delete the diagnostic log. This is a slight abuse of deleteWebRoot, but the
-                        // real semantic is more to reset the site to a fully clean state
-                        FileSystemHelpers.DeleteDirectorySafe(_environment.DiagnosticsPath, ignoreErrors != 0);
-                    }
-
-                    using (_tracer.Step("Deleting ASP.NET 5 approot"))
-                    {
-                        // Delete the approot folder used by ASP.NET 5 apps
-                        FileSystemHelpers.DeleteDirectorySafe(Path.Combine(_environment.SiteRootPath, "approot"), ignoreErrors != 0);
-                    }
-
-                    // Delete first deployment manifest since it is no longer needed
-                    FileSystemHelpers.DeleteFileSafe(Path.Combine(_environment.SiteRootPath, Constants.FirstDeploymentManifestFileName));
-                }
-                else
-                {
-                    using (_tracer.Step("Updating initial deployment manifest"))
-                    {
-                        // The active deployment manifest becomes the baseline initial deployment manifest
-                        // When SCM is reconnected, the new deployment will use this manifest to clean the wwwroot
-                        SaveInitialDeploymentManifest();
-                    }
-                }
-
-                using (_tracer.Step("Deleting deployment cache"))
-                {
-                    // Delete the deployment cache
-                    FileSystemHelpers.DeleteDirectorySafe(_environment.DeploymentsPath, ignoreErrors != 0);
-                }
-            }, TimeSpan.Zero);
-
-            if (!acquired)
+                }, "Delete Repository", TimeSpan.Zero);
+            }
+            catch (LockOperationException ex)
             {
-                HttpResponseMessage response = Request.CreateErrorResponse(HttpStatusCode.Conflict, Resources.Error_DeploymentInProgess);
+                HttpResponseMessage response = Request.CreateErrorResponse(HttpStatusCode.Conflict, ex.Message);
                 throw new HttpResponseException(response);
             }
         }

--- a/Kudu.Services/SourceControl/LiveScmEditorController.cs
+++ b/Kudu.Services/SourceControl/LiveScmEditorController.cs
@@ -58,7 +58,7 @@ namespace Kudu.Services.SourceControl
         public override async Task<HttpResponseMessage> GetItem()
         {
             // Get a lock on the repository
-            await GetLockAsync();
+            await GetLockAsync("Get Scm Vfs Item");
 
             try
             {
@@ -90,7 +90,7 @@ namespace Kudu.Services.SourceControl
         public override async Task<HttpResponseMessage> PutItem()
         {
             // Get a lock on the repository
-            await GetLockAsync();
+            await GetLockAsync("Update Scm Vfs Item");
 
             try
             {
@@ -123,7 +123,7 @@ namespace Kudu.Services.SourceControl
             }
 
             // Get a lock on the repository
-            await GetLockAsync();
+            await GetLockAsync("Delete Scm Vfs Item");
 
             try
             {
@@ -463,9 +463,9 @@ namespace Kudu.Services.SourceControl
             return true;
         }
 
-        private async Task GetLockAsync()
+        private async Task GetLockAsync(string operation)
         {
-            await _operationLock.LockAsync();
+            await _operationLock.LockAsync(operation);
 
             // Make sure we have the current commit ID
             _currentEtag = GetCurrentEtag();


### PR DESCRIPTION
The key change is simply

  - Lock and LockAsync take operationName arg.  This will store as lock owner info along with acquired time.
  - Improve tracing.  When lock can't be acquired to perform operation, one will see below in kudu trace.
```xml
<step title="Lock &apos;C:\Kudu-Test-Files\KuduApps\TestRunnerSiteSUWATCHASUS011\site\locks\deployments.lock&apos; is currently held by &apos;Set Setting&apos; operation started at 2016-05-25T02:20:21.1647455Z." date="2016-05-25T02:20:28.986" /><!-- duration: 6ms -->
```
  - End user will also see this in 409 content.
```javascript
{"Message":"The 'Set Setting' operation conflicts with the pending 'Git Receive Pack' operation started at 2016-05-25T02:18:50.0905464Z."}
```
