### PR TITLE
Fix WebJobs that have spaces in the file name

### DIFF
--- a/Kudu.Core/Jobs/WindowsScriptHost.cs
+++ b/Kudu.Core/Jobs/WindowsScriptHost.cs
@@ -7,7 +7,7 @@ namespace Kudu.Core.Jobs
         private static readonly string[] Supported = { ".cmd", ".bat", ".exe" };
 
         public WindowsScriptHost()
-            : base("cmd", "/c {0}{1}")
+            : base("cmd", "/c \"{0}\"{1}")
         {
         }
 

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -242,13 +242,15 @@ namespace Kudu.FunctionalTests.Jobs
 
                 TestTracer.Trace("Copying the script to the triggered job directory");
 
-                appManager.JobsManager.CreateTriggeredJobAsync(jobName, "run.cmd", JobScript).Wait();
+                string scriptFileName = "Job file with long name and accents àéè.cmd";
+
+                appManager.JobsManager.CreateTriggeredJobAsync(jobName, scriptFileName, JobScript).Wait();
 
                 var expectedTriggeredJob = new TriggeredJob()
                 {
                     Name = jobName,
                     JobType = "triggered",
-                    RunCommand = "run.cmd"
+                    RunCommand = scriptFileName
                 };
 
                 TestTracer.Trace("Verify triggered job exists");


### PR DESCRIPTION
WebJobs were broken if the file name has spaces. e.g. "Foo Bar.exe" or "Foo Bar.cmd". This came up [here](https://social.msdn.microsoft.com/Forums/en-US/ac6b901f-dd93-43fb-8caf-46961263e753/where-does-blank-blankspace-in-exe-name-come-from?forum=windowsazurewebsitespreview).