### PR TITLE
Allow configuration of IIS config file location

### DIFF
--- a/Kudu.SiteManagement/Configuration/IKuduConfiguration.cs
+++ b/Kudu.SiteManagement/Configuration/IKuduConfiguration.cs
@@ -18,6 +18,7 @@ namespace Kudu.SiteManagement.Configuration
         string RootPath { get; }
         string ApplicationsPath { get; }
         string ServiceSitePath { get; }
+        string IisConfigurationFile { get; }
         bool CustomHostNamesEnabled { get; }
 
         IEnumerable<IBindingConfiguration> Bindings { get; }
@@ -76,6 +77,21 @@ namespace Kudu.SiteManagement.Configuration
                 return _section == null
                     ? PathRelativeToRoot(_appSettings["sitesPath"])
                     : PathRelativeToRoot(_section.Applications.Path);
+            }
+        }
+
+        private const string DefaultIisConfigurationFile = "%windir%\\system32\\inetsrv\\config\\applicationHost.config";
+
+        public string IisConfigurationFile
+        {
+            get
+            {
+                if(_section == null || _section.IisConfigurationFile == null)
+                    return Environment.ExpandEnvironmentVariables(DefaultIisConfigurationFile);
+
+                return string.IsNullOrEmpty(_section.IisConfigurationFile.Path)
+                    ? Environment.ExpandEnvironmentVariables(DefaultIisConfigurationFile)
+                    : _section.IisConfigurationFile.Path;
             }
         }
 

--- a/Kudu.SiteManagement/Configuration/IKuduConfiguration.cs
+++ b/Kudu.SiteManagement/Configuration/IKuduConfiguration.cs
@@ -18,7 +18,7 @@ namespace Kudu.SiteManagement.Configuration
         string RootPath { get; }
         string ApplicationsPath { get; }
         string ServiceSitePath { get; }
-        string IisConfigurationFile { get; }
+        string IISConfigurationFile { get; }
         bool CustomHostNamesEnabled { get; }
 
         IEnumerable<IBindingConfiguration> Bindings { get; }
@@ -82,7 +82,7 @@ namespace Kudu.SiteManagement.Configuration
 
         private const string DefaultIisConfigurationFile = "%windir%\\system32\\inetsrv\\config\\applicationHost.config";
 
-        public string IisConfigurationFile
+        public string IISConfigurationFile
         {
             get
             {

--- a/Kudu.SiteManagement/Configuration/Section/KuduConfigurationSection.cs
+++ b/Kudu.SiteManagement/Configuration/Section/KuduConfigurationSection.cs
@@ -24,6 +24,12 @@ namespace Kudu.SiteManagement.Configuration.Section
             get { return this["applications"] as PathConfigurationElement; }
         }
 
+        [ConfigurationProperty("iisConfigurationFile", IsRequired = false)]
+        public PathConfigurationElement IisConfigurationFile
+        {
+            get { return this["iisConfigurationFile"] as PathConfigurationElement; }
+        }
+
         [ConfigurationProperty("bindings", IsRequired = false)]
         public BindingsConfigurationElementCollection Bindings
         {

--- a/Kudu.SiteManagement/SiteManager.cs
+++ b/Kudu.SiteManagement/SiteManager.cs
@@ -584,9 +584,9 @@ namespace Kudu.SiteManagement
             FileSystemHelpers.DeleteDirectorySafe(physicalPath);
         }
 
-        private static ServerManager GetServerManager()
+        private ServerManager GetServerManager()
         {
-            return new ServerManager(Environment.ExpandEnvironmentVariables("%windir%\\system32\\inetsrv\\config\\applicationHost.config"));
+            return new ServerManager(_context.Configuration.IisConfigurationFile);
         }
 
         private static async Task WaitForSiteAsync(string serviceUrl)

--- a/Kudu.SiteManagement/SiteManager.cs
+++ b/Kudu.SiteManagement/SiteManager.cs
@@ -586,7 +586,7 @@ namespace Kudu.SiteManagement
 
         private ServerManager GetServerManager()
         {
-            return new ServerManager(_context.Configuration.IisConfigurationFile);
+            return new ServerManager(_context.Configuration.IISConfigurationFile);
         }
 
         private static async Task WaitForSiteAsync(string serviceUrl)

--- a/Kudu.SiteManagement/SiteManager.cs
+++ b/Kudu.SiteManagement/SiteManager.cs
@@ -171,7 +171,7 @@ namespace Kudu.SiteManagement
                 {
                     try
                     {
-                        DeleteSiteAsync(applicationName).Wait();
+                        await DeleteSiteAsync(applicationName);
                     }
                     catch
                     {

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -186,6 +186,7 @@ namespace Kudu.TestHarness
         public string RootPath { get; private set; }
         public string ApplicationsPath { get; private set; }
         public string ServiceSitePath { get; private set; }
+        public string IisConfigurationFile { get; private set; }
         public bool CustomHostNamesEnabled { get; private set; }
         public IEnumerable<IBindingConfiguration> Bindings { get; private set; }
         public IEnumerable<ICertificateStoreConfiguration> CertificateStores { get; private set; }

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -186,7 +186,7 @@ namespace Kudu.TestHarness
         public string RootPath { get; private set; }
         public string ApplicationsPath { get; private set; }
         public string ServiceSitePath { get; private set; }
-        public string IisConfigurationFile { get; private set; }
+        public string IISConfigurationFile { get; private set; }
         public bool CustomHostNamesEnabled { get; private set; }
         public IEnumerable<IBindingConfiguration> Bindings { get; private set; }
         public IEnumerable<ICertificateStoreConfiguration> CertificateStores { get; private set; }

--- a/Kudu.Web/Web.config
+++ b/Kudu.Web/Web.config
@@ -27,6 +27,15 @@
     <serviceSite path="..\Kudu.Services.Web"/>
     <applications path="..\apps"/>
     <!--
+    IIS Shared Configuration
+    ======================================================================================================================
+    
+    If your IIS config file is in a different location (usually due to running a shared configration, you can specify the 
+    new location like this:
+    
+    <iisConfigurationFile path="c:\myconfig.config"/>
+
+    
     Defining custom host names:
     ======================================================================================================================
 

--- a/Kudu.Web/Web.config
+++ b/Kudu.Web/Web.config
@@ -30,7 +30,7 @@
     IIS Shared Configuration
     ======================================================================================================================
     
-    If your IIS config file is in a different location (usually due to running a shared configration, you can specify the 
+    If your IIS config file is in a different location (usually due to running a shared configration) you can specify the 
     new location like this:
     
     <iisConfigurationFile path="c:\myconfig.config"/>


### PR DESCRIPTION
Something I needed for my own environment where I have IIS in a shared configuration environment which means the location of the `applicationHost.config` file is in a different folder.

This PR allows user to specify the location of the file:

    <iisConfigurationFile path="c:\myconfig.config"/>

This feature was also mentioned in https://github.com/projectkudu/kudu/issues/1438