### PR TITLE
Fix #2034, Perform autoswap on last deployment when there are multiple webhook triggers

### DIFF
--- a/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/DeploymentManagerFacts.cs
@@ -300,7 +300,7 @@ namespace Kudu.Core.Test.Deployment
             deploymentLock = deploymentLock ?? Mock.Of<IOperationLock>();
             globalLogger = globalLogger ?? Mock.Of<ILogger>();
 
-            return new DeploymentManager(builderFactory, environment, traceFactory, analytics, settings, status, deploymentLock, globalLogger, hooksManager, Mock.Of<IAutoSwapHandler>(), Mock.Of<IFunctionManager>());
+            return new DeploymentManager(builderFactory, environment, traceFactory, analytics, settings, status, deploymentLock, globalLogger, hooksManager, Mock.Of<IFunctionManager>());
         }
     }
 }

--- a/Kudu.Core.Test/PurgeDeploymentsTests.cs
+++ b/Kudu.Core.Test/PurgeDeploymentsTests.cs
@@ -56,7 +56,7 @@ namespace Kudu.Core.Test
             var status = new Mock<IDeploymentStatusManager>();
             var trace = new Mock<ITraceFactory>();
             var tracer = new Mock<ITracer>();
-            var manager = new DeploymentManager(null, null, trace.Object, null, null, status.Object, null, null, null, null, null);
+            var manager = new DeploymentManager(null, null, trace.Object, null, null, status.Object, null, null, null, null);
 
             // Setup
             status.Setup(s => s.ActiveDeploymentId)

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -35,7 +35,6 @@ namespace Kudu.Core.Deployment
         private readonly IDeploymentSettingsManager _settings;
         private readonly IDeploymentStatusManager _status;
         private readonly IWebHooksManager _hooksManager;
-        private readonly IAutoSwapHandler _autoSwapHandler;
         private readonly IFunctionManager _functionManager;
 
         private const string XmlLogFile = "log.xml";
@@ -52,7 +51,6 @@ namespace Kudu.Core.Deployment
                                  IOperationLock deploymentLock,
                                  ILogger globalLogger,
                                  IWebHooksManager hooksManager,
-                                 IAutoSwapHandler autoSwapHandler,
                                  IFunctionManager functionManager)
         {
             _builderFactory = builderFactory;
@@ -64,7 +62,6 @@ namespace Kudu.Core.Deployment
             _settings = settings;
             _status = status;
             _hooksManager = hooksManager;
-            _autoSwapHandler = autoSwapHandler;
             _functionManager = functionManager;
         }
 
@@ -158,7 +155,7 @@ namespace Kudu.Core.Deployment
             }
         }
 
-        public async Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, bool needFileUpdate)
+        public async Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, bool needFileUpdate = true)
         {
             using (var deploymentAnalytics = new DeploymentAnalytics(_analytics, _settings))
             {
@@ -617,8 +614,6 @@ namespace Kudu.Core.Deployment
                     {
                         await builder.Build(context);
                         builder.PostBuild(context);
-                        await _autoSwapHandler.HandleAutoSwap(id, context);
-
                         await _functionManager.SyncTriggersAsync();
 
                         if (_settings.TouchWebConfigAfterDeployment())

--- a/Kudu.Core/Deployment/IAutoSwapHandler.cs
+++ b/Kudu.Core/Deployment/IAutoSwapHandler.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Kudu.Contracts.Tracing;
 
 namespace Kudu.Core.Deployment
 {
@@ -8,6 +9,6 @@ namespace Kudu.Core.Deployment
 
         bool IsAutoSwapOngoing();
 
-        Task HandleAutoSwap(string currChangeSetId, DeploymentContext context);
+        Task HandleAutoSwap(string currChangeSetId, ILogger logger, ITracer tracer);
     }
 }


### PR DESCRIPTION
Only last deployment would trigger autoswap, below deployment log are from a sequence of consecutive webhook triggeded deployment, and it end up two deployments, and  only the last deployment will trigger autoswap.



````
[
{
log_time: "2016-06-09T01:40:46.7414829Z",
id: "152386e8-3918-4082-85db-66c3ceeb9949",
message: "Updating submodules.",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:40:46.8884516Z",
id: "98b8215c-56b6-4a8e-9a06-f00b55bceceb",
message: "Preparing deployment for commit id '5e5cc1dfc4'.",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:40:47.170165Z",
id: "4000547a-cc5b-4870-b3e0-d534dbb84f55",
message: "Generating deployment script.",
type: 0,
details_url: "https://kudutry.scm.azurewebsites.net/api/deployments/5e5cc1dfc45e7779982907d6d3bcbf1f1aeb47ec/log/4000547a-cc5b-4870-b3e0-d534dbb84f55"
},
{
log_time: "2016-06-09T01:40:47.2651707Z",
id: "24335ab5-7768-44ec-b2e3-31db3ef57f09",
message: "Running deployment command...",
type: 0,
details_url: "https://kudutry.scm.azurewebsites.net/api/deployments/5e5cc1dfc45e7779982907d6d3bcbf1f1aeb47ec/log/24335ab5-7768-44ec-b2e3-31db3ef57f09"
},
{
log_time: "2016-06-09T01:42:02.8921909Z",
id: "62bd4945-3cde-4295-8468-a131c83b4aba",
message: "Running post deployment command(s)...",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:42:03.0176962Z",
id: "fde50c62-cc0c-4f0f-a12e-ef3e6dd508c5",
message: "Deployment successful.",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:42:05.6152969Z",
id: "2d14e0ed-432f-4cab-b15a-985afcda8b89",
message: "Requesting auto swap to slot - 'production' operation id - 'AUTOSWAPf495cba5-eca4-4b0b-8d3d-47cd551541a3' deployment id - '5e5cc1dfc45e7779982907d6d3bcbf1f1aeb47ec'",
type: 0,
details_url: null
}
]
````


````
[
{
log_time: "2016-06-09T01:39:08.6699873Z",
id: "63b879a7-fc59-45c7-818a-0da209a8a952",
message: "Updating submodules.",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:39:08.763638Z",
id: "783ceb5b-d73e-421a-bfb2-1bfebce42d9d",
message: "Preparing deployment for commit id 'a74a0fd8b1'.",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:39:09.0356331Z",
id: "1bad9fb3-cb96-46e6-911b-382cefe43719",
message: "Generating deployment script.",
type: 0,
details_url: "https://kudutry.scm.azurewebsites.net/api/deployments/a74a0fd8b1d1fbebad942a788ca67febe37467a8/log/1bad9fb3-cb96-46e6-911b-382cefe43719"
},
{
log_time: "2016-06-09T01:39:10.0201723Z",
id: "bc309b72-afdb-4225-9019-29a5ab76b486",
message: "Running deployment command...",
type: 0,
details_url: "https://kudutry.scm.azurewebsites.net/api/deployments/a74a0fd8b1d1fbebad942a788ca67febe37467a8/log/bc309b72-afdb-4225-9019-29a5ab76b486"
},
{
log_time: "2016-06-09T01:40:42.7940499Z",
id: "b8b8b33a-b2a8-4904-b926-f08ea7ab34a9",
message: "Running post deployment command(s)...",
type: 0,
details_url: null
},
{
log_time: "2016-06-09T01:40:43.0284176Z",
id: "340aaeb4-51d9-408d-b055-d0d792561bf6",
message: "Deployment successful.",
type: 0,
details_url: null
}
]
````