### PR TITLE
fix WindowsScriptHost to support program and args with spaces

### DIFF
--- a/Kudu.Core/Jobs/WindowsScriptHost.cs
+++ b/Kudu.Core/Jobs/WindowsScriptHost.cs
@@ -6,8 +6,19 @@ namespace Kudu.Core.Jobs
     {
         private static readonly string[] Supported = { ".cmd", ".bat", ".exe" };
 
+        // for cmd /c, once any following args are quoted,
+        // the overall args must be wrapped with an extra outer quote.
+        // for instance, below is not working.
+        //> cmd /c "program.exe" "first arg" "second arg"
+        //'program.exe" "first' is not recognized as an internal or external command
+        //> cmd /c "my program.exe" "first arg" "second arg"
+        //'my' is not recognized as an internal or external command
+        // To fix, we must wrap with an extra outer quote.
+        //> cmd /c ""program.exe" "first arg" "second arg""
+        // This also works if no arg is passed.
+        //> cmd /c ""program.exe""
         public WindowsScriptHost()
-            : base("cmd", "/c \"{0}\"{1}")
+            : base("cmd", "/c \"\"{0}\"{1}\"")
         {
         }
 

--- a/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
+++ b/Kudu.FunctionalTests/Jobs/WebJobsTests.cs
@@ -31,7 +31,7 @@ namespace Kudu.FunctionalTests.Jobs
         private const string JobsDataPath = "data/jobs";
         private const string ExpectedVerificationFileContent = "Verified!!!";
         private const string ExpectedChangedFileContent = "Changed!!!";
-        private const string JobScript = "echo " + ExpectedVerificationFileContent + " >> %WEBROOT_PATH%\\..\\..\\LogFiles\\verification.txt.%WEBSITE_INSTANCE_ID%\n";
+        private const string JobScript = "set _args=%~1,%~2\necho " + ExpectedVerificationFileContent + " >> %WEBROOT_PATH%\\..\\..\\LogFiles\\verification.txt.%WEBSITE_INSTANCE_ID%\n";
 
         private const string ContinuousJobsBinPath = JobsBinPath + "/continuous";
         private const string ConsoleWorkerJobPath = ContinuousJobsBinPath + "/deployedJob";
@@ -264,9 +264,9 @@ namespace Kudu.FunctionalTests.Jobs
 
                 VerifyVerificationFile(appManager, new string[] { ExpectedVerificationFileContent });
 
-                TestTracer.Trace("Trigger the job again");
+                TestTracer.Trace("Trigger the job again with arguments");
 
-                VerifyTriggeredJobTriggers(appManager, jobName, 2, "Success", "echo ");
+                VerifyTriggeredJobTriggers(appManager, jobName, 2, "Success", "set _args=first arg,second arg", arguments: "\"first arg\" \"second arg\"");
 
                 VerifyVerificationFile(appManager, new string[] { ExpectedVerificationFileContent, ExpectedVerificationFileContent });
 


### PR DESCRIPTION
The broken scenario is WindowsScriptingHost with quoted argument.   Customer reported regression caused by https://github.com/projectkudu/kudu/commit/3805e3ba1a69f7e0432fe81a65ad381f9a29e353.
 
```
[06/08/2016 15:00:23 > c0d520: SYS INFO] Status changed to Initializing
[06/08/2016 15:00:23 > c0d520: SYS INFO] Run script 'SwiftExporter.exe' with script host - 'WindowsScriptHost'
[06/08/2016 15:00:23 > c0d520: SYS INFO] Status changed to Running
[06/08/2016 15:00:23 > c0d520: ERR ] 'SwiftExporter.exe" "data' is not recognized as an internal or external command,
[06/08/2016 15:00:23 > c0d520: ERR ] operable program or batch file.
[06/08/2016 15:00:23 > c0d520: SYS INFO] Status changed to Failed
[06/08/2016 15:00:23 > c0d520: SYS ERR ] Job failed due to exit code 1
```