### PR TITLE
Hide disk space calculation on mono

### DIFF
--- a/Kudu.Services.Web/Env.cshtml
+++ b/Kudu.Services.Web/Env.cshtml
@@ -35,7 +35,8 @@
         <li>System directory: @Environment.SystemDirectory</li>
         <li>Current working directory: @Environment.CurrentDirectory</li>
         <li>IIS command line: @Environment.CommandLine</li>
-        @{
+        @if (Kudu.Core.Helpers.OSDetector.IsOnWindows())
+        {
             var homePath = Environment.GetEnvironmentVariable("HOME");
             var localPath = "d:\\local";
             <li>@homePath usage: @Html.Raw(Kudu.Core.Environment.GetFreeSpaceHtml(homePath))</li>


### PR DESCRIPTION
We are using below code to get freespace which is not existed in mono. 
On Mono we might have to use function from "Mono.Unix.DriveInfo namespace", which mean Kudu will take mono dependency in code. Need to spend more time for investigation to see if there is other way. 

As for now, I will just hide this feature on mono.

````
        [SuppressUnmanagedCodeSecurity]
        static class EnvironmentNativeMethods
        {
            [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
            [return: MarshalAs(UnmanagedType.Bool)]
            public static extern bool GetDiskFreeSpaceEx(string path, out ulong freeBytes, out ulong totalBytes, out ulong diskFreeBytes);
        }
````