### PR TITLE
Fix #2062, Remove duplicated tracing.

### DIFF
--- a/Kudu.Core/Tracing/Analytics.cs
+++ b/Kudu.Core/Tracing/Analytics.cs
@@ -60,25 +60,17 @@ namespace Kudu.Core.Tracing
 
         public void UnexpectedException(Exception exception, bool trace = true)
         {
-            KuduEventSource.Log.KuduUnexpectedException(
+            KuduEventSource.Log.KuduException(
                 _serverConfiguration.ApplicationName,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
                 GetExceptionContent(exception, trace));
         }
 
         public void UnexpectedException(Exception ex, string method, string path, string result, string message, bool trace = true)
         {
-            // ETW event for KuduException is not existed yet in current Antares deployment
-            // "duplicate" log with KuduUnexpectedException so that we will have some data for trouble shooting for now
-            // TODO: once next antares release is out, KuduUnexpectedException will be merge into KuduException
-            KuduEventSource.Log.KuduUnexpectedException(
-                 _serverConfiguration.ApplicationName,
-                 string.Format(CultureInfo.InvariantCulture, "Method: {0}, Path: {1}, Result: {2}, Message: {3}, Exception: {4}",
-                     NullToEmptyString(method),
-                     NullToEmptyString(path),
-                     NullToEmptyString(result),
-                     NullToEmptyString(message),
-                     GetExceptionContent(ex, trace)));
-
             KuduEventSource.Log.KuduException(
                 _serverConfiguration.ApplicationName,
                 NullToEmptyString(method),

--- a/Kudu.Core/Tracing/KuduEventSource.cs
+++ b/Kudu.Core/Tracing/KuduEventSource.cs
@@ -25,16 +25,6 @@ namespace Kudu.Core.Tracing
             }
         }
 
-        // TODO: once next Antares is out, removed event 65509, and only keep 65512
-        [Event(65509, Level = EventLevel.Warning, Message = "Unexpected exception for site {0}", Channel = EventChannel.Operational)]
-        public void KuduUnexpectedException(string siteName, string exception)
-        {
-            if (IsEnabled())
-            {
-                WriteEvent(65509, siteName, exception);
-            }
-        }
-
         [Event(65512, Level = EventLevel.Warning, Message = "Unexpected exception for site {0}", Channel = EventChannel.Operational)]
         public void KuduException(string siteName, string method, string path, string result, string Message, string exception)
         {


### PR DESCRIPTION
From tracing, confirm we have duplicated log (as expected). 
After this code change we should only one from KuduException only.


````
"2016-06-28T19:42:53.0111765Z","d2d453788bd641ec88dcf17e6c779051","SmallDedicatedWebWorkerRole","SmallDedicatedWebWorkerRole_IN_581",null,"3","58b0fe49-8cda-50e3-ef06-8622dccf30d0","Microsoft-Windows-WebSites-Kudu","65509",null,"Session3;Session2;Session1;Session0","KuduUnexpectedException","Microsoft-Windows-WebSites-Kudu/Operational","Unexpected exception for site %1","00000000-0000-0000-0000-000000000000","kudutry","Method: PUT, Path: /api/siteextensions/filecounter, Result: Failed, Message: {""version"": , ""feed_url"": }, Exception: System.InvalidOperationException: test foo bar\n   at Kudu.Core.SiteExtensions.SiteExtensionManager.<InstallExtension>d__26.MoveNext()\n",null,null,null,"4388","6440"
"2016-06-28T19:42:53.0229515Z","d2d453788bd641ec88dcf17e6c779051","SmallDedicatedWebWorkerRole","SmallDedicatedWebWorkerRole_IN_581","{""version"": , ""feed_url"": }","3","58b0fe49-8cda-50e3-ef06-8622dccf30d0","Microsoft-Windows-WebSites-Kudu","65512",null,"Session3;Session2;Session1;Session0","KuduException","Microsoft-Windows-WebSites-Kudu/Operational","Unexpected exception for site %1","00000000-0000-0000-0000-000000000000","kudutry","System.InvalidOperationException: test foo bar\n   at Kudu.Core.SiteExtensions.SiteExtensionManager.<InstallExtension>d__26.MoveNext()\n","PUT","/api/siteextensions/filecounter","Failed","4388","6440"
````