### PR TITLE
Fix #2064, trace vs project id to ETW.

### DIFF
--- a/Kudu.Core/Helpers/ProjectGuidParser.cs
+++ b/Kudu.Core/Helpers/ProjectGuidParser.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+/// <summary>
+/// This file is from https://github.com/vijayrkn-test/ProjectGuidParser/blob/dfa4bbdc0d163b46684e1438fb4f5cb972bfcb71/ProjectGuidParser/ProjectGuidParser.cs
+/// </summary>
+namespace Kudu.Core.Helpers
+{
+    public static class ProjectGuidParser
+    {
+        public static Guid? GetProjectGuidFromWebConfig(Stream webConfig)
+        {
+            int DefaultBufferSize = 1024;
+            string ProjectGuidPrefix = "ProjectGuid:";
+            try
+            {
+                using (TextReader documentReader = new StreamReader(webConfig, Encoding.UTF8, true, DefaultBufferSize, false))
+                {
+                    XDocument document = null;
+                    document = XDocument.Load(documentReader);
+                    if (document != null)
+                    {
+                        XNode lastNode = document.LastNode;
+                        while (lastNode != null && lastNode.NodeType != XmlNodeType.EndElement && lastNode.NodeType != XmlNodeType.Element && lastNode.NodeType != XmlNodeType.XmlDeclaration)
+                        {
+                            if (lastNode.NodeType == XmlNodeType.Comment)
+                            {
+                                XComment projectGuidComment = (XComment)lastNode;
+                                string projectGuidValue = projectGuidComment.Value;
+                                if (projectGuidValue != null)
+                                {
+                                    bool isProjectGuidPrefixPresent = projectGuidValue.Trim().StartsWith(ProjectGuidPrefix, StringComparison.OrdinalIgnoreCase);
+                                    // if we find the ProjectGuid prefix, we always exit even if the value returned is not a valid Guid.
+                                    if (isProjectGuidPrefixPresent)
+                                    {
+                                        projectGuidValue = projectGuidValue.Replace(ProjectGuidPrefix, string.Empty).Trim(' ');
+                                        Guid projectGuid;
+                                        if (Guid.TryParse(projectGuidValue, out projectGuid))
+                                        {
+                                            return projectGuid;
+                                        }
+
+                                        return null;
+                                    }
+                                }
+                            }
+
+                            lastNode = lastNode.PreviousNode;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Helpers\EnvironmentHelper.cs" />
     <Compile Include="Helpers\OSDetector.cs" />
     <Compile Include="Helpers\PermissionHelper.cs" />
+    <Compile Include="Helpers\ProjectGuidParser.cs" />
     <Compile Include="Hooks\WebHooksManager.cs" />
     <Compile Include="Infrastructure\AspNetCoreHelper.cs" />
     <Compile Include="Infrastructure\InstanceIdUtility.cs" />

--- a/Kudu.Core/Tracing/Analytics.cs
+++ b/Kudu.Core/Tracing/Analytics.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Globalization;
 using System.Text;
 using Kudu.Contracts.Settings;
-using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 
 namespace Kudu.Core.Tracing
@@ -24,7 +21,7 @@ namespace Kudu.Core.Tracing
             _traceFactory = traceFactory;
         }
 
-        public void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode)
+        public void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode, string vsProjectId = "")
         {
             KuduEventSource.Log.ProjectDeployed(
                 _serverConfiguration.ApplicationName,
@@ -33,7 +30,8 @@ namespace Kudu.Core.Tracing
                 NullToEmptyString(error),
                 deploymentDurationInMilliseconds,
                 NullToEmptyString(siteMode),
-                NullToEmptyString(_settings.GetValue(SettingsKeys.ScmType)));
+                NullToEmptyString(_settings.GetValue(SettingsKeys.ScmType)),
+                NullToEmptyString(vsProjectId));
         }
 
         public void JobStarted(string jobName, string scriptExtension, string jobType, string siteMode, string error, string trigger)

--- a/Kudu.Core/Tracing/IAnalytics.cs
+++ b/Kudu.Core/Tracing/IAnalytics.cs
@@ -4,7 +4,7 @@ namespace Kudu.Core.Tracing
 {
     public interface IAnalytics
     {
-        void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode);
+        void ProjectDeployed(string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode, string vsProjectId = "");
 
         void JobStarted(string jobName, string scriptExtension, string jobType, string siteMode, string error, string trigger);
 

--- a/Kudu.Core/Tracing/KuduEventSource.cs
+++ b/Kudu.Core/Tracing/KuduEventSource.cs
@@ -8,11 +8,11 @@ namespace Kudu.Core.Tracing
         public static readonly KuduEventSource Log = new KuduEventSource();
 
         [Event(65501, Level = EventLevel.Informational, Message = "Project was deployed for site {0} with result {2}", Channel = EventChannel.Operational)]
-        public void ProjectDeployed(string siteName, string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode, string scmType)
+        public void ProjectDeployed(string siteName, string projectType, string result, string error, long deploymentDurationInMilliseconds, string siteMode, string scmType, string vsProjectId)
         {
             if (IsEnabled())
             {
-                WriteEvent(65501, siteName, projectType, result, error, deploymentDurationInMilliseconds, siteMode, scmType);
+                WriteEvent(65501, siteName, projectType, result, error, deploymentDurationInMilliseconds, siteMode, scmType, vsProjectId);
             }
         }
 


### PR DESCRIPTION
Tested with sample project https://github.com/KuduApps/AspNetCoreRC2VisualStudioSln

**ETW log:**

https://jarvis-west.dc.ad.msft.net/51D0C3B0

![image](https://cloud.githubusercontent.com/assets/79823/16502865/4b352e56-3ec5-11e6-94e0-aa11bf4cb474.png)


**Project Id from** 
https://github.com/KuduApps/AspNetCoreRC2VisualStudioSln/blob/d2b621db0278e995ebd5e93fd51e8637cc32f4fb/src/AspNetCoreRC2/AspNetCoreRC2.xproj#L9
````
    <ProjectGuid>ddafc915-84e9-47ca-8ab4-54c8f41c9b07</ProjectGuid>
````