### PR TITLE
Support to change the credential of basic authentication in Kudu.Web

### DIFF
--- a/Kudu.SiteManagement.Test/Configuration/Fakes/BasicAuthConfigurationElementFake.cs
+++ b/Kudu.SiteManagement.Test/Configuration/Fakes/BasicAuthConfigurationElementFake.cs
@@ -1,0 +1,15 @@
+﻿using Kudu.SiteManagement.Configuration.Section;
+
+namespace Kudu.SiteManagement.Test.Configuration.Fakes {
+    public class BasicAuthConfigurationElementFake : BasicAuthConfigurationElement {
+        public static BasicAuthConfigurationElementFake Fake( string username , string password ) {
+            return new BasicAuthConfigurationElementFake( ).SetFake( username , password );
+        }
+
+        public BasicAuthConfigurationElementFake SetFake(string username , string password ) {
+            this[ "username" ] = username;
+            this[ "password" ] = password;
+            return this;
+        }
+    }
+}

--- a/Kudu.SiteManagement.Test/Configuration/KuduConfigurationFacts.cs
+++ b/Kudu.SiteManagement.Test/Configuration/KuduConfigurationFacts.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using Kudu.Client.Infrastructure;
 using Kudu.SiteManagement.Configuration;
 using Kudu.SiteManagement.Configuration.Section;
 using Kudu.SiteManagement.Configuration.Section.Cert;
@@ -14,6 +15,25 @@ namespace Kudu.SiteManagement.Test.Configuration
 {
     public class KuduConfigurationFacts
     {
+        [Fact]
+        public void BasicAuthCredential_NoConfiguration_ReturnDefaultCredential( ) {
+            var appSettingsFake = new NameValueCollection( );
+
+            IKuduConfiguration config = CreateConfiguration( null , appSettingsFake );
+            var defaultCredential = new System.Net.NetworkCredential( "admin" , "kudu" );
+            Assert.Equal( defaultCredential , config.BasicAuthCredential.GetCredentials( ) );
+        }
+        
+        [Fact]
+        public void BasicAuthCredential_WithConfigurationSection_ReturnBasicAuthCredentialProvider( ) {
+            var configFake = new KuduConfigurationSectionFake( );
+            configFake.SetFake( "basicAuth" , BasicAuthConfigurationElementFake.Fake( "testingUser" , "testingPw" ) );
+
+            IKuduConfiguration config = CreateConfiguration( configFake , new NameValueCollection( ) );
+            var testingCredential = new System.Net.NetworkCredential( "testingUser" , "testingPw" );
+            Assert.Equal( testingCredential , config.BasicAuthCredential.GetCredentials( ) );
+        }
+
         [Fact]
         public void CustomHostNamesEnabled_NoConfiguration_DefaultsToFalse()
         {

--- a/Kudu.SiteManagement.Test/Kudu.SiteManagement.Test.csproj
+++ b/Kudu.SiteManagement.Test/Kudu.SiteManagement.Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Certificates\CertificateSearcherFacts.cs" />
     <Compile Include="Certificates\Fakes\X509Certificate2CollectionFake.cs" />
     <Compile Include="Configuration\Fakes\ApplicationBindingConfigurationElementFake.cs" />
+    <Compile Include="Configuration\Fakes\BasicAuthConfigurationElementFake.cs" />
     <Compile Include="Configuration\Fakes\BindingsConfigurationElementCollectionFake.cs" />
     <Compile Include="Configuration\Fakes\CertificateStoreConfigurationElementFake.cs" />
     <Compile Include="Configuration\Fakes\CertificateStoresConfigurationElementCollectionFake.cs" />
@@ -88,6 +89,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Kudu.Client\Kudu.Client.csproj">
+      <Project>{222E740B-EF14-4976-A9DC-C12CF57A46A2}</Project>
+      <Name>Kudu.Client</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Kudu.SiteManagement\Kudu.SiteManagement.csproj">
       <Project>{D5669C1D-3408-4CEE-8C1B-D86D03D27EE2}</Project>
       <Name>Kudu.SiteManagement</Name>

--- a/Kudu.SiteManagement/Configuration/IKuduConfiguration.cs
+++ b/Kudu.SiteManagement/Configuration/IKuduConfiguration.cs
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Web;
 using Kudu.SiteManagement.Configuration.Section;
+using Kudu.Client.Infrastructure;
 
 namespace Kudu.SiteManagement.Configuration
 {
@@ -20,6 +21,7 @@ namespace Kudu.SiteManagement.Configuration
         string ServiceSitePath { get; }
         string IISConfigurationFile { get; }
         bool CustomHostNamesEnabled { get; }
+        BasicAuthCredentialProvider BasicAuthCredential { get; }
 
         IEnumerable<IBindingConfiguration> Bindings { get; }
         IEnumerable<ICertificateStoreConfiguration> CertificateStores { get; }
@@ -127,6 +129,21 @@ namespace Kudu.SiteManagement.Configuration
             }
         }
 
+        public BasicAuthCredentialProvider BasicAuthCredential
+        {
+            get
+            {
+                if ( _section == null ||
+                    _section.BasicAuthCredential == null ||
+                    string.IsNullOrEmpty( _section.BasicAuthCredential.Username ) ||
+                    string.IsNullOrEmpty( _section.BasicAuthCredential.Password ) ) {
+                    return new BasicAuthCredentialProvider( "admin" , "kudu" );
+                }
+                return new BasicAuthCredentialProvider( _section.BasicAuthCredential.Username , _section.BasicAuthCredential.Password );
+            }
+        }
+
+
         private KuduConfiguration(string root, KuduConfigurationSection section, NameValueCollection appSettings)
         {
             RootPath = root;
@@ -149,5 +166,7 @@ namespace Kudu.SiteManagement.Configuration
             }
             yield return new BindingConfiguration(legacyBinding, UriScheme.Http, type, null);
         }
+
+
     }
 }

--- a/Kudu.SiteManagement/Configuration/Section/BasicAuthConfigurationElement.cs
+++ b/Kudu.SiteManagement/Configuration/Section/BasicAuthConfigurationElement.cs
@@ -1,0 +1,20 @@
+﻿using System.Configuration;
+
+namespace Kudu.SiteManagement.Configuration.Section {
+
+    public class BasicAuthConfigurationElement : ConfigurationElement {
+        [ConfigurationProperty( "username" , IsRequired = true )]
+        public string Username
+        {
+            get { return ( string ) this[ "username" ]; }           
+        }
+
+
+        [ConfigurationProperty( "password" , IsRequired = true )]
+        public string Password
+        {
+            get { return ( string ) this[ "password" ]; }
+        }
+
+    }
+}

--- a/Kudu.SiteManagement/Configuration/Section/KuduConfigurationSection.cs
+++ b/Kudu.SiteManagement/Configuration/Section/KuduConfigurationSection.cs
@@ -41,5 +41,13 @@ namespace Kudu.SiteManagement.Configuration.Section
         {
             get { return this["certificateStores"] as CertificateStoresConfigurationElementCollection; }
         }
+
+
+        [ConfigurationProperty( "basicAuth" , IsRequired = false )]
+        public BasicAuthConfigurationElement BasicAuthCredential
+        {
+            get { return this[ "basicAuth" ] as BasicAuthConfigurationElement; }
+        }
+
     }
 }

--- a/Kudu.SiteManagement/Kudu.SiteManagement.csproj
+++ b/Kudu.SiteManagement/Kudu.SiteManagement.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Configuration\IBindingConfiguration.cs" />
     <Compile Include="Configuration\ICertificateConfiguration.cs" />
     <Compile Include="Configuration\IKuduConfiguration.cs" />
+    <Compile Include="Configuration\Section\BasicAuthConfigurationElement.cs" />
     <Compile Include="Configuration\Section\Bindings\ApplicationBindingConfigurationElement.cs" />
     <Compile Include="Configuration\Section\Bindings\BindingConfigurationElement.cs" />
     <Compile Include="Configuration\Section\Bindings\BindingsConfigurationElementCollection.cs" />

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -14,6 +14,7 @@ using Kudu.SiteManagement.Certificates;
 using Kudu.SiteManagement.Configuration;
 using Kudu.SiteManagement.Context;
 using Kudu.TestHarness.Xunit;
+using Kudu.Client.Infrastructure;
 
 namespace Kudu.TestHarness
 {
@@ -190,6 +191,7 @@ namespace Kudu.TestHarness
         public bool CustomHostNamesEnabled { get; private set; }
         public IEnumerable<IBindingConfiguration> Bindings { get; private set; }
         public IEnumerable<ICertificateStoreConfiguration> CertificateStores { get; private set; }
+        public BasicAuthCredentialProvider BasicAuthCredential { get; private set; }
 
         public KuduTestConfiguration()
         {

--- a/Kudu.Web/App_Start/Startup.cs
+++ b/Kudu.Web/App_Start/Startup.cs
@@ -82,8 +82,8 @@ namespace Kudu.Web.App_Start
             });
 
 
-            // TODO: Integrate with membership system
-            kernel.Bind<ICredentialProvider>().ToConstant(new BasicAuthCredentialProvider("admin", "kudu"));
+            // TODO: Integrate with membership system            
+            kernel.Bind<ICredentialProvider>( ).ToConstant( configuration.BasicAuthCredential );
             kernel.Bind<IApplicationService>().To<ApplicationService>().InRequestScope();
             kernel.Bind<ISettingsService>().To<SettingsService>();
 

--- a/Kudu.Web/Web.config
+++ b/Kudu.Web/Web.config
@@ -102,6 +102,13 @@
     https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.storename%28v=vs.110%29.aspx
 
     Using these settings allows some flexibility in the way IIS bindings are created by default.
+    
+    ### Credential of Basic Authentication
+    =======================================
+    The default credential that used by Kudu.Web is admin/kudu. 
+    It can be changed with following configuration:
+    <basicAuth username="user" password="password" />    
+    
     -->
   </kudu.management>
   <system.web>


### PR DESCRIPTION
By default, the credential that used in Kudu.Web is admin/kudu. 
To enable changing the credential for basic authentication, I have added a new configuration element to allow enter the credential in the web.config.
