### PR TITLE
Adding aria-live='polite' to jquery.console to support screen readers

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/jquery-console/jquery.console.js
+++ b/Kudu.Services.Web/Content/Scripts/jquery-console/jquery.console.js
@@ -226,7 +226,7 @@
 			promptBox.append(pid.text("").show());
 			promptBox.append(label.text(labelText).show());
 			label.html(label.html().replace(' ','&nbsp;'));
-			prompt = $('<span class="jquery-console-prompt"></span>');
+			prompt = $('<span class="jquery-console-prompt" aria-live="polite"></span>');
 			promptBox.append(prompt);
 			inner.append(promptBox);
 			updatePromptDisplay();
@@ -543,7 +543,7 @@
 		////////////////////////////////////////////////////////////////////////
 		// Display a message
 		function message(msg,className) {
-			var mesg = $('<div class="jquery-console-message" style="display: inline"></div>');
+			var mesg = $('<div class="jquery-console-message" aria-live="polite" style="display: inline"></div>');
 			if (className) mesg.addClass(className);
 			mesg.filledText(msg).hide();
 			inner.append(mesg);


### PR DESCRIPTION
This is a very safe change. Just adding some metadata on the console divs to tell screen readers that they are alive and they should be monitored  Here is [MDN docs on how it works](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)