### PR TITLE
fix #2121 and improve job initializing logging

### DIFF
--- a/Kudu.Core/Infrastructure/StringExtensions.cs
+++ b/Kudu.Core/Infrastructure/StringExtensions.cs
@@ -16,15 +16,6 @@ namespace Kudu.Core
             return String.Format(CultureInfo.CurrentCulture, format, args);
         }
 
-        /// <summary>
-        /// Make string PII safe.
-        /// Use this method for sensitive personal information to hides its content.
-        /// </summary>
-        public static string Fuzz(this string str)
-        {
-            return String.IsNullOrEmpty(str) ? str : str.GetHashCode().ToString();
-        }
-
         public static string EscapeHashCharacter(this string str)
         {
             return str.Replace("#", Uri.EscapeDataString("#"));

--- a/Kudu.Core/Jobs/BaseJobRunner.cs
+++ b/Kudu.Core/Jobs/BaseJobRunner.cs
@@ -548,7 +548,7 @@ namespace Kudu.Core.Jobs
                         jobType += "/SDK";
                     }
 
-                    _analytics.JobStarted(_job.Name.Fuzz(), scriptFileExtension, jobType, _siteMode, Error, _trigger);
+                    _analytics.JobStarted(_job.Name, scriptFileExtension, jobType, _siteMode, Error, _trigger);
                 }
             }
 

--- a/Kudu.Core/Jobs/JobsFileWatcher.cs
+++ b/Kudu.Core/Jobs/JobsFileWatcher.cs
@@ -35,6 +35,7 @@ namespace Kudu.Core.Jobs
         private readonly Action<string> _onJobChanged;
         private readonly string _filter;
         private readonly Func<bool, IEnumerable<string>> _listJobNames;
+        private readonly string _jobType;
 
         public JobsFileWatcher(
             string watchedDirectoryPath,
@@ -42,7 +43,8 @@ namespace Kudu.Core.Jobs
             string filter,
             Func<bool, IEnumerable<string>> listJobNames,
             ITraceFactory traceFactory,
-            IAnalytics analytics)
+            IAnalytics analytics,
+            string jobType)
         {
             _traceFactory = traceFactory;
             _analytics = analytics;
@@ -50,6 +52,7 @@ namespace Kudu.Core.Jobs
             _onJobChanged = onJobChanged;
             _filter = filter;
             _listJobNames = listJobNames;
+            _jobType = jobType;
 
             _makeChangesTimer = new Timer(OnMakeChanges);
             _startFileWatcherTimer = new Timer(StartWatcher);
@@ -83,9 +86,13 @@ namespace Kudu.Core.Jobs
                 try
                 {
                     _onJobChanged(updatedJobName);
+
+                    _analytics.JobEvent(updatedJobName, "Job initialized successfully", _jobType, String.Empty);
                 }
                 catch (Exception ex)
                 {
+                    _analytics.JobEvent(updatedJobName, "Job initialized failed", _jobType, ex.ToString());
+
                     _traceFactory.GetTracer().TraceError(ex);
                 }
             }
@@ -149,6 +156,9 @@ namespace Kudu.Core.Jobs
             HostingEnvironment.QueueBackgroundWorkItem(cancellationToken =>
             {
                 Exception ex = e.GetException();
+
+                _analytics.UnexpectedException(ex, trace: false);
+
                 _traceFactory.GetTracer().TraceError(ex.ToString());
                 ResetWatcher();
             });
@@ -211,6 +221,9 @@ namespace Kudu.Core.Jobs
 
         private void MarkJobUpdated(string jobName)
         {
+            // job initialization and changed come thru this code path
+            _analytics.JobEvent(jobName, "Job initializing", _jobType, String.Empty);
+
             _updatedJobs.Add(jobName);
             _makeChangesTimer.Change(TimeoutUntilMakingChanges, Timeout.Infinite);
         }

--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -84,7 +84,7 @@ namespace Kudu.Core.Jobs
 
             JobsBinariesPath = Path.Combine(Environment.JobsBinariesPath, jobsTypePath);
             JobsDataPath = Path.Combine(Environment.JobsDataPath, jobsTypePath);
-            JobsWatcher = new JobsFileWatcher(JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics);
+            JobsWatcher = new JobsFileWatcher(JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
             HostingEnvironment.RegisterObject(this);
         }
 

--- a/Kudu.Core/Jobs/TriggeredJobSchedule.cs
+++ b/Kudu.Core/Jobs/TriggeredJobSchedule.cs
@@ -52,7 +52,7 @@ namespace Kudu.Core.Jobs
                 Logger.LogInformation("Next schedule expected in " + nextInterval);
             }
 
-            _analytics.JobEvent(TriggeredJob.Name.Fuzz(), $"Reschedule {nextInterval}", TriggeredJob.JobType, String.Empty);
+            _analytics.JobEvent(TriggeredJob.Name, $"Reschedule {nextInterval}", TriggeredJob.JobType, String.Empty);
 
             _timer.Change(nextInterval, Timeout.InfiniteTimeSpan);
         }


### PR DESCRIPTION
The fix contains ..
- log jobName as is (previously hash value)
- log job change event (initializing and initialized) - to help debug the missing job changed notification.

Sample log below,
![image](https://cloud.githubusercontent.com/assets/1088218/18890585/96e4133a-84b6-11e6-8a1e-542636ecc508.png)
