### PR TITLE
fix regression in tracer due to deployment background

### DIFF
--- a/Kudu.Services.Test/FetchHandlerFacts.cs
+++ b/Kudu.Services.Test/FetchHandlerFacts.cs
@@ -131,7 +131,7 @@ namespace Kudu.Services.Test
         private Mock<IServiceHookHandler> GetServiceHookHandler()
         {
             var handler = new Mock<IServiceHookHandler>();
-            handler.Setup(h => h.Fetch(It.IsAny<IRepository>(), It.IsAny<DeploymentInfo>(), It.IsAny<string>(), It.IsAny<ILogger>()))
+            handler.Setup(h => h.Fetch(It.IsAny<IRepository>(), It.IsAny<DeploymentInfo>(), It.IsAny<string>(), It.IsAny<ILogger>(), It.IsAny<ITracer>()))
                    .Returns(Task.FromResult(0));
             return handler;
         }

--- a/Kudu.Services.Test/OneDriveDeployment/OneDriveHelperTests.cs
+++ b/Kudu.Services.Test/OneDriveDeployment/OneDriveHelperTests.cs
@@ -99,7 +99,7 @@ namespace Kudu.Services.Test.OneDriveDeployment
 
             // perform action
             OneDriveHelper helper = CreateMockOneDriveHelper(handler: handler, tracer: mockTracer.Object);
-            await helper.Sync(info, repository);
+            await helper.Sync(info, repository, mockTracer.Object);
 
             // verification
             /*

--- a/Kudu.Services/FetchHelpers/DropboxHelper.cs
+++ b/Kudu.Services/FetchHelpers/DropboxHelper.cs
@@ -41,7 +41,7 @@ namespace Kudu.Services
         private const int MaxRetries = 2;
         private const int MaxFilesPerSecs = 9; // Dropbox rate-limit at 600/min or 10/s
 
-        private readonly ITracer _tracer;
+        private ITracer _tracer;
         private readonly IDeploymentStatusManager _status;
         private readonly IDeploymentSettingsManager _settings;
         private readonly IEnvironment _environment;
@@ -122,9 +122,12 @@ namespace Kudu.Services
             dropboxInfo.NewCursor = currentCursor;
         }
 
-        internal async Task<ChangeSet> Sync(DropboxInfo dropboxInfo, string branch, IRepository repository)
+        internal async Task<ChangeSet> Sync(DropboxInfo dropboxInfo, string branch, IRepository repository, ITracer tracer)
         {
             DropboxDeployInfo deployInfo = dropboxInfo.DeployInfo;
+
+            // use incoming tracer since it is background work
+            _tracer = tracer;
 
             ResetStats();
 

--- a/Kudu.Services/FetchHelpers/OneDriveHelper.cs
+++ b/Kudu.Services/FetchHelpers/OneDriveHelper.cs
@@ -32,7 +32,7 @@ namespace Kudu.Services.FetchHelpers
         // if we exceed this failure (considered unrecoverable - token expired), we will bail out.
         private const int MaxFailures = 10;
 
-        private readonly ITracer _tracer;
+        private ITracer _tracer;
         private readonly IDeploymentStatusManager _status;
         private readonly IDeploymentSettingsManager _settings;
         private readonly IEnvironment _environment;
@@ -57,11 +57,15 @@ namespace Kudu.Services.FetchHelpers
             _environment = environment;
         }
 
-        internal async Task<ChangeSet> Sync(OneDriveInfo info, IRepository repository)
+        internal async Task<ChangeSet> Sync(OneDriveInfo info, IRepository repository, ITracer tracer)
         {
             ChangeSet changeSet = null;
             string cursor = _settings.GetValue(CursorKey);
             ChangesResult changes = null;
+
+            // use incoming tracer since it is background work
+            _tracer = tracer;
+
             // We truncate cursor value in filename but keep it unharmed in the trace content
             using (_tracer.Step("Getting delta changes with cursor: {0}...", cursor.Truncate(5)))
             using (_tracer.Step("cursor: {0}", cursor))

--- a/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/DropboxHandler.cs
@@ -68,12 +68,12 @@ namespace Kudu.Services.ServiceHookHandlers
             return DeployAction.UnknownPayload;
         }
 
-        public virtual async Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger)
+        public virtual async Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
         {
             // (A)sync with dropbox
             var dropboxInfo = (DropboxInfo)deploymentInfo;
             _dropBoxHelper.Logger = logger;
-            deploymentInfo.TargetChangeset = await _dropBoxHelper.Sync(dropboxInfo, targetBranch, repository);
+            deploymentInfo.TargetChangeset = await _dropBoxHelper.Sync(dropboxInfo, targetBranch, repository, tracer);
         }
 
         private RepositoryType GetRepositoryType()

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -240,7 +240,7 @@ namespace Kudu.Services
 
                         try
                         {
-                            await deploymentInfo.Handler.Fetch(repository, deploymentInfo, targetBranch, innerLogger);
+                            await deploymentInfo.Handler.Fetch(repository, deploymentInfo, targetBranch, innerLogger, _tracer);
                         }
                         catch (BranchNotFoundException)
                         {

--- a/Kudu.Services/ServiceHookHandlers/IServiceHookHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/IServiceHookHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using System.Web;
+using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment;
 using Kudu.Core.SourceControl;
 using Newtonsoft.Json.Linq;
@@ -15,7 +16,7 @@ namespace Kudu.Services.ServiceHookHandlers
         /// <returns>True if successfully parsed</returns>
         DeployAction TryParseDeploymentInfo(HttpRequestBase request, JObject payload, string targetBranch, out DeploymentInfo deploymentInfo);
 
-        Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger);
+        Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger, ITracer tracer);
     }
 
     public enum DeployAction

--- a/Kudu.Services/ServiceHookHandlers/OneDriveHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/OneDriveHandler.cs
@@ -65,11 +65,11 @@ namespace Kudu.Services.ServiceHookHandlers
             return DeployAction.ProcessDeployment;
         }
 
-        public async Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger)
+        public async Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
         {
             var oneDriveInfo = (OneDriveInfo)deploymentInfo;
             _oneDriveHelper.Logger = logger;
-            oneDriveInfo.TargetChangeset = await _oneDriveHelper.Sync(oneDriveInfo, repository);
+            oneDriveInfo.TargetChangeset = await _oneDriveHelper.Sync(oneDriveInfo, repository, tracer);
         }
     }
 }

--- a/Kudu.Services/ServiceHookHandlers/ServiceHookHandlerBase.cs
+++ b/Kudu.Services/ServiceHookHandlers/ServiceHookHandlerBase.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment;
 using Kudu.Core.SourceControl;
 
 namespace Kudu.Services.ServiceHookHandlers
 {
-    public abstract class ServiceHookHandlerBase :  IServiceHookHandler
+    public abstract class ServiceHookHandlerBase : IServiceHookHandler
     {
         private static readonly Task _completed = Task.FromResult(0);
 
         public abstract DeployAction TryParseDeploymentInfo(System.Web.HttpRequestBase request, Newtonsoft.Json.Linq.JObject payload, string targetBranch, out DeploymentInfo deploymentInfo);
 
-        public Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger)
+        public Task Fetch(IRepository repository, DeploymentInfo deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
         {
             repository.FetchWithoutConflict(deploymentInfo.RepositoryUrl, targetBranch);
             return _completed;


### PR DESCRIPTION
Tracer created in ctor tied to a HTTP request.   We need to use a background tracer for background work.