### PR TITLE
Improve unexpect exception message

### DIFF
--- a/Kudu.Core.Test/XmlLoggerFacts.cs
+++ b/Kudu.Core.Test/XmlLoggerFacts.cs
@@ -97,7 +97,7 @@ namespace Kudu.Core.Test
 
             // Assert
             Assert.Equal(0, entries.Count());
-            analytics.Verify(a => a.UnexpectedException(It.IsAny<Exception>(), false), Times.Once);
+            analytics.Verify(a => a.UnexpectedException(It.IsAny<Exception>(), false, "GetDocument", It.IsAny<string>(), It.IsAny<int>()), Times.Once);
         }
     }
 }

--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -220,8 +220,12 @@ namespace Kudu.Core.Jobs
                 IEnumerable<string> directoriesToRemove = allJobDataDirectories.Except(jobNames, StringComparer.OrdinalIgnoreCase);
                 foreach (string directoryToRemove in directoriesToRemove)
                 {
-                    TraceFactory.GetTracer().Trace("Removed job data path as the job was already deleted: " + directoryToRemove);
-                    FileSystemHelpers.DeleteDirectorySafe(Path.Combine(JobsDataPath, directoryToRemove));
+                    var tracer = TraceFactory.GetTracer();
+                    using (tracer.Step("CleanupDeletedJobs"))
+                    {
+                        tracer.Trace("Removed job data path as the job was already deleted: " + directoryToRemove);
+                        FileSystemHelpers.DeleteDirectorySafe(Path.Combine(JobsDataPath, directoryToRemove));
+                    }
                 }
             }
         }

--- a/Kudu.Core/Tracing/IAnalytics.cs
+++ b/Kudu.Core/Tracing/IAnalytics.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Kudu.Core.Tracing
 {
@@ -10,7 +11,7 @@ namespace Kudu.Core.Tracing
 
         void JobEvent(string jobName, string message, string jobType, string error);
 
-        void UnexpectedException(Exception ex, bool trace = true);
+        void UnexpectedException(Exception ex, bool trace = true, [CallerMemberName] string memberName = null, [CallerFilePath] string sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = 0);
 
         void UnexpectedException(Exception ex, string method, string path, string result, string message, bool trace = true);
 

--- a/Setup/DeployPrivateKudu.cmd
+++ b/Setup/DeployPrivateKudu.cmd
@@ -40,11 +40,11 @@ if NOT EXIST "%_CURLEXE%" (
 )
 
 @echo.
-@echo "%_CURLEXE%" -k -v -T "%_KUDUZIP%" "%_SCMURI%/zip"
+@echo "%_CURLEXE%" -k -v -T "%_KUDUZIP%" "%_SCMURI%/api/zip"
 @echo.
-@call "%_CURLEXE%" -k -v -T "%_KUDUZIP%" "%_SCMURI%/zip"
+@call "%_CURLEXE%" -k -v -T "%_KUDUZIP%" "%_SCMURI%/api/zip"
 @echo.
-@call "%_CURLEXE%" -k -X DELETE "%_SCMURI%/diagnostics/processes/0" >nul 2>&1
+@call "%_CURLEXE%" -k -X DELETE "%_SCMURI%/api/processes/0" >nul 2>&1
 if "%ERRORLEVEL%" equ "0" (
   @echo - w3wp.exe restarted 
 )


### PR DESCRIPTION
To make it clearer when looking at the historical logs (geneva).

```csharp
Open() at C:\gitroot\kudu\Kudu.Core\Deployment\DeploymentStatusFile.cs:76
System.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: deployment. Line 18, position 1.
   at System.Xml.XmlTextReaderImpl.Throw(Exception e)
   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)
   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()
   at System.Xml.XmlTextReaderImpl.ParseElementContent()
   at System.Xml.XmlTextReaderImpl.Read()
   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)
   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r, LoadOptions o)
   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)
   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)
   at Kudu.Core.Deployment.DeploymentStatusFile.<>c__DisplayClass6_0.<Open>b__0()
```