### PR TITLE
Improve webjob singleton locking diagnostics

### DIFF
--- a/Kudu.Contracts/Infrastructure/OperationLockInfo.cs
+++ b/Kudu.Contracts/Infrastructure/OperationLockInfo.cs
@@ -13,5 +13,6 @@ namespace Kudu.Contracts.Infrastructure
         public string OperationName { get; set; }
         public string AcquiredDateTime { get; set; }
         public string StackTrace { get; set; }
+        public string InstanceId { get; set; }
     }
 }

--- a/Kudu.Core/Infrastructure/LockFile.cs
+++ b/Kudu.Core/Infrastructure/LockFile.cs
@@ -196,7 +196,8 @@ namespace Kudu.Core.Infrastructure
             var json = JObject.FromObject(new OperationLockInfo
             {
                 OperationName = operationName,
-                StackTrace = System.Environment.StackTrace
+                StackTrace = System.Environment.StackTrace,
+                InstanceId = InstanceIdUtility.GetShortInstanceId()
             });
 
             var bytes = Encoding.UTF8.GetBytes(json.ToString());

--- a/Kudu.Core/Jobs/ContinuousJobRunner.cs
+++ b/Kudu.Core/Jobs/ContinuousJobRunner.cs
@@ -188,6 +188,7 @@ namespace Kudu.Core.Jobs
         private bool TryGetLockIfSingleton()
         {
             bool isSingleton = JobSettings.IsSingleton;
+            _continuousJobLogger.LogInformation(string.Format("WebJob singleton setting is {0}", isSingleton));
             if (!isSingleton)
             {
                 return true;
@@ -195,6 +196,7 @@ namespace Kudu.Core.Jobs
 
             if (_singletonLock.Lock("Acquiring continuous WebJob singleton lock"))
             {
+                _continuousJobLogger.LogInformation("WebJob singleton lock is acquired");
                 return true;
             }
 


### PR DESCRIPTION
Add more info to help with WebJob singleton issue.

This will be in the job_log.txt.   Notice the singleton info.
```
[10/27/2016 17:02:50 > 123456: SYS INFO] Status changed to Starting
[10/27/2016 17:02:50 > 123456: SYS INFO] WebJob singleton setting is True
[10/27/2016 17:02:50 > 123456: SYS INFO] WebJob singleton lock is acquired
[10/27/2016 17:02:50 > 123456: SYS INFO] Run script 'run.bat' with script host - 'WindowsScriptHost'
[10/27/2016 17:02:50 > 123456: SYS INFO] Status changed to Running
```

This will be in the job lock file itself.   InstanceId is added to show who is currently has it.
```
{
  "OperationName": "Acquiring continuous WebJob singleton lock",
  "AcquiredDateTime": "2016-10-27T17:02:50.8966895Z",
  "StackTrace": "   at System.Environment.GetStackTrace(Exception e, Boolean needFileInfo)\r\n   at System.Environment.get_StackTrace()\r\n   at Kudu.Core.Infrastructure.LockFile.WriteLockInfo(String operationName, Stream lockStream) in C:\\gitroot\\kudu\\Kudu.Core\\Infrastructure\\LockFile.cs:line 196\r\n   at Kudu.Core.Infrastructure.LockFile.Lock(String operationName) in C:\\gitroot\\kudu\\Kudu.Core\\Infrastructure\\LockFile.cs:line 144\r\n   at Kudu.Core.Jobs.ContinuousJobRunner.TryGetLockIfSingleton() in C:\\gitroot\\kudu\\Kudu.Core\\Jobs\\ContinuousJobRunner.cs:line 197\r\n   at Kudu.Core.Jobs.ContinuousJobRunner.<>c__DisplayClass19_0.<StartJob>b__0() in C:\\gitroot\\kudu\\Kudu.Core\\Jobs\\ContinuousJobRunner.cs:line 0\r\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)\r\n   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)\r\n   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)\r\n   at System.Threading.ThreadHelper.ThreadStart()",
  "InstanceId": "123456"
}
```