### PR TITLE
suppress thread aborted by kudu event

### DIFF
--- a/Kudu.Core/Infrastructure/ThreadAbortExtensions.cs
+++ b/Kudu.Core/Infrastructure/ThreadAbortExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+
+namespace Kudu.Core
+{
+    public static class ThreadAbortExtensions
+    {
+        public const string KuduThreadAbortMessage = "Kudu aborts thread.";
+
+        public static void KuduAbort(this Thread thread, string message)
+        {
+            thread.Abort(String.Format("{0}  {1}", KuduThreadAbortMessage, message));
+        }
+
+        public static bool AbortedByKudu(this Exception exception)
+        {
+            return AbortedByKudu(exception as ThreadAbortException);
+        }
+
+        public static bool AbortedByKudu(this ThreadAbortException exception)
+        {
+            var state = exception?.ExceptionState as string;
+            return !String.IsNullOrEmpty(state) && state.StartsWith(KuduThreadAbortMessage);
+        }
+
+        public static string GetString(this ThreadAbortException exception)
+        {
+            if (exception.ExceptionState != null)
+            {
+                return String.Format("{0}  {1}", exception.ExceptionState, exception);
+            }
+
+            return exception.ToString();
+        }
+    }
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -360,6 +360,7 @@
     <Compile Include="Infrastructure\StringReader.cs" />
     <Compile Include="Infrastructure\Executable.cs" />
     <Compile Include="Infrastructure\IStringReader.cs" />
+    <Compile Include="Infrastructure\ThreadAbortExtensions.cs" />
     <Compile Include="Infrastructure\VsSolution.cs" />
     <Compile Include="Infrastructure\VsSolutionProject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Kudu.Core/Tracing/Analytics.cs
+++ b/Kudu.Core/Tracing/Analytics.cs
@@ -58,6 +58,11 @@ namespace Kudu.Core.Tracing
 
         public void UnexpectedException(Exception exception, bool trace = true, string memberName = null, string sourceFilePath = null, int sourceLineNumber = 0)
         {
+            if (exception.AbortedByKudu())
+            {
+                return;
+            }
+
             KuduEventSource.Log.KuduException(
                 _serverConfiguration.ApplicationName,
                 string.Empty,
@@ -69,6 +74,11 @@ namespace Kudu.Core.Tracing
 
         public void UnexpectedException(Exception ex, string method, string path, string result, string message, bool trace = true)
         {
+            if (ex.AbortedByKudu())
+            {
+                return;
+            }
+
             KuduEventSource.Log.KuduException(
                 _serverConfiguration.ApplicationName,
                 NullToEmptyString(method),


### PR DESCRIPTION
To reduce noises in Kudu log (file system as well as internal jarvis/kusto).   This helps us identify the actual unexpected errors more efficiently.