### PR TITLE
change siteExtension src to nuget.org and add tag filter for search

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -15,8 +15,9 @@ namespace Kudu.Contracts.Settings
 
         public const int DefaultMaxJobRunsHistoryCount = 50;
 
-        public static readonly string DefaultSiteExtensionFeedUrl = "https://www.siteextensions.net/api/v2/";
-
+        public static readonly string DefaultSiteExtensionFeedUrl = "https://www.nuget.org/api/v2/"; 
+        //"https://www.myget.org/F/shunsiteextensiontest/api/v2"; 
+        //TODO still using nugetV2?
         public static string GetValue(this IDeploymentSettingsManager settings, string key)
         {
             return settings.GetValue(key, onlyPerSite: false);

--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -83,7 +83,7 @@ namespace Kudu.Core.SiteExtensions
 
             using (tracer.Step("Search site extensions by filter: {0}", filter))
             {
-                packages = (await remoteRepo.Search(string.IsNullOrWhiteSpace(filter) ? string.Empty : filter, filterOptions: filterOptions))
+                packages = (await remoteRepo.Search(filter, filterOptions: filterOptions))
                             .OrderByDescending(p => p.DownloadCount);
             }
 

--- a/Kudu.Services/SiteExtensions/SiteExtensionController.cs
+++ b/Kudu.Services/SiteExtensions/SiteExtensionController.cs
@@ -40,8 +40,9 @@ namespace Kudu.Services.SiteExtensions
         }
 
         [HttpGet]
-        public async Task<HttpResponseMessage> GetRemoteExtensions(string filter = null, bool allowPrereleaseVersions = false, string feedUrl = null)
+        public async Task<HttpResponseMessage> GetRemoteExtensions(string filter = "", bool allowPrereleaseVersions = false, string feedUrl = null)
         {
+            filter = " Tags:\"siteextension\" " + filter; //you can search for title/description/author etc http://blog.nuget.org/20130325/improved-search-syntax.html
             return Request.CreateResponse(
                 HttpStatusCode.OK,
                 ArmUtils.AddEnvelopeOnArmRequest<SiteExtensionInfo>(await _manager.GetRemoteExtensions(filter, allowPrereleaseVersions, feedUrl), Request));


### PR DESCRIPTION
TODO, wait until nuget sever support searchTerm `PackageType:"azuresiteextension"`
TODO, get a more unique name for the tag, ie `azuresiteextension`

python script for migration can be found [here](https://github.com/watashiSHUN/nugetMigrate)