### PR TITLE
fix index out of range in ProcessExtensions.EnvToDictionary

### DIFF
--- a/Kudu.Core/Infrastructure/ProcessExtensions.cs
+++ b/Kudu.Core/Infrastructure/ProcessExtensions.cs
@@ -549,37 +549,17 @@ namespace Kudu.Core.Infrastructure
                 }
             }
 
-            char[] environmentCharArray = Encoding.Unicode.GetChars(env, 0, len);
-
-            for (int i = 0; i < environmentCharArray.Length; i++)
+            // envs are key=value pair separated by '\0'
+            var envs = Encoding.Unicode.GetString(env, 0, len).Split('\0');
+            var separators = new[] { '=' };
+            for (int i = 0; i < envs.Length; i++)
             {
-                int startIndex = i;
-                while ((environmentCharArray[i] != '=') && (environmentCharArray[i] != '\0'))
+                var pair = envs[i].Split(separators, 2);
+                if (pair.Length != 2)
                 {
-                    i++;
+                    continue;
                 }
-                if (environmentCharArray[i] != '\0')
-                {
-                    if ((i - startIndex) == 0)
-                    {
-                        while (environmentCharArray[i] != '\0')
-                        {
-                            i++;
-                        }
-                    }
-                    else
-                    {
-                        string str = new string(environmentCharArray, startIndex, i - startIndex);
-                        i++;
-                        int num3 = i;
-                        while (environmentCharArray[i] != '\0')
-                        {
-                            i++;
-                        }
-                        string str2 = new string(environmentCharArray, num3, i - num3);
-                        result[str] = str2;
-                    }
-                }
+                result[pair[0]] = pair[1];
             }
 
             return result;


### PR DESCRIPTION
This is to address the exception below.   There are many potential index-out-of-length issues where we incremented `i` and used it without checking whether it was out of length.    I started fixing by adding checking here and there and the codes become hard to maintain and understand.   I decided to rewrite and simplify it.   I have done a backward compatibility comparison between old vs. new implementations against various processes to make sure no regression. 

```csharp
at Kudu.Core.Infrastructure.ProcessExtensions.EnvToDictionary(Byte[] env)
   at Kudu.Core.Infrastructure.ProcessExtensions.GetEnvironmentVariablesCore(IntPtr hProcess)
   at Kudu.Core.Infrastructure.ProcessExtensions.GetEnvironmentVariables(Process process)
   at Kudu.Services.Performance.ProcessController.SafeGetValue[T](Func`1 func, T defaultValue)
```