### PR TITLE
fix issue #2278

### DIFF
--- a/Kudu.Core/SiteExtensions/FeedExtensions.cs
+++ b/Kudu.Core/SiteExtensions/FeedExtensions.cs
@@ -57,6 +57,23 @@ namespace Kudu.Core.SiteExtensions
 
             return latestPackage;
         }
+        
+        // TODO refactor last function, after kudu private test all passes
+        public static async Task<UIPackageMetadata> GetLatestPackageById(this UIMetadataResource metadataResource, string packageId, bool includePrerelease = true, bool includeUnlisted = false)
+        {
+            UIPackageMetadata latestPackage = null;
+            IEnumerable<UIPackageMetadata> packages = await metadataResource.GetMetadata(packageId, includePrerelease, includeUnlisted, token: CancellationToken.None);
+            foreach (var p in packages)
+            {
+                if (latestPackage == null ||
+                    latestPackage.Identity.Version < p.Identity.Version)
+                {
+                    latestPackage = p;
+                }
+            }
+
+            return latestPackage;
+        }
 
         /// <summary>
         /// <para>Query source repository for a package base on given package id and version</para>
@@ -245,7 +262,7 @@ namespace Kudu.Core.SiteExtensions
             }
         }
 
-        private static async Task<T> GetResourceAndValidateAsync<T>(this SourceRepository srcRepo) where T : class, INuGetResource
+        public static async Task<T> GetResourceAndValidateAsync<T>(this SourceRepository srcRepo) where T : class, INuGetResource
         {
             var resource = await srcRepo.GetResourceAsync<T>();
             if (resource == null)

--- a/Kudu.Core/SiteExtensions/FeedExtensions.cs
+++ b/Kudu.Core/SiteExtensions/FeedExtensions.cs
@@ -41,25 +41,15 @@ namespace Kudu.Core.SiteExtensions
         /// <summary>
         /// Query source repository for latest package base given package id
         /// </summary>
-        public static async Task<UIPackageMetadata> GetLatestPackageById(this SourceRepository srcRepo, string packageId, bool includePrerelease = true, bool includeUnlisted = false)
+        internal static async Task<UIPackageMetadata> GetLatestPackageByIdFromSrcRepo(this SourceRepository srcRepo, string packageId)
         {
-            UIPackageMetadata latestPackage = null;
+            // 7 references none of which uses bool includePrerelease = true, bool includeUnlisted = false
             var metadataResource = await srcRepo.GetResourceAndValidateAsync<UIMetadataResource>();
-            IEnumerable<UIPackageMetadata> packages = await metadataResource.GetMetadata(packageId, includePrerelease, includeUnlisted, token: CancellationToken.None);
-            foreach (var p in packages)
-            {
-                if (latestPackage == null ||
-                    latestPackage.Identity.Version < p.Identity.Version)
-                {
-                    latestPackage = p;
-                }
-            }
-
-            return latestPackage;
+            return await metadataResource.GetLatestPackageByIdFromMetaRes(packageId);
         }
         
-        // TODO refactor last function, after kudu private test all passes
-        public static async Task<UIPackageMetadata> GetLatestPackageById(this UIMetadataResource metadataResource, string packageId, bool includePrerelease = true, bool includeUnlisted = false)
+        // can be called concurrently if metaDataResource is provided
+        internal static async Task<UIPackageMetadata> GetLatestPackageByIdFromMetaRes(this UIMetadataResource metadataResource, string packageId, bool includePrerelease = true, bool includeUnlisted = false)
         {
             UIPackageMetadata latestPackage = null;
             IEnumerable<UIPackageMetadata> packages = await metadataResource.GetMetadata(packageId, includePrerelease, includeUnlisted, token: CancellationToken.None);
@@ -143,7 +133,7 @@ namespace Kudu.Core.SiteExtensions
             using (Stream newPackageStream = await srcRepo.GetPackageStream(identity))
             {
                 // update file
-                var localPackage = await localRepo.GetLatestPackageById(identity.Id);
+                var localPackage = await localRepo.GetLatestPackageByIdFromSrcRepo(identity.Id);
                 if (localPackage == null)
                 {
                     throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Package {0} not found from local repo.", identity.Id));
@@ -262,7 +252,7 @@ namespace Kudu.Core.SiteExtensions
             }
         }
 
-        public static async Task<T> GetResourceAndValidateAsync<T>(this SourceRepository srcRepo) where T : class, INuGetResource
+        internal static async Task<T> GetResourceAndValidateAsync<T>(this SourceRepository srcRepo) where T : class, INuGetResource
         {
             var resource = await srcRepo.GetResourceAsync<T>();
             if (resource == null)

--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -116,7 +116,7 @@ namespace Kudu.Core.SiteExtensions
             {
                 using (tracer.Step("Version is null, search latest package by id: {0}", id))
                 {
-                    package = await remoteRepo.GetLatestPackageById(id);
+                    package = await remoteRepo.GetLatestPackageByIdFromSrcRepo(id);
                 }
             }
             else
@@ -167,7 +167,7 @@ namespace Kudu.Core.SiteExtensions
             UIPackageMetadata package = null;
             using (tracer.Step("Now querying from local repo for package '{0}'.", id))
             {
-                package = await _localRepository.GetLatestPackageById(id);
+                package = await _localRepository.GetLatestPackageByIdFromSrcRepo(id);
             }
 
             if (package == null)
@@ -263,7 +263,7 @@ namespace Kudu.Core.SiteExtensions
                     {
                         using (tracer.Step("Version is null, search latest package by id: {0}, will not search for unlisted package.", id))
                         {
-                            repoPackage = await remoteRepo.GetLatestPackageById(id);
+                            repoPackage = await remoteRepo.GetLatestPackageByIdFromSrcRepo(id);
                         }
                     }
                     else
@@ -483,7 +483,7 @@ namespace Kudu.Core.SiteExtensions
                 throw;
             }
 
-            return await _localRepository.GetLatestPackageById(package.Identity.Id);
+            return await _localRepository.GetLatestPackageByIdFromSrcRepo(package.Identity.Id);
         }
 
         /// <summary>
@@ -560,7 +560,7 @@ namespace Kudu.Core.SiteExtensions
             else if (string.IsNullOrWhiteSpace(version) && string.IsNullOrWhiteSpace(feedUrl))
             {
                 // case 3
-                UIPackageMetadata remotePackage = await remoteRepo.GetLatestPackageById(id);
+                UIPackageMetadata remotePackage = await remoteRepo.GetLatestPackageByIdFromSrcRepo(id);
                 if (remotePackage != null)
                 {
                     isInstalled = remotePackage.Identity.Version.ToNormalizedString().Equals(localPackageVersion, StringComparison.OrdinalIgnoreCase);
@@ -761,7 +761,7 @@ namespace Kudu.Core.SiteExtensions
 
         private async Task<SiteExtensionInfo> CheckRemotePackageLatestVersion(SiteExtensionInfo info, UIMetadataResource metadataResource)
         {
-            UIPackageMetadata localPackage = await metadataResource.GetLatestPackageById(info.Id);
+            UIPackageMetadata localPackage = await metadataResource.GetLatestPackageByIdFromMetaRes(info.Id);
 
             if (localPackage != null)
             {
@@ -799,7 +799,7 @@ namespace Kudu.Core.SiteExtensions
                 {
                     // FindPackage gets back the latest version.
                     SourceRepository remoteRepo = GetRemoteRepository(info.FeedUrl);
-                    UIPackageMetadata latestPackage = await remoteRepo.GetLatestPackageById(info.Id);
+                    UIPackageMetadata latestPackage = await remoteRepo.GetLatestPackageByIdFromSrcRepo(info.Id);
                     if (latestPackage != null)
                     {
                         NuGetVersion currentVersion = NuGetVersion.Parse(info.Version);


### PR DESCRIPTION
Kudu.FunctionalTests.SiteExtensions.SiteExtensionApiFacts.SiteExtensionV2AndV3FeedTests
Kudu.FunctionalTests.SiteExtensions.SiteExtensionApiFacts.SiteExtensionGetArmTest
Kudu.FunctionalTests.SiteExtensions.SiteExtensionApiFacts.SiteExtensionBasicTests
....

which all calls [GetRemoteExtensions](https://github.com/projectkudu/kudu/blob/4593ba51254eaca21fe7f2274718a995239980c2/Kudu.FunctionalTests/SiteExtensions/SiteExtensionApiFacts.cs#L96) should no longer appear in teamcity test errors