### PR TITLE
Fix for #2193

### DIFF
--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -79,8 +79,8 @@ namespace Kudu.Core.Infrastructure
         public static bool IsSubfolder(string parent, string child)
         {
             // normalize
-            string parentPath = Path.GetFullPath(parent).TrimEnd('\\') + '\\';
-            string childPath = Path.GetFullPath(child).TrimEnd('\\') + '\\';
+            string parentPath = Path.GetFullPath(parent).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            string childPath = Path.GetFullPath(child).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
             return childPath.StartsWith(parentPath, StringComparison.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
Fix for #2193. Hard-coded backslashes used in path logic caused string comparison failure.