### PR TITLE
kudusync needs to use LF and mono

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -47,3 +47,4 @@
 *.fsproj text=auto
 *.dbproj text=auto
 *.sln text=auto eol=crlf
+kudusync text eol=lf

--- a/Kudu.Core/Scripts/kudusync
+++ b/Kudu.Core/Scripts/kudusync
@@ -1,4 +1,4 @@
 #!/bin/sh
-"$0.NET.exe" "$@"
+mono "$0.NET.exe" "$@"
 ret=$?
 exit $ret

--- a/Kudu.Core/Scripts/kudusync
+++ b/Kudu.Core/Scripts/kudusync
@@ -1,4 +1,10 @@
 #!/bin/sh
-mono "$0.NET.exe" "$@"
+
+# Use mono if it is available
+MONO=
+mono --version >/dev/null 2>/dev/null
+if [ $? -eq 0 ]; then MONO=mono; fi
+
+$MONO "$0.NET.exe" "$@"
 ret=$?
 exit $ret


### PR DESCRIPTION
Since kudusync is supposed to run on Linux, all line break characters need to be LF instead of CRLF.
Also kudusync.NET.exe cannot be directly executed without mono.
