### PR TITLE
OnePerRequestHttpModule -> SafeOnePerRequestHttpModule

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -72,7 +72,7 @@ namespace Kudu.Services.Web.App_Start
         /// </summary>
         public static void Start()
         {
-            HttpApplication.RegisterModule(typeof(OnePerRequestHttpModule));
+            HttpApplication.RegisterModule(typeof(SafeOnePerRequestHttpModule));
             HttpApplication.RegisterModule(typeof(NinjectHttpModule));
             HttpApplication.RegisterModule(typeof(TraceModule));
             _bootstrapper.Initialize(CreateKernel);
@@ -103,7 +103,7 @@ namespace Kudu.Services.Web.App_Start
         /// <returns>The created kernel.</returns>
         private static IKernel CreateKernel()
         {
-            var kernel = new StandardKernel();
+            var kernel = new StandardKernel(new SafeOnePerRequestNinjectModule());
             kernel.Bind<Func<IKernel>>().ToMethod(ctx => () => new Bootstrapper().Kernel);
             kernel.Bind<IHttpModule>().To<HttpApplicationInitializationHttpModule>();
             kernel.Components.Add<INinjectHttpApplicationPlugin, NinjectHttpApplicationPlugin>();

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -186,8 +186,10 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="App_Start\TraceDeprecatedActionAttribute.cs" />
+    <Compile Include="SafeOnePerRequestHttpModule.cs" />
     <Compile Include="Infrastruture\HttpHandlerRouteHandler.cs" />
     <Compile Include="Infrastruture\RouteCollectionExtensions.cs" />
+    <Compile Include="SafeOnePerRequestNinjectModule.cs" />
     <Compile Include="Security\BlockLocalhostModule.cs" />
     <Compile Include="Services\DeploymentEnvironment.cs" />
     <Compile Include="Services\NinjectWebApiDependencyResolver.cs" />

--- a/Kudu.Services.Web/SafeOnePerRequestHttpModule.cs
+++ b/Kudu.Services.Web/SafeOnePerRequestHttpModule.cs
@@ -1,0 +1,34 @@
+﻿namespace Kudu.Services.Web
+{
+    using System.Web;
+    using Ninject.Activation.Caching;
+    using Ninject;
+
+    /// <summary>
+    /// Based on Ninject.Web.Common's OnePerRequestHttpModule
+    /// (https://github.com/ninject/Ninject.Web.Common/blob/14fc90d197f02a528ab81eb2a3f12dccdfacb642/src/Ninject.Web.Common/OnePerRequestHttpModule.cs),
+    /// but does a null check on HttpContext.Current before calling MapKernels. On Linux/Mono, HttpContext.Current is occasionally null
+    /// in the EndRequest stage of the pipeline due to a bug, and the call to MapKernels throws.
+    /// If HttpContext.Current is null, disposal of InRequestScope resources will still happen, it just won't be as aggressive.
+    /// </summary>
+    public sealed class SafeOnePerRequestHttpModule : GlobalKernelRegistration, IHttpModule
+    {
+        public void Init(HttpApplication application)
+        {
+            application.EndRequest += (o, e) => this.DeactivateInstancesForCurrentHttpRequest();
+        }
+
+        public void DeactivateInstancesForCurrentHttpRequest()
+        {
+            var context = HttpContext.Current;
+            if (context != null)
+            {
+                this.MapKernels(kernel => kernel.Components.Get<ICache>().Clear(context));
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Kudu.Services.Web/SafeOnePerRequestNinjectModule.cs
+++ b/Kudu.Services.Web/SafeOnePerRequestNinjectModule.cs
@@ -11,14 +11,5 @@
     /// </summary>
     public class SafeOnePerRequestNinjectModule : GlobalKernelRegistrationModule<SafeOnePerRequestHttpModule>
     {
-        public override void Load()
-        {
-            base.Load();
-        }
-
-        public override void Unload()
-        {
-            base.Unload();
-        }
     }
 }

--- a/Kudu.Services.Web/SafeOnePerRequestNinjectModule.cs
+++ b/Kudu.Services.Web/SafeOnePerRequestNinjectModule.cs
@@ -1,0 +1,24 @@
+﻿namespace Kudu.Services.Web
+{
+    using Ninject;
+
+    /// <summary>
+    /// Globally registers SafeOnePerRequestHttpModule in the same way that Ninject.Web.Common's
+    /// WebCommonNinjectModule registers its own implementation.
+    /// Note that the Ninject implementation is still registered (automatically via assembly
+    /// reflection on Ninject.Web.*), but it won't do anything at runtime since we don't
+    /// register its HttpModule with the application.
+    /// </summary>
+    public class SafeOnePerRequestNinjectModule : GlobalKernelRegistrationModule<SafeOnePerRequestHttpModule>
+    {
+        public override void Load()
+        {
+            base.Load();
+        }
+
+        public override void Unload()
+        {
+            base.Unload();
+        }
+    }
+}


### PR DESCRIPTION
Replacing OnePerRequestHttpModule with similar implementation that
does an extra null check to avoid exceptions on Linux/Mono.