### PR TITLE
address issue #2334

### DIFF
--- a/Kudu.Core.Test/Functions/FunctionManagerTests.cs
+++ b/Kudu.Core.Test/Functions/FunctionManagerTests.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Configuration;
+using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Kudu.Contracts.Tracing;
 using Kudu.Core.Functions;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
@@ -18,28 +13,74 @@ namespace Kudu.Core.Test.Functions
 {
     public class FunctionManagerTests
     {
-
-        [Fact]
-        public void DeterminePrimaryScriptFileMissingTest()
+        private IFileSystem MockFileSystem(string directory, string[] files)
         {
-            JObject functionConfig = new JObject()
-            {
-                { "scriptFile", "QUEUETriggER.py" }
-            };
             var fileSystemMock = new Mock<IFileSystem>();
             var fileBaseMock = new Mock<FileBase>();
+            var directoryBaseMock = new Mock<DirectoryBase>();
 
             fileSystemMock.SetupGet(fs => fs.File)
                       .Returns(fileBaseMock.Object);
-            fileBaseMock.Setup(f => f.Exists(@"c:\functions\QUEUETriggER.py"))
-                        .Returns(false);
-            FileSystemHelpers.Instance = fileSystemMock.Object;
+            fileSystemMock.SetupGet(fs => fs.Directory)
+                      .Returns(directoryBaseMock.Object);
+            string[] fullPaths = new string[files.Length];
+            for (int i = 0; i < files.Length; i++)
+            {
+                fullPaths[i] = Path.Combine(directory, files[i]);
+            }
+            fileBaseMock.Setup(f => f.Exists(It.IsIn<String>(fullPaths))).Returns(true);
+            fileBaseMock.Setup(f => f.Exists(It.IsNotIn<String>(fullPaths))).Returns(false);
+            directoryBaseMock.Setup(d => d.GetFiles(directory, "*.*", SearchOption.TopDirectoryOnly))
+                        .Returns(fullPaths); // technically this returns with flag SearchOption.AllDirectory
+            return fileSystemMock.Object;
+        }
 
+        private void runDeterminePrimaryScriptFile(string expect, string jObjectStr, string dir)
+        {
+            JObject functionConfig = JObject.Parse(jObjectStr);
             var traceFactoryMock = new Mock<ITraceFactory>();
             traceFactoryMock.Setup(tf => tf.GetTracer()).Returns(NullTracer.Instance);
 
             var functionManager = new FunctionManager(new Mock<IEnvironment>().Object, traceFactoryMock.Object);
-            Assert.Throws<ConfigurationErrorsException>(() => functionManager.DeterminePrimaryScriptFile(functionConfig, @"c:\functions"));
+            if (string.IsNullOrEmpty(expect))
+            {
+                Assert.Throws<ConfigurationErrorsException>(() => functionManager.DeterminePrimaryScriptFile(functionConfig, dir));
+            }
+            else
+            {
+                Assert.Equal(expect, functionManager.DeterminePrimaryScriptFile(functionConfig, dir), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        [Theory]
+        // missing script files
+        [InlineData("", new[] { "function.json" })]
+        // unable to determine primary
+        [InlineData("", new[] { "function.json", "randomFileA.txt", "randomFileB.txt" })]
+        // only one file left in function directory
+        [InlineData(@"c:\functions\functionScript.py", new[] { "function.json", "functionScript.py" })]
+        // with datafiles in function directory
+        [InlineData(@"c:\functions\index.js", new[] { "function.json", "index.js", "test1.dat", "test2.dat" })]
+        [InlineData(@"c:\functions\run.csx", new[] { "function.json", "run.csx", "test.dat" })]
+        public void DeterminePrimaryScriptFileTests(string expect, string[] files)
+        {
+            var dir = @"c:\functions";
+            var functionConfigStr = "{}";
+            FileSystemHelpers.Instance = MockFileSystem(dir, files);
+            runDeterminePrimaryScriptFile(expect, functionConfigStr, dir);
+
+        }
+
+        [Theory]
+        // https://github.com/projectkudu/kudu/issues/2334
+        [InlineData("{\"scriptFile\": \"subDirectory\\\\compiled.dll\"}", @"c:\functions\subDirectory\compiled.dll")]
+        // cannot find script file specified
+        [InlineData("{\"scriptFile\": \"random.text\"}", "")]
+        public void DeterminePrimaryScriptFileWithConfigTests(string functionConfigStr, string expect)
+        {
+            var dir = @"c:\functions";
+            FileSystemHelpers.Instance = MockFileSystem(@"c:\functions", new string[] { "function.json", @"subDirectory\compiled.dll" });
+            runDeterminePrimaryScriptFile(expect, functionConfigStr, dir);
         }
     }
 }

--- a/Kudu.Core.Test/Functions/FunctionManagerTests.cs
+++ b/Kudu.Core.Test/Functions/FunctionManagerTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Functions;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Kudu.Core.Test.Functions
+{
+    public class FunctionManagerTests
+    {
+
+        [Fact]
+        public void DeterminePrimaryScriptFileMissingTest()
+        {
+            JObject functionConfig = new JObject()
+            {
+                { "scriptFile", "QUEUETriggER.py" }
+            };
+            var fileSystemMock = new Mock<IFileSystem>();
+            var fileBaseMock = new Mock<FileBase>();
+
+            fileSystemMock.SetupGet(fs => fs.File)
+                      .Returns(fileBaseMock.Object);
+            fileBaseMock.Setup(f => f.Exists(@"c:\functions\QUEUETriggER.py"))
+                        .Returns(false);
+            FileSystemHelpers.Instance = fileSystemMock.Object;
+
+            var traceFactoryMock = new Mock<ITraceFactory>();
+            traceFactoryMock.Setup(tf => tf.GetTracer()).Returns(NullTracer.Instance);
+
+            var functionManager = new FunctionManager(new Mock<IEnvironment>().Object, traceFactoryMock.Object);
+            Assert.Throws<ConfigurationErrorsException>(() => functionManager.DeterminePrimaryScriptFile(functionConfig, @"c:\functions"));
+        }
+    }
+}

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Deployment\NodeSiteEnablerTests.cs" />
     <Compile Include="Deployment\DeploymentManagerFacts.cs" />
     <Compile Include="FileSystemHubFacts.cs" />
+    <Compile Include="Functions\FunctionManagerTests.cs" />
     <Compile Include="HgRepositoryFacts.cs" />
     <Compile Include="Hooks\WebHooksManagerTests.cs" />
     <Compile Include="IdleManagerFacts.cs" />

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -104,9 +105,8 @@ namespace Kudu.Core.Functions
             var configList = await Task.WhenAll(
                     FileSystemHelpers
                     .GetDirectories(_environment.FunctionsPath)
-                    .Select(d => Path.Combine(d, Constants.FunctionsConfigFile))
-                    .Where(FileSystemHelpers.FileExists)
-                    .Select(f => TryGetFunctionConfigAsync(Path.GetFileName(Path.GetDirectoryName(f)))));
+                    .Select(d => TryGetFunctionConfigAsync(Path.GetFileName(d))));
+                    // TryGetFunctionConfigAsync checks the existence of function.config
             return configList.Where(c => c != null);
         }
 
@@ -266,7 +266,7 @@ namespace Kudu.Core.Functions
             {
                 Name = functionName,
                 ScriptRootPathHref = FilePathToVfsUri(GetFunctionPath(functionName), isDirectory: true),
-                ScriptHref = FilePathToVfsUri(GetFunctionScriptPath(functionName, functionConfig)),
+                ScriptHref = FilePathToVfsUri(DeterminePrimaryScriptFile(functionConfig, GetFunctionPath(functionName))),
                 ConfigHref = FilePathToVfsUri(GetFunctionConfigPath(functionName)),
                 SecretsFileHref = FilePathToVfsUri(GetFunctionSecretsFilePath(functionName)),
                 Href = GetFunctionHref(functionName),
@@ -275,35 +275,46 @@ namespace Kudu.Core.Functions
             };
         }
 
-        private string GetFunctionScriptPath(string functionName, JObject functionConfig)
-        {
-            var functionPath = GetFunctionPath(functionName);
-            var functionFiles = FileSystemHelpers.GetFiles(functionPath, "*.*", SearchOption.TopDirectoryOnly)
-                .Where(p => Path.GetFileName(p).ToLowerInvariant() != "function.json").ToArray();
-
-            return DeterminePrimaryScriptFile(functionConfig, functionFiles);
-        }
-
         // Logic for this function is copied from here:
         // https://github.com/Azure/azure-webjobs-sdk-script/blob/dev/src/WebJobs.Script/Host/ScriptHost.cs
         // These two implementations must stay in sync!
-        internal static string DeterminePrimaryScriptFile(JObject functionConfig, string[] functionFiles)
+
+        /// <summary>
+        /// Determines which script should be considered the "primary" entry point script.
+        /// </summary>
+        /// <exception cref="ConfigurationErrorsException">Thrown if the function metadata points to an invalid script file, or no script files are present.</exception>
+        internal static string DeterminePrimaryScriptFile(JObject functionConfig, string scriptDirectory)
         {
-            if (functionFiles.Length == 1)
+            // First see if there is an explicit primary file indicated
+            // in config. If so use that.
+            string functionPrimary = null;
+            string scriptFile = (string)functionConfig["scriptFile"];
+
+            if (!string.IsNullOrEmpty(scriptFile))
             {
-                // if there is only a single file, that file is primary
-                return functionFiles[0];
+                string scriptPath = Path.Combine(scriptDirectory, scriptFile);
+                if (!FileSystemHelpers.FileExists(scriptPath))
+                {
+                    throw new ConfigurationErrorsException("Invalid script file name configuration. The 'scriptFile' property is set to a file that does not exist.");
+                }
+
+                functionPrimary = scriptPath;
             }
             else
             {
-                // First see if there is an explicit primary file indicated
-                // in config. If so use that.
-                string functionPrimary = null;
-                string scriptFileName = (string)functionConfig["scriptFile"];
-                if (!string.IsNullOrEmpty(scriptFileName))
+                string[] functionFiles = FileSystemHelpers.GetFiles(scriptDirectory,"*.*", SearchOption.TopDirectoryOnly)
+                    .Where(p => Path.GetFileName(p).ToLowerInvariant() != "function.json")
+                    .ToArray();
+
+                if (functionFiles.Length == 0)
                 {
-                    functionPrimary = functionFiles.FirstOrDefault(p =>
-                        string.Compare(Path.GetFileName(p), scriptFileName, StringComparison.OrdinalIgnoreCase) == 0);
+                    throw new ConfigurationErrorsException("No function script files present.");
+                }
+
+                if (functionFiles.Length == 1)
+                {
+                    // if there is only a single file, that file is primary
+                    functionPrimary = functionFiles[0];
                 }
                 else
                 {
@@ -313,9 +324,15 @@ namespace Kudu.Core.Functions
                         Path.GetFileNameWithoutExtension(p).ToLowerInvariant() == "run" ||
                         Path.GetFileName(p).ToLowerInvariant() == "index.js");
                 }
-
-                return functionPrimary;
             }
+
+            if (string.IsNullOrEmpty(functionPrimary))
+            {
+                throw new ConfigurationErrorsException("Unable to determine the primary function script. Try renaming your entry point script to 'run' (or 'index' in the case of Node), " +
+                    "or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.");
+            }
+
+            return Path.GetFullPath(functionPrimary);
         }
 
         private Uri FilePathToVfsUri(string filePath, bool isDirectory = false)

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -106,7 +106,7 @@ namespace Kudu.Core.Functions
                     FileSystemHelpers
                     .GetDirectories(_environment.FunctionsPath)
                     .Select(d => TryGetFunctionConfigAsync(Path.GetFileName(d))));
-                    // TryGetFunctionConfigAsync checks the existence of function.json
+            // TryGetFunctionConfigAsync checks the existence of function.json
             return configList.Where(c => c != null);
         }
 
@@ -157,7 +157,7 @@ namespace Kudu.Core.Functions
 
             string jsonStr = null;
             int timeOut = 5;
-            while(true)
+            while (true)
             {
                 try
                 {
@@ -166,7 +166,7 @@ namespace Kudu.Core.Functions
                 }
                 catch (Exception)
                 {
-                    if(timeOut == 0)
+                    if (timeOut == 0)
                     {
                         throw new TimeoutException($"Fail to read {keyPath}, the file is being held by another process");
                     }
@@ -310,8 +310,8 @@ namespace Kudu.Core.Functions
             }
             else
             {
-                string[] functionFiles = FileSystemHelpers.GetFiles(scriptDirectory,"*.*", SearchOption.TopDirectoryOnly)
-                    .Where(p => ! String.Equals(Path.GetFileName(p),"function.json", StringComparison.OrdinalIgnoreCase))
+                string[] functionFiles = FileSystemHelpers.GetFiles(scriptDirectory, "*.*", SearchOption.TopDirectoryOnly)
+                    .Where(p => !String.Equals(Path.GetFileName(p), "function.json", StringComparison.OrdinalIgnoreCase))
                     .ToArray();
 
                 if (functionFiles.Length == 0)
@@ -329,8 +329,8 @@ namespace Kudu.Core.Functions
                     // if there is a "run" file, that file is primary,
                     // for Node, any index.js file is primary
                     functionPrimary = functionFiles.FirstOrDefault(p =>
-                        String.Equals(Path.GetFileNameWithoutExtension(p),"run",StringComparison.OrdinalIgnoreCase) ||
-                        String.Equals(Path.GetFileName(p),"index.js",StringComparison.OrdinalIgnoreCase));
+                        String.Equals(Path.GetFileNameWithoutExtension(p), "run", StringComparison.OrdinalIgnoreCase) ||
+                        String.Equals(Path.GetFileName(p), "index.js", StringComparison.OrdinalIgnoreCase));
                 }
             }
 

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -291,7 +291,7 @@ namespace Kudu.Core.Functions
         /// Determines which script should be considered the "primary" entry point script.
         /// </summary>
         /// <exception cref="ConfigurationErrorsException">Thrown if the function metadata points to an invalid script file, or no script files are present.</exception>
-        private string DeterminePrimaryScriptFile(JObject functionConfig, string scriptDirectory)
+        internal string DeterminePrimaryScriptFile(JObject functionConfig, string scriptDirectory)
         {
             // First see if there is an explicit primary file indicated
             // in config. If so use that.

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -17,7 +17,7 @@ namespace Kudu.Core.Infrastructure
         private static IFileSystem _instance;
 
         public static IFileSystem Instance
-        { 
+        {
             get { return _instance ?? _default; }
             set { _instance = value; }
         }


### PR DESCRIPTION
address issue #2334 
"function.json"
```
{
    "scriptFile": "bin/Debug/PreCompiledFunctionSample.dll",
    "entryPoint": "PreCompiledFunctionSample.MyFunction.Run",
     ...
}
```
kudu/api/functions:
```
[{
        ...
	"script_href": "https://shunfunctionapp.scm.azurewebsites.net/api/vfs/site/wwwroot/dllTest/bin/Debug/PreCompiledFunctionSample.dll",
	"config_href": "https://shunfunctionapp.scm.azurewebsites.net/api/vfs/site/wwwroot/dllTest/function.json",
	"secrets_file_href": "https://shunfunctionapp.scm.azurewebsites.net/api/vfs/data/functions/secrets/dllTest.json",
	"href": "https://shunfunctionapp.scm.azurewebsites.net/api/functions/dllTest"
        ...
}]
```
`DeterminePrimaryScriptFile()` comes from this [commit](https://github.com/Azure/azure-webjobs-sdk-script/commit/71142175acd4a48a938c79951861492583576313).

TODO: refactor this function into a library