### PR TITLE
add a class to track space remains in ARM package, fix issue#2311

### DIFF
--- a/Kudu.Contracts/Functions/FunctionTestData.cs
+++ b/Kudu.Contracts/Functions/FunctionTestData.cs
@@ -2,31 +2,18 @@
 {
     public class FunctionTestData
     {
-        public static readonly long packageMaxSizeInBytes = 8300000;
         // test shows test_data of size 8310000 bytes still delivers as an ARM package
         // whereas test_data of size 8388608 bytes fails
+        public const long PackageMaxSizeInBytes = 8300000;
 
-        private long remain;
+        public long BytesLeftInPackage { get; set; } = PackageMaxSizeInBytes;
 
-        public FunctionTestData()
+        public bool DeductFromBytesLeftInPackage(long fileSize)
         {
-            remain = packageMaxSizeInBytes;
-        }
-
-        public long spaceLeftinPackage
-        {
-            get
-            {
-                return remain;
-            }
-        }
-
-        public bool canWrite(long fileSize)
-        {
-            long spaceLeft = remain - fileSize;
+            long spaceLeft = BytesLeftInPackage - fileSize;
             if (spaceLeft >= 0)
             {
-                remain = spaceLeft;
+                BytesLeftInPackage = spaceLeft;
                 return true;
             }
             return false;

--- a/Kudu.Contracts/Functions/FunctionTestData.cs
+++ b/Kudu.Contracts/Functions/FunctionTestData.cs
@@ -1,0 +1,35 @@
+﻿namespace Kudu.Contracts.Functions
+{
+    public class FunctionTestData
+    {
+        public static readonly long packageMaxSizeInBytes = 8300000;
+        // test shows test_data of size 8310000 bytes still delivers as an ARM package
+        // whereas test_data of size 8388608 bytes fails
+
+        private long remain;
+
+        public FunctionTestData()
+        {
+            remain = packageMaxSizeInBytes;
+        }
+
+        public long spaceLeftinPackage
+        {
+            get
+            {
+                return remain;
+            }
+        }
+
+        public bool canWrite(long fileSize)
+        {
+            long spaceLeft = remain - fileSize;
+            if (spaceLeft >= 0)
+            {
+                remain = spaceLeft;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Kudu.Contracts/Functions/IFunctionManager.cs
+++ b/Kudu.Contracts/Functions/IFunctionManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Kudu.Contracts.Functions;
 using Kudu.Contracts.Tracing;
 using Newtonsoft.Json.Linq;
 
@@ -10,8 +11,8 @@ namespace Kudu.Core.Functions
     {
         Task SyncTriggersAsync(ITracer tracer = null);
         Task<FunctionEnvelope> CreateOrUpdateAsync(string name, FunctionEnvelope functionEnvelope, Action setConfigChanged);
-        Task<IEnumerable<FunctionEnvelope>> ListFunctionsConfigAsync();
-        Task<FunctionEnvelope> GetFunctionConfigAsync(string name);
+        Task<IEnumerable<FunctionEnvelope>> ListFunctionsConfigAsync(FunctionTestData packageLimit);
+        Task<FunctionEnvelope> GetFunctionConfigAsync(string name, FunctionTestData packageLimit);
         Task<FunctionSecrets> GetFunctionSecretsAsync(string name);
         Task<MasterKey> GetMasterKeyAsync();
         Task<JObject> GetHostConfigAsync();

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Functions\FunctionSecrets.cs" />
     <Compile Include="Functions\FunctionEnvelope.cs" />
     <Compile Include="Functions\FunctionSecretsJsonOps.cs" />
+    <Compile Include="Functions\FunctionTestData.cs" />
     <Compile Include="Functions\IFunctionManager.cs" />
     <Compile Include="Functions\IKeyJsonOps.cs" />
     <Compile Include="Functions\MasterKey.cs" />

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -372,9 +372,9 @@ namespace Kudu.Core.Functions
             if (packageLimit != null)
             {
                 var fileSize = FileSystemHelpers.FileInfoFromFileName(testDataFilePath).Length;
-                if (!packageLimit.canWrite(fileSize))
+                if (!packageLimit.DeductFromBytesLeftInPackage(fileSize))
                 {
-                    return $"Test_Data is of size {fileSize}bytes, but there's only {packageLimit.spaceLeftinPackage}bytes left in ARM response";
+                    return $"Test_Data is of size {fileSize} bytes, but there's only {packageLimit.BytesLeftInPackage} bytes left in ARM response";
                 }
             }
 

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -249,7 +249,7 @@ namespace Kudu.Core.Functions
                 var path = GetFunctionConfigPath(name);
                 if (FileSystemHelpers.FileExists(path))
                 {
-                    return CreateFunctionConfig(await FileSystemHelpers.ReadAllTextFromFileAsync(path), name, packageLimit);
+                    return await CreateFunctionConfig(await FileSystemHelpers.ReadAllTextFromFileAsync(path), name, packageLimit);
                 }
             }
             catch
@@ -259,7 +259,7 @@ namespace Kudu.Core.Functions
             return null;
         }
 
-        private FunctionEnvelope CreateFunctionConfig(string configContent, string functionName, FunctionTestData packageLimit)
+        private async Task<FunctionEnvelope> CreateFunctionConfig(string configContent, string functionName, FunctionTestData packageLimit)
         {
             var functionConfig = JObject.Parse(configContent);
 
@@ -272,7 +272,7 @@ namespace Kudu.Core.Functions
                 SecretsFileHref = FilePathToVfsUri(GetFunctionSecretsFilePath(functionName)),
                 Href = GetFunctionHref(functionName),
                 Config = functionConfig,
-                TestData = GetFunctionTestData(functionName, packageLimit)
+                TestData = await GetFunctionTestData(functionName, packageLimit)
             };
         }
 
@@ -359,7 +359,7 @@ namespace Kudu.Core.Functions
             return Path.Combine(_environment.ApplicationLogFilesPath, Constants.Functions, Constants.Function, name);
         }
 
-        private string GetFunctionTestData(string functionName, FunctionTestData packageLimit)
+        private async Task<string> GetFunctionTestData(string functionName, FunctionTestData packageLimit)
         {
             string testDataFilePath = GetFunctionTestDataFilePath(functionName);
 
@@ -378,7 +378,7 @@ namespace Kudu.Core.Functions
                 }
             }
 
-            return FileSystemHelpers.ReadAllText(testDataFilePath); //why isn't this function async?
+            return await FileSystemHelpers.ReadAllTextFromFileAsync(testDataFilePath);
 
         }
 

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Kudu.Contracts.Functions;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Helpers;
 using Kudu.Core.Infrastructure;
@@ -96,23 +97,23 @@ namespace Kudu.Core.Functions
                 await FileSystemHelpers.WriteAllTextToFileAsync(dataFilePath, functionEnvelope.TestData);
             }
 
-            return await GetFunctionConfigAsync(name);
+            return await GetFunctionConfigAsync(name); // test_data took from incoming request, it will not exceed the limit
         }
 
-        public async Task<IEnumerable<FunctionEnvelope>> ListFunctionsConfigAsync()
+        public async Task<IEnumerable<FunctionEnvelope>> ListFunctionsConfigAsync(FunctionTestData packageLimit = null) // null means no limit
         {
             var configList = await Task.WhenAll(
                     FileSystemHelpers
                     .GetDirectories(_environment.FunctionsPath)
                     .Select(d => Path.Combine(d, Constants.FunctionsConfigFile))
                     .Where(FileSystemHelpers.FileExists)
-                    .Select(f => TryGetFunctionConfigAsync(Path.GetFileName(Path.GetDirectoryName(f)))));
+                    .Select(f => TryGetFunctionConfigAsync(Path.GetFileName(Path.GetDirectoryName(f)), packageLimit)));
             return configList.Where(c => c != null);
         }
 
-        public async Task<FunctionEnvelope> GetFunctionConfigAsync(string name)
+        public async Task<FunctionEnvelope> GetFunctionConfigAsync(string name, FunctionTestData packageLimit = null) // null means no limit
         {
-            var config = await TryGetFunctionConfigAsync(name);
+            var config = await TryGetFunctionConfigAsync(name, packageLimit);
             if (config == null)
             {
                 throw new FileNotFoundException($"Function ({name}) config does not exist or is invalid");
@@ -157,7 +158,7 @@ namespace Kudu.Core.Functions
 
             string jsonStr = null;
             int timeOut = 5;
-            while(true)
+            while (true)
             {
                 try
                 {
@@ -166,7 +167,7 @@ namespace Kudu.Core.Functions
                 }
                 catch (Exception)
                 {
-                    if(timeOut == 0)
+                    if (timeOut == 0)
                     {
                         throw new TimeoutException($"Fail to read {keyPath}, the file is being held by another process");
                     }
@@ -241,14 +242,14 @@ namespace Kudu.Core.Functions
             FileSystemHelpers.DeleteFileSafe(GetFunctionLogPath(name));
         }
 
-        private async Task<FunctionEnvelope> TryGetFunctionConfigAsync(string name)
+        private async Task<FunctionEnvelope> TryGetFunctionConfigAsync(string name, FunctionTestData packageLimit)
         {
             try
             {
                 var path = GetFunctionConfigPath(name);
                 if (FileSystemHelpers.FileExists(path))
                 {
-                    return CreateFunctionConfig(await FileSystemHelpers.ReadAllTextFromFileAsync(path), name);
+                    return CreateFunctionConfig(await FileSystemHelpers.ReadAllTextFromFileAsync(path), name, packageLimit);
                 }
             }
             catch
@@ -258,7 +259,7 @@ namespace Kudu.Core.Functions
             return null;
         }
 
-        private FunctionEnvelope CreateFunctionConfig(string configContent, string functionName)
+        private FunctionEnvelope CreateFunctionConfig(string configContent, string functionName, FunctionTestData packageLimit)
         {
             var functionConfig = JObject.Parse(configContent);
 
@@ -271,7 +272,7 @@ namespace Kudu.Core.Functions
                 SecretsFileHref = FilePathToVfsUri(GetFunctionSecretsFilePath(functionName)),
                 Href = GetFunctionHref(functionName),
                 Config = functionConfig,
-                TestData = GetFunctionTestData(functionName)
+                TestData = GetFunctionTestData(functionName, packageLimit)
             };
         }
 
@@ -358,7 +359,7 @@ namespace Kudu.Core.Functions
             return Path.Combine(_environment.ApplicationLogFilesPath, Constants.Functions, Constants.Function, name);
         }
 
-        private string GetFunctionTestData(string functionName)
+        private string GetFunctionTestData(string functionName, FunctionTestData packageLimit)
         {
             string testDataFilePath = GetFunctionTestDataFilePath(functionName);
 
@@ -368,7 +369,17 @@ namespace Kudu.Core.Functions
                 FileSystemHelpers.WriteAllText(testDataFilePath, String.Empty);
             }
 
-            return FileSystemHelpers.ReadAllText(testDataFilePath);
+            if (packageLimit != null)
+            {
+                var fileSize = FileSystemHelpers.FileInfoFromFileName(testDataFilePath).Length;
+                if (!packageLimit.canWrite(fileSize))
+                {
+                    return $"Test_Data is of size {fileSize}bytes, but there's only {packageLimit.spaceLeftinPackage}bytes left in ARM response";
+                }
+            }
+
+            return FileSystemHelpers.ReadAllText(testDataFilePath); //why isn't this function async?
+
         }
 
         private string GetFunctionTestDataFilePath(string functionName)

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -118,7 +118,7 @@ namespace Kudu.Core.Infrastructure
         }
 
         /// <summary>
-        /// Async version of ReadAllTestFromFile,
+        /// Async version of ReadAllTextFromFile,
         /// </summary>
         public static async Task<string> ReadAllTextFromFileAsync(string path)
         {

--- a/Kudu.Services/Functions/FunctionController.cs
+++ b/Kudu.Services/Functions/FunctionController.cs
@@ -81,7 +81,7 @@ namespace Kudu.Services.Functions
             var tracer = _traceFactory.GetTracer();
             using (tracer.Step("FunctionsController.list()"))
             {
-                var functions = (await _manager.ListFunctionsConfigAsync(ArmUtils.IsArmRequest(Request)?new FunctionTestData():null)).Select(f => AddFunctionAppIdToEnvelope(f));
+                var functions = (await _manager.ListFunctionsConfigAsync(ArmUtils.IsArmRequest(Request) ? new FunctionTestData() : null)).Select(f => AddFunctionAppIdToEnvelope(f));
                 return Request.CreateResponse(HttpStatusCode.OK, ArmUtils.AddEnvelopeOnArmRequest(functions, Request));
             }
         }
@@ -94,7 +94,7 @@ namespace Kudu.Services.Functions
             {
                 return Request.CreateResponse(HttpStatusCode.OK,
                     ArmUtils.AddEnvelopeOnArmRequest(
-                        AddFunctionAppIdToEnvelope(await _manager.GetFunctionConfigAsync(name, ArmUtils.IsArmRequest(Request)?new FunctionTestData():null)), Request));
+                        AddFunctionAppIdToEnvelope(await _manager.GetFunctionConfigAsync(name, ArmUtils.IsArmRequest(Request) ? new FunctionTestData() : null)), Request));
             }
         }
 

--- a/Kudu.Services/Functions/FunctionController.cs
+++ b/Kudu.Services/Functions/FunctionController.cs
@@ -17,6 +17,7 @@ using Kudu.Core.Helpers;
 using Newtonsoft.Json.Linq;
 
 using Environment = System.Environment;
+using Kudu.Contracts.Functions;
 
 namespace Kudu.Services.Functions
 {
@@ -80,7 +81,7 @@ namespace Kudu.Services.Functions
             var tracer = _traceFactory.GetTracer();
             using (tracer.Step("FunctionsController.list()"))
             {
-                var functions = (await _manager.ListFunctionsConfigAsync()).Select(f => AddFunctionAppIdToEnvelope(f));
+                var functions = (await _manager.ListFunctionsConfigAsync(ArmUtils.IsArmRequest(Request)?new FunctionTestData():null)).Select(f => AddFunctionAppIdToEnvelope(f));
                 return Request.CreateResponse(HttpStatusCode.OK, ArmUtils.AddEnvelopeOnArmRequest(functions, Request));
             }
         }
@@ -93,7 +94,7 @@ namespace Kudu.Services.Functions
             {
                 return Request.CreateResponse(HttpStatusCode.OK,
                     ArmUtils.AddEnvelopeOnArmRequest(
-                        AddFunctionAppIdToEnvelope(await _manager.GetFunctionConfigAsync(name)), Request));
+                        AddFunctionAppIdToEnvelope(await _manager.GetFunctionConfigAsync(name, ArmUtils.IsArmRequest(Request)?new FunctionTestData():null)), Request));
             }
         }
 


### PR DESCRIPTION
refer to #2311 
I created a `wrapper class` so that when [list function ARM api is invoked](https://github.com/projectkudu/kudu/wiki/Functions-API#listing-functions), we make the most out of the available package space left.

running the following ARM request: 

`GET https://management.azure.com/subscriptions/109f90ba-79f7-4d1e-8a0d-0e926b8dcbd8/resourceGroups/shunTest/providers/Microsoft.Web/sites/azurekudufunctionApp/functions?api-version=2015-08-01` 

on a machine:
```
Directory of D:\home\data\Functions\sampledata

02/28/2017  11:05 PM    <DIR>          .
02/28/2017  11:05 PM    <DIR>          ..
03/02/2017  05:47 PM         8,388,608 ManualTriggerCSharp1.dat
03/02/2017  05:47 PM         8,300,000 ManualTriggerCSharp2.dat
```
will give you either
`"test_data": "Test_Data is of size 8388608bytes, but there's only 0bytes left in ARM response"` 
`"test_data": "Test_Data is of size 8388608bytes, but there's only 8300000bytes left in ARM response"`
for the `ManualTriggerCSharp1.dat`, 
it depends on which async function finishes executing first