### PR TITLE
Fix DebugConsole monospace font for Macs

### DIFF
--- a/Kudu.Services.Web/Content/Styles/FileBrowser.css
+++ b/Kudu.Services.Web/Content/Styles/FileBrowser.css
@@ -86,7 +86,7 @@ div.upload-unzip-show {
 }
 
 div.zip-upload-text {
-    font-family: Consolas, 'Lucida Console', 'Courier New', monospace;
+    font-family: Consolas, Monaco, 'Lucida Console', 'Courier New', monospace;
     font-size: large;
     position: relative;
     text-align: center;
@@ -94,7 +94,7 @@ div.zip-upload-text {
 }
 
 div.console {
-    font-family: Consolas, 'Lucida Console', 'Courier New', monospace;
+    font-family: Consolas, Monaco, 'Lucida Console', 'Courier New', monospace;
     height: 100%;
     margin: auto;
     white-space: pre-wrap;


### PR DESCRIPTION
Added **Monaco** to DebugConsole font list. Courier makes the console look like it's 1995 on a Mac (which depending on the nostalgia factor could be regarded as a feature)..

Before (Courier New):
![screen shot 2017-03-06 at 11 09 31 am](https://cloud.githubusercontent.com/assets/6472374/23603334/6e8fa4e2-025d-11e7-905d-0241e2ea04fb.png)

After (Monaco):
![screen shot 2017-03-06 at 11 07 24 am](https://cloud.githubusercontent.com/assets/6472374/23603347/7ed39ab6-025d-11e7-9049-834f6770a8cd.png)

