### PR TITLE
Adding support for IIS profiling events in KUDU's process explorer

### DIFF
--- a/Kudu.Contracts/Diagnostics/ProcessInfo.cs
+++ b/Kudu.Contracts/Diagnostics/ProcessInfo.cs
@@ -30,6 +30,12 @@ namespace Kudu.Core.Diagnostics
         [JsonProperty(PropertyName = "is_profile_running", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsProfileRunning { get; set; }
 
+        [JsonProperty(PropertyName = "is_iis_profile_running", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool IsIisProfileRunning { get; set; }
+
+        [JsonProperty(PropertyName = "iis_profile_timeout_seconds", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public double IisProfileTimeoutInSeconds { get; set; }
+
         [JsonProperty(PropertyName = "parent", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Uri Parent { get; set; }
 

--- a/Kudu.Contracts/Diagnostics/ProcessInfo.cs
+++ b/Kudu.Contracts/Diagnostics/ProcessInfo.cs
@@ -33,7 +33,7 @@ namespace Kudu.Core.Diagnostics
         [JsonProperty(PropertyName = "is_iis_profile_running", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool IsIisProfileRunning { get; set; }
 
-        [JsonProperty(PropertyName = "iis_profile_timeout_seconds", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "iis_profile_timeout_in_seconds", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public double IisProfileTimeoutInSeconds { get; set; }
 
         [JsonProperty(PropertyName = "parent", DefaultValueHandling = DefaultValueHandling.Ignore)]

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -404,7 +404,6 @@ var Process = (function () {
             $(profilingButton).off("click");
             $(profilingButton).attr("title", "Profiling is not supported for Free/Shared sites.");
             $(profilingButton).tooltip().show();
-
         }
 
         tr.appendChild(Utilities.ToTd(iisProfilingCheckbox));
@@ -951,7 +950,7 @@ function handleProfilingEvents(e, processId) {
 
     var iisProfiling = false;
 
-    if (document.getElementById(processId + "-iisProfilingCheck") !=null) {
+    if (document.getElementById(processId + "-iisProfilingCheck") != null) {
         iisProfiling = document.getElementById(processId + "-iisProfilingCheck").checked;
     }
 
@@ -1024,7 +1023,6 @@ function stopProfiling(e, processId) {
 
     Utilities.downloadURL(uri, true);
     e.target.textContent = "Start Profiling";
-
     e.target.title = "It may take a few seconds for the download profile dialog to appear";
     $(e.currentTarget).removeClass("btn-danger");  // remove highlight button if the profiler has stopped
 }

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -401,7 +401,7 @@ var Process = (function () {
         }, false)));
         
         var profilingButton = Utilities.getButton("btn btn-info", this._json.id + "-Profiling", this._json.is_profile_running ? "Stop Profiling" : "Start Profiling", function (e) {
-            handleProfilingEvents(e, _this._json.id, _this._json.iis_profile_timeout_seconds);
+            handleProfilingEvents(e, _this._json.id, _this._json.iis_profile_timeout_in_seconds);
         }, false);
         $(profilingButton).css("width", "138px");
 
@@ -980,18 +980,14 @@ function handleProfilingEvents(e, processId, iisProfilingTimeoutInSeconds) {
         }
     }
     else if (e.target.textContent.indexOf("Starting") !== 0) {
-
         if (iisProfiling) {
-
             var divConfirm = document.getElementById('dialog-confirm')
             if (divConfirm == null) {
                 divConfirm = Utilities.createDiv('dialog-confirm');
                 divConfirm.title = "Collect IIS Events?";
 
             }
-
-            divConfirm.innerHTML = "IIS profiling enables IIS and threadtime ETW events. The generated trace file can be analyzed using Perview which is available at <a style='outline: none' href='https://www.microsoft.com/en-us/download/details.aspx?id=28567'>https://www.microsoft.com/en-us/download/details.aspx?id=28567</a>. <br/><br/>The profiling session will automatically timeout after <b>" + iisProfilingTimeoutInSeconds.toString() + "</b> seconds if not stopped manually.<br/><br/>Enabling IIS Profiling is a relatively <b>expensive option</b> to turn on as it increases the CPU usage and disk I/O on your instance. Are you sure you want to continue ?"
-
+            divConfirm.innerHTML = "IIS profiling enables IIS and threadTime ETW events. The generated trace file can be analyzed using Perfview which is available at <a style='outline: none' href='https://www.microsoft.com/en-us/download/details.aspx?id=28567'>https://www.microsoft.com/en-us/download/details.aspx?id=28567</a>. <br/><br/>The profiling session will automatically timeout after <b>" + iisProfilingTimeoutInSeconds.toString() + "</b> seconds if not stopped manually.<br/><br/>Enabling IIS Profiling is a relatively <b>expensive option</b> to turn on as it increases the CPU usage and disk I/O on your instance. Are you sure you want to continue?"
             $(divConfirm).dialog({
                 resizable: false,
                 height: 330,

--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -393,6 +393,9 @@ var Process = (function () {
         }, false);
         $(profilingButton).css("width", "138px");
 
+        if (this._json.is_profile_running) { // highlight button if the profiler has started
+            $(profilingButton).addClass("btn-danger");
+        }
 
         var iisProfilingCheckbox = Utilities.getCheckbox(this._json.id + "-iisProfilingCheck", "Collect IIS Events")
        

--- a/Kudu.Services.Web/ProcessExplorer/Default.cshtml
+++ b/Kudu.Services.Web/ProcessExplorer/Default.cshtml
@@ -30,7 +30,7 @@
             <th style="width: 7%">private_memory</th>
             <th style="width: 6%">thread_count</th>
             <th style="width: 4%">properties</th>
-            <th style="width: 4%">profiling</th>
+            <th style="width: 14%; text-align: center;" colspan="2">profiling</th>            
         </tr>
     </table>
     <ul id="treeRoot" class="tree"></ul>

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -451,6 +451,8 @@ namespace Kudu.Services.Performance
                 info.EnvironmentVariables = SafeGetValue(process.GetEnvironmentVariables, null);
                 info.CommandLine = SafeGetValue(process.GetCommandLine, null);
                 info.IsProfileRunning = ProfileManager.IsProfileRunning(process.Id);
+                info.IsIisProfileRunning = ProfileManager.IsIisProfileRunning(process.Id);
+                info.IisProfileTimeoutInSeconds = ProfileManager.IisProfileTimeoutInSeconds;
                 SetEnvironmentInfo(info);
             }
 

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -253,7 +253,7 @@ namespace Kudu.Services.Performance
                 // check if the process Ids exists in the sandbox. If it doesn't, this method returns a 404 and we are done.
                 var process = GetProcessById(id);
 
-                bool iisProfiling = ProfileManager.IsIISProfileRunning(process.Id);
+                bool iisProfiling = ProfileManager.IsIisProfileRunning(process.Id);
 
                 var result = await ProfileManager.StopProfileAsync(process.Id, _tracer, iisProfiling);
 

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -225,14 +225,14 @@ namespace Kudu.Services.Performance
         }
 
         [HttpPost]
-        public async Task<HttpResponseMessage> StartProfileAsync(int id)
+        public async Task<HttpResponseMessage> StartProfileAsync(int id, bool iisProfiling = false)
         {
             using (_tracer.Step("ProcessController.StartProfileAsync"))
             {
                 // check if the process Ids exists in the sandbox. If it doesn't, this method returns a 404 and we are done.
                 var process = GetProcessById(id);
 
-                var result = await ProfileManager.StartProfileAsync(process.Id, _tracer);
+                var result = await ProfileManager.StartProfileAsync(process.Id, _tracer, iisProfiling);
 
                 if(result.StatusCode != HttpStatusCode.OK)
                 {
@@ -253,7 +253,9 @@ namespace Kudu.Services.Performance
                 // check if the process Ids exists in the sandbox. If it doesn't, this method returns a 404 and we are done.
                 var process = GetProcessById(id);
 
-                var result = await ProfileManager.StopProfileAsync(process.Id, _tracer);
+                bool iisProfiling = ProfileManager.IsIISProfileRunning(process.Id);
+
+                var result = await ProfileManager.StopProfileAsync(process.Id, _tracer, iisProfiling);
 
                 if (result.StatusCode != HttpStatusCode.OK)
                 {
@@ -261,7 +263,8 @@ namespace Kudu.Services.Performance
                 }
                 else
                 {
-                    string profileFileFullPath = ProfileManager.GetProfilePath(process.Id);
+                    string profileFileFullPath = ProfileManager.GetProfilePath(process.Id, iisProfiling);
+
                     string profileFileName = Path.GetFileName(profileFileFullPath);
 
                     HttpResponseMessage response = Request.CreateResponse();

--- a/Kudu.Services/Diagnostics/ProfileManager.cs
+++ b/Kudu.Services/Diagnostics/ProfileManager.cs
@@ -29,16 +29,11 @@ namespace Kudu.Services.Performance
         // The profiling session timeout, this is temp fix before VS2015 Update 1.
         private static readonly TimeSpan _profilingTimeout = TimeSpan.FromMinutes(15);
 
-        private static readonly TimeSpan _profilingIisTimeout = TimeSpan.MinValue;
+        private static readonly TimeSpan _profilingIisTimeout = GetIisProfilingTimeout();
 
         private static Timer _profilingIdleTimer;
 
         private static string _processName = System.Environment.ExpandEnvironmentVariables("%SystemDrive%\\msvsmon\\profiler\\VSStandardCollector.Dev14.exe");
-
-        static ProfileManager()
-        {
-            _profilingIisTimeout = GetIisProfilingTimeout();            
-        }
 
         internal static async Task<ProfileResultInfo> StartProfileAsync(int processId, ITracer tracer = null, bool iisProfiling = false)
         {


### PR DESCRIPTION
This code will create a checkbox called "Collect IIS events" next to the START PROFILING button in process explorer in KUDU and this will allow to collect IIS ETW events, along with thread time events for Perfview and they will help in troubleshooting slow performance issues in Azure App Service