### PR TITLE
Preserve original order of PATH items

### DIFF
--- a/Kudu.Services.Web/Env.cshtml
+++ b/Kudu.Services.Web/Env.cshtml
@@ -81,7 +81,7 @@
 
     <h3 id="path">PATH</h3>
     <ul class="fixed-width">
-        @foreach (string folder in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator).Where(s => !String.IsNullOrWhiteSpace(s)).OrderBy(s => s))
+        @foreach (string folder in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator).Where(s => !String.IsNullOrWhiteSpace(s)))
          {
             <li>@folder</li>
          }


### PR DESCRIPTION
Updated Env.cshtml to preserve the original order of PATH items.  The original order of PATH items is significant, ordering them alphabetically is wrong.