### PR TITLE
Enable .NET Core builds on Linux

### DIFF
--- a/Kudu.Core/SourceControl/Git/GitExeRepository.cs
+++ b/Kudu.Core/SourceControl/Git/GitExeRepository.cs
@@ -439,13 +439,13 @@ fi" + "\n";
                     IEnumerable<string> lines = output.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
                     lines = lines
-                        .Select(line => Path.Combine(RepositoryPath, line.Trim().Trim('"').Replace('/', '\\')))
+                        .Select(line => Path.Combine(RepositoryPath, line.Trim().Trim('"').Replace('/', Path.DirectorySeparatorChar)))
                         .Where(p => p.StartsWith(path, StringComparison.OrdinalIgnoreCase));
 
                     switch (searchOption)
                     {
                         case SearchOption.TopDirectoryOnly:
-                            lines = lines.Where(line => !line.Substring(path.Length).TrimStart('\\').Contains('\\'));
+                            lines = lines.Where(line => !line.Substring(path.Length).TrimStart(Path.DirectorySeparatorChar).Contains(Path.DirectorySeparatorChar));
                             break;
 
                         case SearchOption.AllDirectories:

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/4161bca23a9e2532fffa20cf5fc4df45982796cf
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/75eaf360465fcc7bd24338bbf65deff2de470805
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end


### PR DESCRIPTION
- Update to newest kuduscript
- Fix for GitExeRepository.ListFiles (platform-independent directory separator char)
- .NET Core projects with solutions still fail to deploy on Linux; VsSolution.cs and VsSolutionProject.cs take dependencies on assemblies that have incompatible implementations on mono