### PR TITLE
return HTTP 400 when function keys are malformatted, fix issue #2341

### DIFF
--- a/Kudu.Services/Filters/FunctionExceptionFilterAttribute.cs
+++ b/Kudu.Services/Filters/FunctionExceptionFilterAttribute.cs
@@ -26,8 +26,12 @@ namespace Kudu.Services.Filters
             {
                 statusCode = HttpStatusCode.BadRequest;
             }
+            else if (context.Exception is FormatException)
+            {
+                statusCode = HttpStatusCode.BadRequest;
+            }
 
-            context.Response =  ArmUtils.CreateErrorResponse(context.Request, statusCode, context.Exception);
+            context.Response = ArmUtils.CreateErrorResponse(context.Request, statusCode, context.Exception);
         }
     }
 }


### PR DESCRIPTION
since [`GetKeyValueFromJson()`](https://github.com/projectkudu/kudu/blob/master/Kudu.Contracts/Functions/MasterKeyJsonOps.cs#L46-L51) parse all failures to `FormatException` (whether there's a json formatting issue or certain required field is missing) we give it error code 400, so that user can fix the file manually. This does not affect other exceptions thrown in [`GetKeyObjectFromFile()`](https://github.com/projectkudu/kudu/blob/master/Kudu.Core/Functions/FunctionManager.cs#L124)