### PR TITLE
check function existance before creating function keys, #2342

### DIFF
--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -195,7 +195,7 @@ namespace Kudu.Core.Functions
         public async Task<FunctionSecrets> GetFunctionSecretsAsync(string functionName)
         {
             // check to see if the function folder exists
-            GetFunctionPath(functionName);
+            GetFuncPathAndCheckExistance(functionName);
             return await GetKeyObjectFromFile<FunctionSecrets>(functionName, new FunctionSecretsJsonOps());
         }
 
@@ -233,7 +233,7 @@ namespace Kudu.Core.Functions
 
         public void DeleteFunction(string name, bool ignoreErrors)
         {
-            FileSystemHelpers.DeleteDirectorySafe(GetFunctionPath(name), ignoreErrors);
+            FileSystemHelpers.DeleteDirectorySafe(GetFuncPathAndCheckExistance(name), ignoreErrors);
             DeleteFunctionArtifacts(name);
         }
 
@@ -264,7 +264,7 @@ namespace Kudu.Core.Functions
         private async Task<FunctionEnvelope> CreateFunctionConfig(string configContent, string functionName, FunctionTestData packageLimit)
         {
             var functionConfig = JObject.Parse(configContent);
-            var functionPath = GetFunctionPath(functionName);
+            var functionPath = GetFuncPathAndCheckExistance(functionName);
 
             return new FunctionEnvelope
             {
@@ -365,7 +365,7 @@ namespace Kudu.Core.Functions
             }
         }
 
-        private string GetFunctionPath(string name)
+        private string GetFuncPathAndCheckExistance(string name)
         {
             var path = Path.Combine(_environment.FunctionsPath, name);
             if (FileSystemHelpers.DirectoryExists(path))
@@ -378,7 +378,7 @@ namespace Kudu.Core.Functions
 
         private string GetFunctionConfigPath(string name)
         {
-            return Path.Combine(GetFunctionPath(name), Constants.FunctionsConfigFile);
+            return Path.Combine(GetFuncPathAndCheckExistance(name), Constants.FunctionsConfigFile);
         }
 
         private string GetFunctionLogPath(string name)

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -194,6 +194,8 @@ namespace Kudu.Core.Functions
 
         public async Task<FunctionSecrets> GetFunctionSecretsAsync(string functionName)
         {
+            // check to see if the function folder exists
+            GetFunctionPath(functionName);
             return await GetKeyObjectFromFile<FunctionSecrets>(functionName, new FunctionSecretsJsonOps());
         }
 

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -195,7 +195,7 @@ namespace Kudu.Core.Functions
         public async Task<FunctionSecrets> GetFunctionSecretsAsync(string functionName)
         {
             // check to see if the function folder exists
-            GetFuncPathAndCheckExistance(functionName);
+            GetFuncPathAndCheckExistence(functionName);
             return await GetKeyObjectFromFile<FunctionSecrets>(functionName, new FunctionSecretsJsonOps());
         }
 
@@ -233,7 +233,7 @@ namespace Kudu.Core.Functions
 
         public void DeleteFunction(string name, bool ignoreErrors)
         {
-            FileSystemHelpers.DeleteDirectorySafe(GetFuncPathAndCheckExistance(name), ignoreErrors);
+            FileSystemHelpers.DeleteDirectorySafe(GetFuncPathAndCheckExistence(name), ignoreErrors);
             DeleteFunctionArtifacts(name);
         }
 
@@ -264,7 +264,7 @@ namespace Kudu.Core.Functions
         private async Task<FunctionEnvelope> CreateFunctionConfig(string configContent, string functionName, FunctionTestData packageLimit)
         {
             var functionConfig = JObject.Parse(configContent);
-            var functionPath = GetFuncPathAndCheckExistance(functionName);
+            var functionPath = GetFuncPathAndCheckExistence(functionName);
 
             return new FunctionEnvelope
             {
@@ -365,7 +365,7 @@ namespace Kudu.Core.Functions
             }
         }
 
-        private string GetFuncPathAndCheckExistance(string name)
+        private string GetFuncPathAndCheckExistence(string name)
         {
             var path = Path.Combine(_environment.FunctionsPath, name);
             if (FileSystemHelpers.DirectoryExists(path))
@@ -378,7 +378,7 @@ namespace Kudu.Core.Functions
 
         private string GetFunctionConfigPath(string name)
         {
-            return Path.Combine(GetFuncPathAndCheckExistance(name), Constants.FunctionsConfigFile);
+            return Path.Combine(GetFuncPathAndCheckExistence(name), Constants.FunctionsConfigFile);
         }
 
         private string GetFunctionLogPath(string name)


### PR DESCRIPTION
if the function folder is not found, it returns a 404:
```
https://azurekudufunctionapp.scm.azurewebsites.net/api/functions/ManualTriggerJS4/listsecrets

{
  "Message": "An error has occurred.",
  "ExceptionMessage": "Function (ManualTriggerJS4) does not exist",
  "ExceptionType": "System.IO.FileNotFoundException",
  "StackTrace":  ...
}
```
to be safer, we call also read the `function.json` to [make sure the function is valid](https://github.com/projectkudu/kudu/blob/master/Kudu.Core/Functions/FunctionManager.cs#L116-L120).