### PR TITLE
create keys if the file is empty, fix issue #2363

### DIFF
--- a/Kudu.Services/Functions/FunctionController.cs
+++ b/Kudu.Services/Functions/FunctionController.cs
@@ -111,6 +111,9 @@ namespace Kudu.Services.Functions
         [HttpPost]
         public async Task<HttpResponseMessage> GetSecrets(string name)
         {
+            // "name".json will be created as function keys, (runtime will always have lowercase "name")
+            // kudu REST api does not care, "name" can be camelcase (ex: function portal)
+            // windows file system is case insensitive, but this might not work in linux
             var tracer = _traceFactory.GetTracer();
             using (tracer.Step($"FunctionsController.GetSecrets({name})"))
             {


### PR DESCRIPTION
adjust some comments, real change is just adding a length check, and the `FileMode` goes from `CreateNew` (`IOException` if the file already exists) to `Create`