### PR TITLE
Update detailed tracing agent GUID

### DIFF
--- a/Kudu.Services/Diagnostics/ProfileManager.cs
+++ b/Kudu.Services/Diagnostics/ProfileManager.cs
@@ -19,7 +19,7 @@ namespace Kudu.Services.Performance
         private const int ProcessExitTimeoutInSeconds = 180;
 
         private const string UserModeCustomProviderAgentGuid = "F5091AA9-80DC-49FF-A7CF-BD1103FE149D";
-        private const string DetailedTracingAgentGuid = "1C92BA2A-A990-480F-A02F-40068871CAAC";
+        private const string DetailedTracingAgentGuid = "31003EE3-A8E1-427A-931E-97057D4D2B7D";
         private const string IisWebServerProviderGuid = "3A2A4E84-4C21-4981-AE10-3FDA0D9B0F83";
         private const string DiagnosticsHubAgentGuid = "4EA90761-2248-496C-B854-3C0399A591A4";
         


### PR DESCRIPTION
In a future Antares build (targeting end of April 2017) , we will be updating the ServiceProfilerAgent.dll which is used to assist with profiling. In that update, we will remove support for (what we call) the V1V2 circular monitor agent. V3 will be the only one supported in Antares.

Therefore, the ```DetailedTracingAgentGuid``` constant needs to be updated to the V3 agent GUID:
https://github.com/projectkudu/kudu/blob/master/Kudu.Services/Diagnostics/ProfileManager.cs#L22

This change can be made now. V3 has been available since November 2016, so it is already in all Antares stamps.

Just updating the GUID is enough. There are no other changes required.