### PR TITLE
remove TODO comment on list-secrets

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -526,7 +526,6 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRoute("put-function", "api/functions/{name}", new { controller = "Function", action = "CreateOrUpdate" }, new { verb = new HttpMethodConstraint("PUT") });
             routes.MapHttpRoute("list-functions", "api/functions", new { controller = "Function", action = "List" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("get-function", "api/functions/{name}", new { controller = "Function", action = "Get" }, new { verb = new HttpMethodConstraint("GET") });
-            // TODO: remove obsolete getsecrets route once consumer switches to listsecrets
             routes.MapHttpRoute("list-secrets", "api/functions/{name}/listsecrets", new { controller = "Function", action = "GetSecrets" }, new { verb = new HttpMethodConstraint("POST") });
             routes.MapHttpRoute("get-masterkey", "api/functions/admin/masterkey", new { controller = "Function", action = "GetMasterKey" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("delete-function", "api/functions/{name}", new { controller = "Function", action = "Delete" }, new { verb = new HttpMethodConstraint("DELETE") });


### PR DESCRIPTION
this `TODO` was created at [this commit back in March 2016](https://github.com/projectkudu/kudu/commit/f9947cc441240dcb266698e2539ca8a30b5480fa) and could be removed by [this commit in May 2016](https://github.com/projectkudu/kudu/commit/0bfe30f857fb61a67a31ef17e57a15bac4443845)

btw, why are we using `POST` instead of `PUT` for "list-secrets"?