### PR TITLE
Fix for #2380

### DIFF
--- a/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandFactory.cs
@@ -12,7 +12,7 @@ namespace Kudu.Core.Deployment.Generator
     {
         public const string KuduSyncCommand = "kudusync";
 
-        internal const string StarterScriptName = "starter.cmd";
+        internal static string StarterScriptName = OSDetector.IsOnWindows() ? "starter.cmd" : "starter.sh";
 
         private IEnvironment _environment;
         private IDeploymentSettingsManager _deploymentSettings;
@@ -122,16 +122,7 @@ namespace Kudu.Core.Deployment.Generator
         {
             get
             {
-                if (OSDetector.IsOnWindows())
-                {
-                    return Path.Combine(_environment.ScriptPath, StarterScriptName);
-                }
-                else
-                {
-                    // Content in StarterScript is "@%*", means to be less verbose when execute an external script, since by default cmd will print out content of each step.
-                    // Linux doesn`t print out the content of the step when execute a command, so simply use "/bin/bash" here.
-                    return "/bin/bash";
-                }
+                return Path.Combine(_environment.ScriptPath, StarterScriptName);
             }
         }
 

--- a/Kudu.Core/Deployment/Generator/GeneratorSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/GeneratorSiteBuilder.cs
@@ -80,6 +80,13 @@ namespace Kudu.Core.Deployment.Generator
 
                         scriptGenerator.ExecuteWithProgressWriter(buildLogger, context.Tracer, scriptGeneratorCommand);
 
+                        if (!OSDetector.IsOnWindows())
+                        {
+                            // Kuduscript output is typically not given execute permission, so add it
+                            var deploymentScriptPath = DeploymentManager.GetCachedDeploymentScriptPath(Environment);
+                            PermissionHelper.Chmod("ugo+x", deploymentScriptPath, Environment, DeploymentSettings, buildLogger);
+                        }
+
                         CacheDeploymentScript(scriptGeneratorCommandArguments, context);
                     }
                     else

--- a/Kudu.Core/Helpers/PermissionHelper.cs
+++ b/Kudu.Core/Helpers/PermissionHelper.cs
@@ -3,6 +3,7 @@ using Kudu.Contracts.Settings;
 using Kudu.Core.Deployment;
 using Kudu.Core.Deployment.Generator;
 using Kudu.Core.Infrastructure;
+using System;
 
 namespace Kudu.Core.Helpers
 {
@@ -13,7 +14,7 @@ namespace Kudu.Core.Helpers
             var folder = Path.GetDirectoryName(filePath);
             var exeFactory = new ExternalCommandFactory(environment, deploymentSettingManager, null);
             Executable exe = exeFactory.BuildCommandExecutable("/bin/chmod", folder, deploymentSettingManager.GetCommandIdleTimeout(), logger);
-            exe.Execute("{0} {1}", permission, filePath);
+            exe.Execute("{0} \"{1}\"", permission, filePath);
         }
     }
 }

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -418,6 +418,9 @@
     <None Include="Scripts\runDnxWebJob.cmd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="Scripts\starter.sh">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kudu.Contracts\Kudu.Contracts.csproj">

--- a/Kudu.Core/Scripts/starter.sh
+++ b/Kudu.Core/Scripts/starter.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec "$@"

--- a/Kudu.Core/Scripts/starter.sh
+++ b/Kudu.Core/Scripts/starter.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 exec "$@"

--- a/Kudu.Services.Web/Content/Scripts/KuduExec.js
+++ b/Kudu.Services.Web/Content/Scripts/KuduExec.js
@@ -64,7 +64,7 @@ function LoadConsole() {
             // always append these commands so the working directory after the command is returned.
             var remoteCommand = command + " & echo. & cd";
             if ($.serverOS === "linux") {
-                remoteCommand = "-c '" + command + " && echo '' && pwd'";
+                remoteCommand = "bash -c '" + command + " && echo '' && pwd'";
             }
             var request = RemoteExecuteCommandRequest(remoteCommand, curWorkingDir());
             request.done(function (resp) {


### PR DESCRIPTION
- Creates a bash "starter script" for use in ExternalCommandFacotry.BuildExternalCommandExecutable on Linux, to parallel the Windows implementation. Original implementation prefixed all commands with "/bin/bash", which really only makes sense if command is a bash script.