### PR TITLE
migrate from masterkey to admintoken for portal->function runtime authentication

### DIFF
--- a/Kudu.Client/app.config
+++ b/Kudu.Client/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.Console/app.config
+++ b/Kudu.Console/app.config
@@ -1,16 +1,20 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <appSettings>
-      <add key="WaitForDebuggerOnStart" value="false"/>
+      <add key="WaitForDebuggerOnStart" value="false" />
     </appSettings>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Kudu.Contracts/Functions/IFunctionManager.cs
+++ b/Kudu.Contracts/Functions/IFunctionManager.cs
@@ -16,7 +16,7 @@ namespace Kudu.Core.Functions
         Task<FunctionSecrets> GetFunctionSecretsAsync(string name);
         Task<MasterKey> GetMasterKeyAsync();
         Task<JObject> GetHostConfigAsync();
-        string GetToken();
+        string GetAdminToken();
         Task<JObject> PutHostConfigAsync(JObject content);
         void DeleteFunction(string name, bool ignoreErrors);
     }

--- a/Kudu.Contracts/Functions/IFunctionManager.cs
+++ b/Kudu.Contracts/Functions/IFunctionManager.cs
@@ -16,6 +16,7 @@ namespace Kudu.Core.Functions
         Task<FunctionSecrets> GetFunctionSecretsAsync(string name);
         Task<MasterKey> GetMasterKeyAsync();
         Task<JObject> GetHostConfigAsync();
+        string GetToken();
         Task<JObject> PutHostConfigAsync(JObject content);
         void DeleteFunction(string name, bool ignoreErrors);
     }

--- a/Kudu.Core.Test/app.config
+++ b/Kudu.Core.Test/app.config
@@ -3,13 +3,13 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -187,6 +187,7 @@ namespace Kudu.Core.Functions
 
         }
 
+        public string GetToken() => SecurityUtility.GenerateFunctionToken();
 
         public async Task<MasterKey> GetMasterKeyAsync()
         {

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -187,7 +187,7 @@ namespace Kudu.Core.Functions
 
         }
 
-        public string GetToken() => SecurityUtility.GenerateFunctionToken();
+        public string GetAdminToken() => SecurityUtility.GenerateFunctionToken();
 
         public async Task<MasterKey> GetMasterKeyAsync()
         {

--- a/Kudu.Core/Infrastructure/SecurityUtility.cs
+++ b/Kudu.Core/Infrastructure/SecurityUtility.cs
@@ -39,6 +39,13 @@ namespace Kudu.Core.Infrastructure
             return protector.Unprotect(content);
         }
 
+        public static string GenerateFunctionToken()
+        {
+            string siteName = ServerConfiguration.GetApplicationName();
+            string issuer = $"https://{siteName}.scm.azurewebsites.net";
+            string audience = $"https://{siteName}.azurewebsites.net/azurefunctions";
+            return JwtGenerator.GenerateToken(issuer, audience, expires: DateTime.UtcNow.AddMinutes(2));
+        }
     }
 }
 

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -25,67 +25,75 @@
       <HintPath>..\packages\Mercurial.Net.1.1.1.607\lib\net35-Client\Mercurial.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Cryptography.Internal.1.0.0\lib\net451\Microsoft.AspNetCore.Cryptography.Internal.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Cryptography.Internal.1.0.2\lib\net451\Microsoft.AspNetCore.Cryptography.Internal.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.DataProtection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.1.0.0\lib\net451\Microsoft.AspNetCore.DataProtection.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.DataProtection, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.1.0.2\lib\net451\Microsoft.AspNetCore.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.Abstractions.1.0.0\lib\net451\Microsoft.AspNetCore.DataProtection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.Abstractions.1.0.2\lib\net451\Microsoft.AspNetCore.DataProtection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Abstractions.1.0.0\lib\net451\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Abstractions.1.0.2\lib\net451\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.1.0.0\lib\net451\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.1.0.2\lib\net451\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Abstractions.1.0.0\lib\net451\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Abstractions.1.0.2\lib\net451\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.1.0.0\lib\net451\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.1.0.2\lib\net451\Microsoft.AspNetCore.Http.Features.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.6-alpha45\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.77-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource">
       <HintPath>..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.0.26\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.1.0.2\lib\netstandard1.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.2\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.2\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=1.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.1.0.1\lib\netstandard1.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.1.0.2\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.1.0.0\lib\netstandard1.0\Microsoft.Extensions.Options.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Options, Version=1.0.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.1.0.2\lib\netstandard1.0\Microsoft.Extensions.Options.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.1.0.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=1.0.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.1.0.1\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=1.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.1.1.3\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.1.3\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -160,6 +168,10 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.3\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Abstractions, Version=1.4.0.74, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.IO.Abstractions.1.4.0.74\lib\net35\System.IO.Abstractions.dll</HintPath>

--- a/Kudu.Core/app.config
+++ b/Kudu.Core/app.config
@@ -3,17 +3,17 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0"/>
+        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.Core/packages.config
+++ b/Kudu.Core/packages.config
@@ -3,26 +3,28 @@
   <package id="DotNetZip" version="1.9.1.8" targetFramework="net45" />
   <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net45" />
   <package id="Mercurial.Net" version="1.1.1.607" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.DataProtection" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.Http.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.AspNetCore.Http.Features" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.6-alpha45" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.DataProtection" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.77-alpha" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.0.26" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource" version="1.0.26" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.0.26" targetFramework="net45" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Extensions.Options" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Extensions.Primitives" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="1.0.1" targetFramework="net46" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.Extensions.Options" version="1.0.2" targetFramework="net46" />
+  <package id="Microsoft.Extensions.Primitives" version="1.0.1" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Logging" version="1.1.3" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.1.3" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="ncrontab" version="2.0.0" targetFramework="net45" />
@@ -38,10 +40,11 @@
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.3" targetFramework="net46" />
   <package id="System.IO" version="4.1.0" targetFramework="net46" />
   <package id="System.IO.Abstractions" version="1.4.0.74" targetFramework="net45" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />
-  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net46" />
+  <package id="System.Linq.Expressions" version="4.1.1" targetFramework="net46" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net46" />
   <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net46" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net46" />

--- a/Kudu.FunctionalTests/App.config
+++ b/Kudu.FunctionalTests/App.config
@@ -2,32 +2,32 @@
 <configuration>
     <appSettings>
         <!-- Uncomment out this line to reuse the same site for all functional tests, which runs much faster -->
-        <add key="SiteReusedForAllTests" value="TestRunnerSite"/>
+        <add key="SiteReusedForAllTests" value="TestRunnerSite" />
         <!-- Update to change the maximum number of sites created on failure in reuse site mode -->
-        <add key="MaxSiteNameIndex" value="1"/>
+        <add key="MaxSiteNameIndex" value="1" />
         <!-- whether to retry on failure -->
-        <add key="DisableRetry" value="true"/>
+        <add key="DisableRetry" value="true" />
         <!-- By default we use App Pool Identity, but it has caused strange errors that are not well understood -->
-        <add key="UseNetworkServiceIdentity" value="true"/>
+        <add key="UseNetworkServiceIdentity" value="true" />
     </appSettings>
     <system.net>
         <connectionManagement>
-          <clear/>
-          <add address="*" maxconnection="10"/>
+          <clear />
+          <add address="*" maxconnection="10" />
         </connectionManagement>
     </system.net>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Kudu.Performance/app.config
+++ b/Kudu.Performance/app.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.8.0.1549" newVersion="1.8.0.1549"/>
+        <assemblyIdentity name="xunit" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.8.0.1549" newVersion="1.8.0.1549" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Kudu.Services.Test/app.config
+++ b/Kudu.Services.Test/app.config
@@ -3,13 +3,13 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -528,6 +528,7 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRoute("get-function", "api/functions/{name}", new { controller = "Function", action = "Get" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("list-secrets", "api/functions/{name}/listsecrets", new { controller = "Function", action = "GetSecrets" }, new { verb = new HttpMethodConstraint("POST") });
             routes.MapHttpRoute("get-masterkey", "api/functions/admin/masterkey", new { controller = "Function", action = "GetMasterKey" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("get-token", "api/functions/admin/token", new { controller = "Function", action = "GetToken" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("delete-function", "api/functions/{name}", new { controller = "Function", action = "Delete" }, new { verb = new HttpMethodConstraint("DELETE") });
 
             // catch all unregistered url to properly handle not found

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -528,7 +528,7 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRoute("get-function", "api/functions/{name}", new { controller = "Function", action = "Get" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("list-secrets", "api/functions/{name}/listsecrets", new { controller = "Function", action = "GetSecrets" }, new { verb = new HttpMethodConstraint("POST") });
             routes.MapHttpRoute("get-masterkey", "api/functions/admin/masterkey", new { controller = "Function", action = "GetMasterKey" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpRoute("get-token", "api/functions/admin/token", new { controller = "Function", action = "GetToken" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpRoute("get-admintoken", "api/functions/admin/token", new { controller = "Function", action = "GetAdminToken" }, new { verb = new HttpMethodConstraint("GET") });
             routes.MapHttpRoute("delete-function", "api/functions/{name}", new { controller = "Function", action = "Delete" }, new { verb = new HttpMethodConstraint("DELETE") });
 
             // catch all unregistered url to properly handle not found

--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -1,14 +1,14 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <appSettings>
-    <add key="SCM_GIT_USERNAME" value="kudu"/>
-    <add key="SCM_GIT_EMAIL" value="kudu"/>
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="true"/>
+    <add key="SCM_GIT_USERNAME" value="kudu" />
+    <add key="SCM_GIT_EMAIL" value="kudu" />
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="true" />
     <add key="webactivator:assembliesToScan" value="Kudu.Services.Web" />
   </appSettings>
   <!--
@@ -20,142 +20,142 @@
       </system.Web>
   -->
   <system.web>
-    <customErrors mode="Off"/>
-    <httpRuntime targetFramework="4.6" maxRequestLength="4194304" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" requestPathInvalidCharacters=""/>
-    <pages controlRenderingCompatibilityVersion="4.0"/>
+    <customErrors mode="Off" />
+    <httpRuntime targetFramework="4.6" maxRequestLength="4194304" shutdownTimeout="6000" executionTimeout="6000" requestValidationMode="2.0" requestPathInvalidCharacters="" />
+    <pages controlRenderingCompatibilityVersion="4.0" />
   </system.web>
   <location path="." inheritInChildApplications="false">
     <system.web>
       <compilation targetFramework="4.6">
         <assemblies>
           <clear />
-          <add assembly="Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-          <add assembly="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
-          <add assembly="System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"/>
-          <add assembly="WebActivatorEx"/>
-          <add assembly="Kudu.Core"/>
-          <add assembly="Kudu.Contracts"/>
-          <add assembly="Kudu.Services"/>
-          <add assembly="Kudu.Contracts"/>
-          <add assembly="Kudu.Services.Web"/>
-          <add assembly="System.Web.WebPages"/>
-          <add assembly="System.Web.WebPages.Razor"/>
-          <add assembly="Microsoft.Owin.Host.SystemWeb"/>
+          <add assembly="Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+          <add assembly="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+          <add assembly="System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+          <add assembly="WebActivatorEx" />
+          <add assembly="Kudu.Core" />
+          <add assembly="Kudu.Contracts" />
+          <add assembly="Kudu.Services" />
+          <add assembly="Kudu.Contracts" />
+          <add assembly="Kudu.Services.Web" />
+          <add assembly="System.Web.WebPages" />
+          <add assembly="System.Web.WebPages.Razor" />
+          <add assembly="Microsoft.Owin.Host.SystemWeb" />
         </assemblies>
       </compilation>
       <httpModules>
-        <add name="TraceModule" type="Kudu.Services.Web.Tracing.TraceModule"/>
+        <add name="TraceModule" type="Kudu.Services.Web.Tracing.TraceModule" />
       </httpModules>
     </system.web>
     <system.webServer>
-      <validation validateIntegratedModeConfiguration="false"/>
+      <validation validateIntegratedModeConfiguration="false" />
       <modules runAllManagedModulesForAllRequests="true">
-        <remove name="WebDAVModule"/>
+        <remove name="WebDAVModule" />
         <!--<add name="BlockLocalhostModule" type="Kudu.Services.Web.Security.BlockLocalhostModule"/>-->
       </modules>
       <staticContent>
-        <remove fileExtension=".svg"/>
-        <mimeMap fileExtension=".svg" mimeType="image/svg+xml"/>
+        <remove fileExtension=".svg" />
+        <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
       </staticContent>
     </system.webServer>
   </location>
   <system.webServer>
     <security>
       <requestFiltering allowDoubleEscaping="true">
-        <requestLimits maxAllowedContentLength="4294967295"/>
+        <requestLimits maxAllowedContentLength="4294967295" />
         <fileExtensions allowUnlisted="true">
-          <remove fileExtension=".asa"/>
-          <remove fileExtension=".asax"/>
-          <remove fileExtension=".ascx"/>
-          <remove fileExtension=".master"/>
-          <remove fileExtension=".skin"/>
-          <remove fileExtension=".browser"/>
-          <remove fileExtension=".sitemap"/>
-          <remove fileExtension=".config"/>
-          <remove fileExtension=".cs"/>
-          <remove fileExtension=".csproj"/>
-          <remove fileExtension=".vb"/>
-          <remove fileExtension=".vbproj"/>
-          <remove fileExtension=".fsproj"/>
-          <remove fileExtension=".fs"/>
-          <remove fileExtension=".fsx"/>
-          <remove fileExtension=".webinfo"/>
-          <remove fileExtension=".licx"/>
-          <remove fileExtension=".resx"/>
-          <remove fileExtension=".resources"/>
-          <remove fileExtension=".mdb"/>
-          <remove fileExtension=".vjsproj"/>
-          <remove fileExtension=".java"/>
-          <remove fileExtension=".jsl"/>
-          <remove fileExtension=".ldb"/>
-          <remove fileExtension=".dsdgm"/>
-          <remove fileExtension=".ssdgm"/>
-          <remove fileExtension=".lsad"/>
-          <remove fileExtension=".ssmap"/>
-          <remove fileExtension=".cd"/>
-          <remove fileExtension=".dsprototype"/>
-          <remove fileExtension=".lsaprototype"/>
-          <remove fileExtension=".sdm"/>
-          <remove fileExtension=".sdmDocument"/>
-          <remove fileExtension=".mdf"/>
-          <remove fileExtension=".ldf"/>
-          <remove fileExtension=".ad"/>
-          <remove fileExtension=".dd"/>
-          <remove fileExtension=".ldd"/>
-          <remove fileExtension=".sd"/>
-          <remove fileExtension=".adprototype"/>
-          <remove fileExtension=".lddprototype"/>
-          <remove fileExtension=".exclude"/>
-          <remove fileExtension=".refresh"/>
-          <remove fileExtension=".compiled"/>
-          <remove fileExtension=".msgx"/>
-          <remove fileExtension=".vsdisco"/>
+          <remove fileExtension=".asa" />
+          <remove fileExtension=".asax" />
+          <remove fileExtension=".ascx" />
+          <remove fileExtension=".master" />
+          <remove fileExtension=".skin" />
+          <remove fileExtension=".browser" />
+          <remove fileExtension=".sitemap" />
+          <remove fileExtension=".config" />
+          <remove fileExtension=".cs" />
+          <remove fileExtension=".csproj" />
+          <remove fileExtension=".vb" />
+          <remove fileExtension=".vbproj" />
+          <remove fileExtension=".fsproj" />
+          <remove fileExtension=".fs" />
+          <remove fileExtension=".fsx" />
+          <remove fileExtension=".webinfo" />
+          <remove fileExtension=".licx" />
+          <remove fileExtension=".resx" />
+          <remove fileExtension=".resources" />
+          <remove fileExtension=".mdb" />
+          <remove fileExtension=".vjsproj" />
+          <remove fileExtension=".java" />
+          <remove fileExtension=".jsl" />
+          <remove fileExtension=".ldb" />
+          <remove fileExtension=".dsdgm" />
+          <remove fileExtension=".ssdgm" />
+          <remove fileExtension=".lsad" />
+          <remove fileExtension=".ssmap" />
+          <remove fileExtension=".cd" />
+          <remove fileExtension=".dsprototype" />
+          <remove fileExtension=".lsaprototype" />
+          <remove fileExtension=".sdm" />
+          <remove fileExtension=".sdmDocument" />
+          <remove fileExtension=".mdf" />
+          <remove fileExtension=".ldf" />
+          <remove fileExtension=".ad" />
+          <remove fileExtension=".dd" />
+          <remove fileExtension=".ldd" />
+          <remove fileExtension=".sd" />
+          <remove fileExtension=".adprototype" />
+          <remove fileExtension=".lddprototype" />
+          <remove fileExtension=".exclude" />
+          <remove fileExtension=".refresh" />
+          <remove fileExtension=".compiled" />
+          <remove fileExtension=".msgx" />
+          <remove fileExtension=".vsdisco" />
         </fileExtensions>
         <hiddenSegments>
-          <remove segment="App_Data"/>
-          <remove segment="App_GlobalResources"/>
-          <remove segment="App_WebReferences"/>
-          <remove segment="App_LocalResources"/>
-          <remove segment="App_code"/>
-          <remove segment="App_Browsers"/>
-          <remove segment="web.config"/>
-          <remove segment="bin"/>
+          <remove segment="App_Data" />
+          <remove segment="App_GlobalResources" />
+          <remove segment="App_WebReferences" />
+          <remove segment="App_LocalResources" />
+          <remove segment="App_code" />
+          <remove segment="App_Browsers" />
+          <remove segment="web.config" />
+          <remove segment="bin" />
         </hiddenSegments>
       </requestFiltering>
     </security>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
   <system.net>
     <defaultProxy enabled="true">
-      <proxy usesystemdefault="True"/>
+      <proxy usesystemdefault="True" />
     </defaultProxy>
   </system.net>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -51,7 +51,7 @@
       <validation validateIntegratedModeConfiguration="false" />
       <modules runAllManagedModulesForAllRequests="true">
         <remove name="WebDAVModule" />
-        <!--<add name="BlockLocalhostModule" type="Kudu.Services.Web.Security.BlockLocalhostModule"/>-->
+        <!--<add name="BlockLocalhostModule" type="Kudu.Services.Web.Security.BlockLocalhostModule" />-->
       </modules>
       <staticContent>
         <remove fileExtension=".svg" />

--- a/Kudu.Services/Functions/FunctionController.cs
+++ b/Kudu.Services/Functions/FunctionController.cs
@@ -97,6 +97,15 @@ namespace Kudu.Services.Functions
                         AddFunctionAppIdToEnvelope(await _manager.GetFunctionConfigAsync(name, ArmUtils.IsArmRequest(Request) ? new FunctionTestData() : null)), Request));
             }
         }
+        [HttpGet]
+        public HttpResponseMessage GetToken()
+        {
+            var tracer = _traceFactory.GetTracer();
+            using (tracer.Step("FunctionsController.GetToken()"))
+            {
+                return Request.CreateResponse(HttpStatusCode.OK, _manager.GetToken());
+            }
+        }
 
         [HttpGet]
         public async Task<HttpResponseMessage> GetMasterKey()

--- a/Kudu.Services/Functions/FunctionController.cs
+++ b/Kudu.Services/Functions/FunctionController.cs
@@ -97,13 +97,14 @@ namespace Kudu.Services.Functions
                         AddFunctionAppIdToEnvelope(await _manager.GetFunctionConfigAsync(name, ArmUtils.IsArmRequest(Request) ? new FunctionTestData() : null)), Request));
             }
         }
+
         [HttpGet]
-        public HttpResponseMessage GetToken()
+        public HttpResponseMessage GetAdminToken()
         {
             var tracer = _traceFactory.GetTracer();
-            using (tracer.Step("FunctionsController.GetToken()"))
+            using (tracer.Step("FunctionsController.GetAdminToken()"))
             {
-                return Request.CreateResponse(HttpStatusCode.OK, _manager.GetToken());
+                return Request.CreateResponse(HttpStatusCode.OK, _manager.GetAdminToken());
             }
         }
 

--- a/Kudu.Services/app.config
+++ b/Kudu.Services/app.config
@@ -3,9 +3,9 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.SiteManagement.Test/app.config
+++ b/Kudu.SiteManagement.Test/app.config
@@ -3,13 +3,13 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1312.1622" newVersion="4.2.1312.1622"/>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1312.1622" newVersion="4.2.1312.1622" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.SiteManagement/app.config
+++ b/Kudu.SiteManagement/app.config
@@ -3,17 +3,17 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0"/>
+        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.Stress/App.config
+++ b/Kudu.Stress/App.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<startup>
-		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
 	</startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Kudu.TestHarness/app.config
+++ b/Kudu.TestHarness/app.config
@@ -3,13 +3,13 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="5.1.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Kudu.Web/Web.config
+++ b/Kudu.Web/Web.config
@@ -1,19 +1,19 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
   <configSections>
-    <section name="kudu.management" type="Kudu.SiteManagement.Configuration.Section.KuduConfigurationSection, Kudu.SiteManagement, Version=30.0.0.0, Culture=neutral"/>
+    <section name="kudu.management" type="Kudu.SiteManagement.Configuration.Section.KuduConfigurationSection, Kudu.SiteManagement, Version=30.0.0.0, Culture=neutral" />
   </configSections>
   <appSettings>
     <!-- Settings used everywhere -->
-    <add key="webpages:Version" value="3.0.0.0"/>
-    <add key="webpages:Enabled" value="false"/>
-    <add key="PreserveLoginUrl" value="true"/>
-    <add key="ClientValidationEnabled" value="true"/>
-    <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Enabled" value="false" />
+    <add key="PreserveLoginUrl" value="true" />
+    <add key="ClientValidationEnabled" value="true" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <!-- Settings used only in Azure Kudu.Web -->
   </appSettings>
   <!--
@@ -24,8 +24,8 @@
     allows you to add and manage additional hostnames for an application.
     -->
   <kudu.management enableCustomHostNames="false">
-    <serviceSite path="..\Kudu.Services.Web"/>
-    <applications path="..\apps"/>
+    <serviceSite path="..\Kudu.Services.Web" />
+    <applications path="..\apps" />
     <!--
     IIS Shared Configuration
     ======================================================================================================================
@@ -114,19 +114,19 @@
   <system.web>
     <compilation debug="true" targetFramework="4.6">
       <assemblies>
-        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
-        <add assembly="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
-        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
-        <add assembly="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
-        <add assembly="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
+        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+        <add assembly="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+        <add assembly="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+        <add assembly="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
       </assemblies>
     </compilation>
-    <httpRuntime requestValidationMode="2.0"/>
-    <pages controlRenderingCompatibilityVersion="4.0"/>
+    <httpRuntime requestValidationMode="2.0" />
+    <pages controlRenderingCompatibilityVersion="4.0" />
   </system.web>
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false"/>
-    <modules runAllManagedModulesForAllRequests="true"/>
+    <validation validateIntegratedModeConfiguration="false" />
+    <modules runAllManagedModulesForAllRequests="true" />
     <staticContent>
       <!-- Web fonts -->
       <remove fileExtension=".eot" />
@@ -144,31 +144,31 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages.Deployment" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages.Deployment" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Kudu.Web/Web.config
+++ b/Kudu.Web/Web.config
@@ -33,7 +33,7 @@
     If your IIS config file is in a different location (usually due to running a shared configration) you can specify the 
     new location like this:
     
-    <iisConfigurationFile path="c:\myconfig.config"/>
+    <iisConfigurationFile path="c:\myconfig.config" />
 
     
     Defining custom host names:


### PR DESCRIPTION
address Azure/azure-webjobs-sdk-script#1334

1. add a new api `https://testshun.scm.azurewebsites.net/api/functions/admin/token`
2. returned payload: 
```
{
  "nbf": 1490650554,
  "exp": 1490650674,
  "iat": 1490650554,
  "iss": "https://testShun.scm.azurewebsites.net",
  "aud": "https://testShun.azurewebsites.net/azurefunctions"
}
```
**[Note1]** this api will fail when testing on dev machine (non azure environment)
**[Note2]** `<package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.77-alpha" targetFramework="net46" />` comes from **azure app service feed**, not yet in **nuget.org**

looks like there's inconsisitency in VS xml formatting: [this commit](https://github.com/projectkudu/kudu/commit/121eef5fe9f1d987bc0662eee72ca166cfdcb5c0#diff-a57a16f860710345042779a3debf81ad) has both `123/>` and `123 />` style when it comes to self-closing tag.

I suggest we move all to `123 />` with an extra space