### PR TITLE
DeploymentManager.PreDeployment(): Windows only

### DIFF
--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -665,7 +665,9 @@ namespace Kudu.Core.Deployment
 
         private void PreDeployment(ITracer tracer)
         {
-            if (Environment.IsAzureEnvironment() && FileSystemHelpers.DirectoryExists(_environment.SSHKeyPath))
+            if (Environment.IsAzureEnvironment() 
+                && FileSystemHelpers.DirectoryExists(_environment.SSHKeyPath)
+                && OSDetector.IsOnWindows())
             {
                 string src = Path.GetFullPath(_environment.SSHKeyPath);
                 string dst = Path.GetFullPath(Path.Combine(System.Environment.GetEnvironmentVariable("USERPROFILE"), Constants.SSHKeyPath));


### PR DESCRIPTION
Movement of SSH keys is unneeded on Linux