### PR TITLE
change match string for npm error message (using GUID)

### DIFF
--- a/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
+++ b/Kudu.FunctionalTests/GitRepositoryManagementTests.cs
@@ -855,7 +855,9 @@ project = myproject");
                 ApplicationManager.Run(appName, appManager =>
                 {
                     // Replace the express dependency with something that doesn't exist
-                    repo.Replace("package.json", "express", "MadeUpKuduPackage");
+                    // using Guid so that even if cache is used, lookup will still fail
+                    var madeUpPackageName = $"kudu{Guid.NewGuid()}";
+                    repo.Replace("package.json", "express", madeUpPackageName);
                     Git.Commit(repo.PhysicalPath, "Added fake package to package.json");
                     // Act
                     appManager.GitDeploy(repo.PhysicalPath);
@@ -864,7 +866,7 @@ project = myproject");
                     // Assert
                     Assert.Equal(1, results.Count);
                     Assert.Equal(DeployStatus.Failed, results[0].Status);
-                    KuduAssert.VerifyLogOutput(appManager, results[0].Id, "One or more of the selected node/npm paths do not exist.");
+                    KuduAssert.VerifyLogOutput(appManager, results[0].Id, $"'{madeUpPackageName}' is not in the npm registry.");
                 });
             }
         }


### PR DESCRIPTION
the public test failed because somehow `MadeUpKuduPackage` is added to `npm cache` on kudu-ci machine. Adding a `GUID` to the `madeUpPackageName` should prevent it from matching any `npm cache` (if accident happened again)

I removed the old match string: `"One or more of the selected node/npm paths do not exist."` since this error message is returned by [kudu](https://github.com/projectkudu/kudu/blob/2ea953e532d0a44afe291dc4b9e370df9fc51686/Kudu.Core/Scripts/selectNodeVersion.js#L288), not by `npm install`