### PR TITLE
refine dotnet core project type, facilitate yank process

### DIFF
--- a/Kudu.Core/Deployment/Generator/AspNetCoreBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/AspNetCoreBuilder.cs
@@ -1,6 +1,5 @@
-﻿using Kudu.Contracts.Settings;
-using Kudu.Core.SourceControl;
-using System.IO;
+﻿using System;
+using Kudu.Contracts.Settings;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -8,12 +7,25 @@ namespace Kudu.Core.Deployment.Generator
     {
         private readonly string _projectPath;
         private readonly string _solutionPath;
+        private readonly string _version;
 
         public AspNetCoreBuilder(IEnvironment environment, IDeploymentSettingsManager settings, IBuildPropertyProvider propertyProvider, string sourcePath, string projectPath, string solutionPath = null)
             : base(environment, settings, propertyProvider, sourcePath)
         {
-            _projectPath = projectPath;
+            _projectPath = projectPath; // either xproj, csproj or project.json
             _solutionPath = solutionPath;
+            if (_projectPath.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                _version = "csproj";
+            }
+            else if (_projectPath.EndsWith(".xproj", StringComparison.OrdinalIgnoreCase))
+            {
+                _version = "xproj";
+            }
+            else
+            {
+                _version = "project.json";
+            }
         }
 
         protected override string ScriptGeneratorCommandArguments
@@ -23,20 +35,18 @@ namespace Kudu.Core.Deployment.Generator
 
                 if (string.IsNullOrEmpty(_solutionPath))
                 {
-                    return $"--aspNetCore \"{_projectPath}\""; 
-                    // projectfile is either project.json for preview2, ***.csproj for preview3
+                    return $"--aspNetCore \"{_projectPath}\"";
                 }
                 else
                 {
                     return $"--aspNetCore \"{_projectPath}\" --solutionFile \"{_solutionPath}\"";
-                    // if we have a solution file, projectfile is either ***.xproj for preview2, ***.csproj for preview3
                 }
             }
         }
 
         public override string ProjectType
         {
-            get { return "ASP.NET Core"; }
+            get { return $"ASP.NET Core {_version}"; }
         }
     }
 }

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -193,6 +193,7 @@ namespace Kudu.Core.Deployment.Generator
             return ResolveProject(repositoryRoot, repositoryRoot, perDeploymentSettings, fileFinder, tryWebSiteProject, searchOption, specificConfiguration: false);
         }
 
+        // unless user specifies which project to deploy, targetPath == repositoryRoot
         private ISiteBuilder ResolveProject(string repositoryRoot, string targetPath, IDeploymentSettingsManager perDeploymentSettings, IFileFinder fileFinder, bool tryWebSiteProject, SearchOption searchOption = SearchOption.AllDirectories, bool specificConfiguration = true)
         {
             if (DeploymentHelper.IsProject(targetPath))
@@ -222,7 +223,7 @@ namespace Kudu.Core.Deployment.Generator
             }
 
             // Check for ASP.NET Core project without VS solution or project
-            // for ASP.NET Core project which only has project.json, but not xproj ie: AspNetCoreRC2YeomanProject
+            // for ASP.NET Core project which only has project.json, but not xproj ie: dotnet preview2 cli project
             string projectJson;
             if (AspNetCoreHelper.TryAspNetCoreWebProject(targetPath, fileFinder, out projectJson))
             {


### PR DESCRIPTION
three different types of dotnet core deployment (`"project.json"`,`"xproj"`,`"csproj"`) based on the new [kuduscript template](https://github.com/projectkudu/KuduScript/blob/shun-work/lib/generator._js#L295-L311)

simple output to ETW:
![image](https://cloud.githubusercontent.com/assets/6531400/24782623/3ef7cfc2-1afc-11e7-8a15-849aa0d4ba7a.png)

although this shares some duplicate logic with project determination...this change does not require touching any other files