### PR TITLE
PHP Site Deployment

### DIFF
--- a/Kudu.Core/Deployment/Generator/PHPSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/PHPSiteBuilder.cs
@@ -1,0 +1,17 @@
+﻿using Kudu.Contracts.Settings;
+
+namespace Kudu.Core.Deployment.Generator
+{
+    public class PHPSiteBuilder : BaseBasicBuilder
+    {
+        public PHPSiteBuilder(IEnvironment environment, IDeploymentSettingsManager settings, IBuildPropertyProvider propertyProvider, string repositoryPath, string projectPath)
+            : base(environment, settings, propertyProvider, repositoryPath, projectPath, "--php")
+        {
+        }
+
+        public override string ProjectType
+        {
+            get { return "PHP"; }
+        }
+    }
+}

--- a/Kudu.Core/Deployment/Generator/PHPSiteEnabler.cs
+++ b/Kudu.Core/Deployment/Generator/PHPSiteEnabler.cs
@@ -1,0 +1,72 @@
+﻿using System.IO;
+using System.IO.Abstractions;
+using Kudu.Core.Helpers;
+using Kudu.Core.Infrastructure;
+
+namespace Kudu.Core.Deployment.Generator
+{
+    public static class PHPSiteEnabler
+    {
+        private static readonly string[] IisStartupFiles = new[]
+        {
+            "default.htm", "default.html", "default.asp", "index.htm", "index.html", "iisstart.htm", "default.aspx"
+        };
+
+        private static readonly string[] PHPDetectionFiles = new[] { "composer.json" };
+
+        private static readonly string[] PotentialPHPDetectionFiles = new[] { "composer.lock" };
+
+        public static bool LooksLikePHP(string siteFolder)
+        {
+            // only support linux
+            if (OSDetector.IsOnWindows())
+            {
+                return false;
+            }
+
+            bool potentiallyLooksLikePHP = false;
+
+            // If any of the files in PHPDetectionFiles exist
+            // We assume it's PHP
+            foreach (var PHPDetectionFile in PHPDetectionFiles)
+            {
+                string fullPath = Path.Combine(siteFolder, PHPDetectionFile);
+                if (FileSystemHelpers.FileExists(fullPath))
+                {
+                    return true;
+                }
+            }
+
+            // If any of the files in PotentialPHPDetectionFiles exist
+            // We assume it can potentially be PHP
+            foreach (var PHPDetectionFile in PotentialPHPDetectionFiles)
+            {
+                string fullPath = Path.Combine(siteFolder, PHPDetectionFile);
+                if (FileSystemHelpers.FileExists(fullPath))
+                {
+                    potentiallyLooksLikePHP = true;
+                    break;
+                }
+            }
+
+            // If we assume it is potentially a PHP site
+            if (potentiallyLooksLikePHP)
+            {
+                // Check if any of the known iis start pages (excluding index.php) exist
+                // If so, then it is not a PHP web site otherwise it is
+                foreach (var iisStartupFile in IisStartupFiles)
+                {
+                    string fullPath = Path.Combine(siteFolder, iisStartupFile);
+                    if (FileSystemHelpers.FileExists(fullPath))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -159,6 +159,10 @@ namespace Kudu.Core.Deployment.Generator
             {
                 return new RubySiteBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
             }
+            else if (IsPHPSite(sourceProjectPath))
+            {
+                return new PHPSiteBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
+            }
 
             return new BasicBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
         }
@@ -181,6 +185,11 @@ namespace Kudu.Core.Deployment.Generator
         private static bool IsRubySite(string projectPath)
         {
             return RubySiteEnabler.LooksLikeRuby(projectPath);
+        }
+
+        private static bool IsPHPSite(string projectPath)
+        {
+            return PHPSiteEnabler.LooksLikePHP(projectPath);
         }
 
         private static bool IsFunctionApp(string projectPath)

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -220,6 +220,8 @@
     <Compile Include="Deployment\Generator\ExternalCommandFactory.cs" />
     <Compile Include="Deployment\Generator\GoSiteBuilder.cs" />
     <Compile Include="Deployment\Generator\GoSiteEnabler.cs" />
+    <Compile Include="Deployment\Generator\PHPSiteBuilder.cs" />
+    <Compile Include="Deployment\Generator\PHPSiteEnabler.cs" />
     <Compile Include="Deployment\Generator\PythonSiteEnabler.cs" />
     <Compile Include="Deployment\Generator\PythonSiteBuilder.cs" />
     <Compile Include="Deployment\Generator\AspNetCoreBuilder.cs" />

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/75eaf360465fcc7bd24338bbf65deff2de470805
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/5166d4f19d598b3f4f00078a7dca9f50c9ecf4be
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end


### PR DESCRIPTION
Now that kudu container on Azure App Service on Linux has PHP and composer support (cf https://github.com/Azure-App-Service/kudu/pull/15), it seems a great time for kudu to be able to detect php apps.
PHP deployement logic has been submitted on https://github.com/projectkudu/KuduScript/pull/69
This PR was inspired from the Ruby support at #2268