### PR TITLE
add case for functionapp with package.json under root folder

### DIFF
--- a/Kudu.Core/Deployment/Generator/FunctionAppEnabler.cs
+++ b/Kudu.Core/Deployment/Generator/FunctionAppEnabler.cs
@@ -1,17 +1,12 @@
-﻿
-using Kudu.Core.Infrastructure;
-using System.IO;
-
-namespace Kudu.Core.Deployment.Generator
+﻿namespace Kudu.Core.Deployment.Generator
 {
     public static class FunctionAppEnabler
     {
-        private const string FunctionAppRootConfig = "host.json";
 
-        public static bool LooksLikeFunctionApp(string siteFolder)
+        public static bool LooksLikeFunctionApp()
         {
-            return FileSystemHelpers.FileExists(Path.Combine(siteFolder, FunctionAppRootConfig));
+            return !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.FunctionRunTimeVersion));
         }
-           
+
     }
 }

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -139,7 +139,12 @@ namespace Kudu.Core.Deployment.Generator
         private ISiteBuilder ResolveNonAspProject(string repositoryRoot, string projectPath, IDeploymentSettingsManager perDeploymentSettings)
         {
             string sourceProjectPath = projectPath ?? repositoryRoot;
-            if (IsNodeSite(sourceProjectPath))
+            if (IsFunctionApp(sourceProjectPath))
+            {
+                return new FunctionAppBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
+            }
+            // "packge.json" does not 100% imply a nodesite, functionApp can also have one under its root folder
+            else if (IsNodeSite(sourceProjectPath))
             {
                 return new NodeSiteBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
             }
@@ -150,10 +155,6 @@ namespace Kudu.Core.Deployment.Generator
             else if (IsGoSite(sourceProjectPath))
             {
                 return new GoSiteBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
-            }
-            else if (IsFunctionApp(sourceProjectPath))
-            {
-                return new FunctionAppBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
             }
             else if (IsRubySite(sourceProjectPath))
             {

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -139,11 +139,11 @@ namespace Kudu.Core.Deployment.Generator
         private ISiteBuilder ResolveNonAspProject(string repositoryRoot, string projectPath, IDeploymentSettingsManager perDeploymentSettings)
         {
             string sourceProjectPath = projectPath ?? repositoryRoot;
-            if (IsFunctionApp(sourceProjectPath))
+            // "FUNCTIONS_EXTENSION_VERSION" environment variable implies a functionApp
+            if (IsFunctionApp())
             {
                 return new FunctionAppBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
             }
-            // "packge.json" does not 100% imply a nodesite, functionApp can also have one under its root folder
             else if (IsNodeSite(sourceProjectPath))
             {
                 return new NodeSiteBuilder(_environment, perDeploymentSettings, _propertyProvider, repositoryRoot, projectPath);
@@ -193,9 +193,9 @@ namespace Kudu.Core.Deployment.Generator
             return PHPSiteEnabler.LooksLikePHP(projectPath);
         }
 
-        private static bool IsFunctionApp(string projectPath)
+        private static bool IsFunctionApp()
         {
-            return FunctionAppEnabler.LooksLikeFunctionApp(projectPath);
+            return FunctionAppEnabler.LooksLikeFunctionApp();
         }
 
         private ISiteBuilder ResolveProject(string repositoryRoot, IDeploymentSettingsManager perDeploymentSettings, IFileFinder fileFinder, bool tryWebSiteProject = false, SearchOption searchOption = SearchOption.AllDirectories)

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/197392188376c695ecefd81d3d077553fc8375e3
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/ec990c48126fceacc549b63f0aa09667ec8fc5df
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/cba0dfa162112cab02f842e32a47722c87de303f
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/197392188376c695ecefd81d3d077553fc8375e3
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end


### PR DESCRIPTION
use funcpack for functionApp CI deployment

tested for 
1. `package.json` under root [[repro](https://github.com/watashiSHUN/FunctionAppWithBigNpm)]
2. `package.json` under each function folder [[repro](https://github.com/watashiSHUN/FunctionAppWithBigNpm/tree/twopackage.json)]
3. combine 1 and 2 [[repro](https://github.com/watashiSHUN/FunctionAppWithBigNpm/tree/oneatrootoneatsubfolder)]

kuduscript changes see [here](https://github.com/projectkudu/KuduScript/commit/197392188376c695ecefd81d3d077553fc8375e3?diff=unified)