### PR TITLE
disable in place deployment for function app

### DIFF
--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -205,7 +205,7 @@ namespace Kudu.Core.Infrastructure
         public static void CopyDirectoryRecursive(string sourceDirPath, string destinationDirPath, bool overwrite = true, HashSet<string> ignoreDirs = null)
         {
             // Get the subdirectories for the specified directory.
-            var sourceDir = new DirectoryInfo(sourceDirPath);
+            var sourceDir = DirectoryInfoFromDirectoryName(sourceDirPath);
 
             if (!sourceDir.Exists)
             {
@@ -221,9 +221,9 @@ namespace Kudu.Core.Infrastructure
             }
 
             // Get the files in the directory and copy them to the new location.
-            foreach (FileSystemInfo sourceFileSystemInfo in sourceDir.EnumerateFileSystemInfos())
+            foreach (FileSystemInfoBase sourceFileSystemInfo in sourceDir.GetFileSystemInfos())
             {
-                var sourceFile = sourceFileSystemInfo as FileInfo;
+                var sourceFile = sourceFileSystemInfo as FileInfoBase;
                 if (sourceFile != null)
                 {
                     string destinationFilePath = Path.Combine(destinationDirPath, sourceFile.Name);
@@ -231,7 +231,7 @@ namespace Kudu.Core.Infrastructure
                 }
                 else
                 {
-                    var sourceSubDir = sourceFileSystemInfo as DirectoryInfo;
+                    var sourceSubDir = sourceFileSystemInfo as DirectoryInfoBase;
                     if (sourceSubDir != null && (ignoreDirs == null || !ignoreDirs.Contains(sourceSubDir.Name)))
                     {
                         // Copy sub-directories and their contents to new location.

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -201,7 +201,8 @@ namespace Kudu.Core.Infrastructure
         }
 
         // From MSDN: http://msdn.microsoft.com/en-us/library/bb762914.aspx
-        public static void CopyDirectoryRecursive(string sourceDirPath, string destinationDirPath, bool overwrite = true)
+        // <param name="ignoreDir">string of directory/subdirectory names to be excluded from the copy</param>
+        public static void CopyDirectoryRecursive(string sourceDirPath, string destinationDirPath, bool overwrite = true, HashSet<string> ignoreDir = null)
         {
             // Get the subdirectories for the specified directory.
             var sourceDir = new DirectoryInfo(sourceDirPath);
@@ -231,11 +232,11 @@ namespace Kudu.Core.Infrastructure
                 else
                 {
                     var sourceSubDir = sourceFileSystemInfo as DirectoryInfo;
-                    if (sourceSubDir != null)
+                    if (sourceSubDir != null && (ignoreDir == null || !ignoreDir.Contains(sourceSubDir.Name)))
                     {
                         // Copy sub-directories and their contents to new location.
                         string destinationSubDirPath = Path.Combine(destinationDirPath, sourceSubDir.Name);
-                        CopyDirectoryRecursive(sourceSubDir.FullName, destinationSubDirPath, overwrite);
+                        CopyDirectoryRecursive(sourceSubDir.FullName, destinationSubDirPath, overwrite, ignoreDir);
                     }
                 }
             }

--- a/Kudu.Core/Infrastructure/FileSystemHelpers.cs
+++ b/Kudu.Core/Infrastructure/FileSystemHelpers.cs
@@ -202,7 +202,7 @@ namespace Kudu.Core.Infrastructure
 
         // From MSDN: http://msdn.microsoft.com/en-us/library/bb762914.aspx
         // <param name="ignoreDir">string of directory/subdirectory names to be excluded from the copy</param>
-        public static void CopyDirectoryRecursive(string sourceDirPath, string destinationDirPath, bool overwrite = true, HashSet<string> ignoreDir = null)
+        public static void CopyDirectoryRecursive(string sourceDirPath, string destinationDirPath, bool overwrite = true, HashSet<string> ignoreDirs = null)
         {
             // Get the subdirectories for the specified directory.
             var sourceDir = new DirectoryInfo(sourceDirPath);
@@ -232,11 +232,11 @@ namespace Kudu.Core.Infrastructure
                 else
                 {
                     var sourceSubDir = sourceFileSystemInfo as DirectoryInfo;
-                    if (sourceSubDir != null && (ignoreDir == null || !ignoreDir.Contains(sourceSubDir.Name)))
+                    if (sourceSubDir != null && (ignoreDirs == null || !ignoreDirs.Contains(sourceSubDir.Name)))
                     {
                         // Copy sub-directories and their contents to new location.
                         string destinationSubDirPath = Path.Combine(destinationDirPath, sourceSubDir.Name);
-                        CopyDirectoryRecursive(sourceSubDir.FullName, destinationSubDirPath, overwrite, ignoreDir);
+                        CopyDirectoryRecursive(sourceSubDir.FullName, destinationSubDirPath, overwrite, ignoreDirs);
                     }
                 }
             }

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/ce8fa61a076a597eba4e6c4d7773909a1739ff8e
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/ca3661f6cba1cacd122d36b436cfde42f1795c4e
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/b3494d6fc023f34cc0dded832110b608635cca40
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/ce8fa61a076a597eba4e6c4d7773909a1739ff8e
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end

--- a/Kudu.Services/GitServer/InfoRefsController.cs
+++ b/Kudu.Services/GitServer/InfoRefsController.cs
@@ -23,7 +23,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.IO.Abstractions;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -34,6 +33,7 @@ using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core;
 using Kudu.Core.Deployment;
+using Kudu.Core.Helpers;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
 using Kudu.Core.SourceControl.Git;
@@ -193,10 +193,11 @@ namespace Kudu.Services.GitServer
                 if (!string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.FunctionRunTimeVersion)))
                 {
                     // since git clone doesn't happen very often, create this dynamically instead of static
-                    var ignoreDir = new HashSet<string>();
-                    ignoreDir.Add("node_modules");
+                    // windows directory names are case insensitive
+                    var ignoreDirs = new HashSet<string>(OSDetector.IsOnWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+                    ignoreDirs.Add("node_modules");
 
-                    FileSystemHelpers.CopyDirectoryRecursive(env.RepositoryPath, previous, ignoreDir: ignoreDir);
+                    FileSystemHelpers.CopyDirectoryRecursive(env.RepositoryPath, previous, ignoreDirs: ignoreDirs);
                     env.RepositoryPath = previous;
 
                     // do initial commit


### PR DESCRIPTION
add a simple patch to the existing function`CopyDirectoryRecursive` to exclude directories/subdirectories with name "node_modules". This will cover functionApp's use case where there's a `package.json` under `wwwroot` or under each `wwwroot/functionFolder`

note to self:
1. add `SCM_USE_FUNCPACK` to kudu doc as a deployment flag
2. add functional tests for git clone functionApp
