### PR TITLE
Support postdeployment script in postdeployment common codes

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -180,6 +180,7 @@ namespace Kudu.Services.Web.App_Start
             TraceServices.TraceLevel = noContextDeploymentsSettingsManager.GetTraceLevel();
 
             var noContextTraceFactory = new TracerFactory(() => GetTracerWithoutContext(environment, noContextDeploymentsSettingsManager));
+            var etwTraceFactory = new TracerFactory(() => new ETWTracer(string.Empty, string.Empty));
 
             kernel.Bind<IAnalytics>().ToMethod(context => new Analytics(context.Kernel.Get<IDeploymentSettingsManager>(),
                                                                         context.Kernel.Get<IServerConfiguration>(),
@@ -232,7 +233,7 @@ namespace Kudu.Services.Web.App_Start
                                              .InRequestScope();
 
             ITriggeredJobsManager triggeredJobsManager = new TriggeredJobsManager(
-                noContextTraceFactory,
+                etwTraceFactory,
                 kernel.Get<IEnvironment>(),
                 kernel.Get<IDeploymentSettingsManager>(),
                 kernel.Get<IAnalytics>(),
@@ -242,14 +243,14 @@ namespace Kudu.Services.Web.App_Start
 
             TriggeredJobsScheduler triggeredJobsScheduler = new TriggeredJobsScheduler(
                 triggeredJobsManager,
-                noContextTraceFactory,
+                etwTraceFactory,
                 environment,
                 kernel.Get<IAnalytics>());
             kernel.Bind<TriggeredJobsScheduler>().ToConstant(triggeredJobsScheduler)
                                              .InTransientScope();
 
             IContinuousJobsManager continuousJobManager = new ContinuousJobsManager(
-                noContextTraceFactory,
+                etwTraceFactory,
                 kernel.Get<IEnvironment>(),
                 kernel.Get<IDeploymentSettingsManager>(),
                 kernel.Get<IAnalytics>());

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -409,7 +409,7 @@ namespace Kudu.Services
             Uri uri,
             bool waitForTempDeploymentCreation)
         {
-            var tracer = traceLevel <= TraceLevel.Off ? NullTracer.Instance : new XmlTracer(environment.TracePath, traceLevel);
+            var tracer = traceLevel <= TraceLevel.Off ? NullTracer.Instance : new CascadeTracer(new XmlTracer(environment.TracePath, traceLevel), new ETWTracer(environment.RequestId, "POST"));
             var traceFactory = new TracerFactory(() => tracer);
 
             var backgroundTrace = tracer.Step(XmlTracer.BackgroundTrace, new Dictionary<string, string>


### PR DESCRIPTION
This [existing Kudu codes](https://github.com/projectkudu/kudu/blob/4aef0caab757a8738159b0b51ea20ae515832272/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs#L57-L205) are so interwined and lot of kudu-specific dependency.  Trying to refactor will risk regression and may not worth it for this stable codes.   

I decided to extract and repeat some path in PostDeploymentHelper.