### PR TITLE
selectNodeVersion.js revisions for Linux

### DIFF
--- a/Kudu.Core/Infrastructure/PathUtils/PathLinuxUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathLinuxUtility.cs
@@ -28,7 +28,12 @@ namespace Kudu.Core.Infrastructure
 
         internal override string ResolveNpmJsPath()
         {
-            return ResolveRelativePathToUsrBin("npm", "npm");
+            // This is passed as the NPM_JS_PATH envvar, which is used during node deployment
+            // scripts as the default if a more appropriate version isn't found.
+            // It needs to point to an appropriate default version of npm-cli.js, not npm itself,
+            // as it will be run as a parameter to node (interpreted javascript) and not as a raw executable.
+            // For that reason, it also needs to be the full path, as $PATH resolution will not happen on it.
+            return ResolveRelativePathToUsrBin("npm-cli.js", "npm-cli.js");
         }
 
         internal override string ResolveMSBuildPath()


### PR DESCRIPTION
(Looking at adding tests, just getting this out now for an early look)

selectNodeVersion.js is called by kuduscript during node deployments to select node and npm versions used during npm package restore. It contains a lot of logic that isn't relevant on Linux, and is fairly convoluted.

This change bifurcates the majority of the script based on platform, adding a Linux-specific branch with simpler/clearer logic, and fixing problems we're seeing on Linux due to different environment and inputs. It intends to keep Windows behavior completely unchanged.

It looks like github's diff view has a really hard time aligning the two versions; you may want to view in another app.