### PR TITLE
fix typo in GetUrlFromApplicationHost()

### DIFF
--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -736,10 +736,10 @@ namespace Kudu.Core.SiteExtensions
 
         private static string GetUrlFromApplicationHost(string localPath)
         {
-            string xdtFilePath = FileSystemHelpers.FileExists(Path.Combine(localPath, Constants.ScmApplicationHostXdtFileName)) ?
-                                        Path.Combine(localPath, Constants.ScmApplicationHostXdtFileName) :
-                                        FileSystemHelpers.FileExists(Path.Combine(localPath, Constants.ApplicationHostXdtFileName)) ?
-                                            Path.Combine(localPath, Constants.ScmApplicationHostXdtFileName) : null;
+            string xdtFile = Path.Combine(localPath, Constants.ApplicationHostXdtFileName);
+            string scmXdtFile = Path.Combine(localPath, Constants.ScmApplicationHostXdtFileName);
+            string xdtFilePath = FileSystemHelpers.FileExists(scmXdtFile) ? scmXdtFile : FileSystemHelpers.FileExists(xdtFile) ? xdtFile : null;
+
             if (xdtFilePath != null)
             {
                 try


### PR DESCRIPTION
fix #2422
before:
![before](https://cloud.githubusercontent.com/assets/6531400/25767359/4afa8be4-31ad-11e7-9ec6-f5d1edc5c843.JPG)
now:
![now](https://cloud.githubusercontent.com/assets/6531400/25767370/67da4a24-31ad-11e7-9662-03f95430eb8c.JPG)

