### PR TITLE
fix job traces spaming logfiles folder

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -180,6 +180,7 @@ namespace Kudu.Services.Web.App_Start
             TraceServices.TraceLevel = noContextDeploymentsSettingsManager.GetTraceLevel();
 
             var noContextTraceFactory = new TracerFactory(() => GetTracerWithoutContext(environment, noContextDeploymentsSettingsManager));
+            var etwTraceFactory = new TracerFactory(() => new ETWTracer(string.Empty, string.Empty));
 
             kernel.Bind<IAnalytics>().ToMethod(context => new Analytics(context.Kernel.Get<IDeploymentSettingsManager>(),
                                                                         context.Kernel.Get<IServerConfiguration>(),
@@ -232,7 +233,7 @@ namespace Kudu.Services.Web.App_Start
                                              .InRequestScope();
 
             ITriggeredJobsManager triggeredJobsManager = new TriggeredJobsManager(
-                noContextTraceFactory,
+                etwTraceFactory,
                 kernel.Get<IEnvironment>(),
                 kernel.Get<IDeploymentSettingsManager>(),
                 kernel.Get<IAnalytics>(),
@@ -242,14 +243,14 @@ namespace Kudu.Services.Web.App_Start
 
             TriggeredJobsScheduler triggeredJobsScheduler = new TriggeredJobsScheduler(
                 triggeredJobsManager,
-                noContextTraceFactory,
+                etwTraceFactory,
                 environment,
                 kernel.Get<IAnalytics>());
             kernel.Bind<TriggeredJobsScheduler>().ToConstant(triggeredJobsScheduler)
                                              .InTransientScope();
 
             IContinuousJobsManager continuousJobManager = new ContinuousJobsManager(
-                noContextTraceFactory,
+                etwTraceFactory,
                 kernel.Get<IEnvironment>(),
                 kernel.Get<IDeploymentSettingsManager>(),
                 kernel.Get<IAnalytics>());

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -409,7 +409,7 @@ namespace Kudu.Services
             Uri uri,
             bool waitForTempDeploymentCreation)
         {
-            var tracer = traceLevel <= TraceLevel.Off ? NullTracer.Instance : new XmlTracer(environment.TracePath, traceLevel);
+            var tracer = traceLevel <= TraceLevel.Off ? NullTracer.Instance : new CascadeTracer(new XmlTracer(environment.TracePath, traceLevel), new ETWTracer(environment.RequestId, "POST"));
             var traceFactory = new TracerFactory(() => tracer);
 
             var backgroundTrace = tracer.Step(XmlTracer.BackgroundTrace, new Dictionary<string, string>


### PR DESCRIPTION
This was observed when investigating issues with webjobs.  We traces to logfiles folder when starting trigger and continuous job executables.  This could generate a flood of traces (if those come up/down multiple time such as continuous job that stops frequently).    The side effect is the more important traces will be purged out.   The fix is to migrate those traces to ETW instead.  User can still view jog.log file to see if any issue.    