### PR TITLE
use nuget4.3 as default

### DIFF
--- a/Build/NuGet.targets
+++ b/Build/NuGet.targets
@@ -62,10 +62,10 @@
                try {
                    OutputFilename = Path.GetFullPath(OutputFilename);
 
-                   Log.LogMessage("Downloading latest version of NuGet.exe...");
                    WebClient webClient = new WebClient();
-                   webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v3.5.0/NuGet.exe", OutputFilename);
-
+				   Log.LogMessage("Downloading NuGet.exe version4.3...");
+				   webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v4.3.0-preview1/nuget.exe", OutputFilename);
+				   
                    return true;
                }
                catch (Exception ex) {

--- a/Build/NuGet.targets
+++ b/Build/NuGet.targets
@@ -62,10 +62,10 @@
                try {
                    OutputFilename = Path.GetFullPath(OutputFilename);
 
+                   Log.LogMessage("Downloading NuGet.exe version 4.3...");
                    WebClient webClient = new WebClient();
-				   Log.LogMessage("Downloading NuGet.exe version4.3...");
-				   webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v4.3.0-preview1/nuget.exe", OutputFilename);
-				   
+                   webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v4.3.0-preview1/nuget.exe", OutputFilename);
+
                    return true;
                }
                catch (Exception ex) {

--- a/Kudu.Core/Deployment/Generator/AspNetCoreBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/AspNetCoreBuilder.cs
@@ -21,7 +21,6 @@ namespace Kudu.Core.Deployment.Generator
             }
             else if (_projectPath.EndsWith(".xproj", StringComparison.OrdinalIgnoreCase))
             {
-                _version = "xproj";
                 // if it's xproj, throw invalidOperationException
                 throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture,
                                                              Resources.Error_ProjectNotDeployable,

--- a/Kudu.Core/Deployment/Generator/AspNetCoreBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/AspNetCoreBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Kudu.Contracts.Settings;
+using System.Globalization;
 
 namespace Kudu.Core.Deployment.Generator
 {
@@ -21,6 +22,10 @@ namespace Kudu.Core.Deployment.Generator
             else if (_projectPath.EndsWith(".xproj", StringComparison.OrdinalIgnoreCase))
             {
                 _version = "xproj";
+                // if it's xproj, throw invalidOperationException
+                throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture,
+                                                             Resources.Error_ProjectNotDeployable,
+                                                             projectPath));
             }
             else
             {

--- a/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
@@ -98,7 +98,7 @@ namespace Kudu.Core.Infrastructure
         internal override string ResolveMSBuildPath()
         {
             string programFiles = SystemEnvironment.GetFolderPath(SystemEnvironment.SpecialFolder.ProgramFilesX86);
-            return Path.Combine(programFiles, @"MSBuild", "14.0", "Bin", "MSBuild.exe");
+            return Path.Combine(programFiles, "MSBuild", "14.0", "Bin", "MSBuild.exe");
         }
 
         internal override string ResolveVsTestPath()
@@ -238,7 +238,7 @@ namespace Kudu.Core.Infrastructure
 
             return paths;
         }
-        
+
         internal override bool PathsEquals(string path1, string path2)
         {
             if (path1 == null)

--- a/Kudu.FunctionalTests/GitDeploymentTests.cs
+++ b/Kudu.FunctionalTests/GitDeploymentTests.cs
@@ -367,17 +367,6 @@ namespace Kudu.FunctionalTests
     }
 
     [KuduXunitTestClass]
-    public class AspNetCorePreview2MultipleProjectsTests : GitDeploymentTests
-    {
-        [Fact]
-        [KuduXunitTest(PrivateOnly = true)]
-        public void PushAndDeployAspNetCorePreview2MultipleProjects()
-        {
-            PushAndDeployApps("AspNetCorePreview2MultipleProjects", "master", "WebApplication1!", HttpStatusCode.OK, "Deployment successful");
-        }
-    }
-
-    [KuduXunitTestClass]
     public class AspNetCoreRC3CliWithLibTests : GitDeploymentTests
     {
         [Fact]

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/aa49419402e124cb42ac348334f74d9b843baea4
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/5505cac6068d462a22a17472abbc738de7389c27
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end

--- a/Kudu.TestHarness/TestRepositories.cs
+++ b/Kudu.TestHarness/TestRepositories.cs
@@ -13,7 +13,6 @@ namespace Kudu.TestHarness
             new TestRepositoryInfo("https://github.com/KuduApps/-benr-.git",                        "c553978"),
             new TestRepositoryInfo("https://github.com/KuduApps/AppWithPostBuildEvent.git",         "083b651"),
             new TestRepositoryInfo("https://github.com/KuduApps/AspNetCore2.0CliWithLib.git",       "4bd5890"),
-            new TestRepositoryInfo("https://github.com/KuduApps/AspNetCorePreview2MultipleProjects.git","f08f582"),
             new TestRepositoryInfo("https://github.com/KuduApps/AspNetCoreRC3CliWithLib.git",       "d8a1286"),
             new TestRepositoryInfo("https://github.com/KuduApps/AspNetCoreRC4WebApiCli.git",        "96168e9"),
             new TestRepositoryInfo("https://github.com/KuduApps/AspNetCoreRC4WebApiVsSln.git",      "3907f92"),


### PR DESCRIPTION
change does following things
1. add download link to ~[nuget4.1](https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe)~ [nuget4.3](https://dist.nuget.org/win-x86-commandline/v4.3.0-preview1/nuget.exe)
2. ~replace msbuild14 in `PATH` with `D:\Program Files (x86)\MSBuild\15.0\Bin`~
3. ~replace msbuild14 as value of `MSBUILD_PATH` with `D:\Program Files (x86)\MSBuild\15.0\Bin\MSBuild.exe`~
4. ~at startup, copy msbuild installation information to `%ProgramData%\Microsoft\VisualStudio\Packages\_Instances`~