### PR TITLE
Add new WEBJOBS_DISABLE_SCHEDULE flag

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -102,6 +102,13 @@ namespace Kudu.Contracts.Settings
             return StringUtils.IsTrueLike(value);
         }
 
+        public static bool IsWebJobsScheduleDisabled(this IDeploymentSettingsManager settings)
+        {
+            string value = settings.GetValue(SettingsKeys.WebJobsDisableSchedule);
+
+            return StringUtils.IsTrueLike(value);
+        }
+
         public static string GetBranch(this IDeploymentSettingsManager settings)
         {
             string value = settings.GetValue(SettingsKeys.Branch, onlyPerSite: true);

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -32,6 +32,7 @@
         public const string WebJobsIdleTimeoutInSeconds = "WEBJOBS_IDLE_TIMEOUT";
         public const string WebJobsHistorySize = "WEBJOBS_HISTORY_SIZE";
         public const string WebJobsStopped = "WEBJOBS_STOPPED";
+        public const string WebJobsDisableSchedule = "WEBJOBS_DISABLE_SCHEDULE";
         public const string PostDeploymentActionsDirectory = "SCM_POST_DEPLOYMENT_ACTIONS_PATH";
         public const string DisableSubmodules = "SCM_DISABLE_SUBMODULES";
         public const string SiteExtensionsFeedUrl = "SCM_SITEEXTENSIONS_FEED_URL";

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -245,6 +245,7 @@ namespace Kudu.Services.Web.App_Start
                 triggeredJobsManager,
                 etwTraceFactory,
                 environment,
+                kernel.Get<IDeploymentSettingsManager>(),
                 kernel.Get<IAnalytics>());
             kernel.Bind<TriggeredJobsScheduler>().ToConstant(triggeredJobsScheduler)
                                              .InTransientScope();


### PR DESCRIPTION
Was straightforward enough and seems like a valid need when dealing with slots. The cron schedule is disabled, but the job can still be triggered manually for testing.