### PR TITLE
Skip ssl verification in Azure test env

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -322,7 +322,7 @@ namespace Kudu.Services.Web.App_Start
             EnsureUserProfileDirectory();
 
             // Skip SSL Certificate Validate
-            if (System.Environment.GetEnvironmentVariable(SettingsKeys.SkipSslValidation) == "1")
+            if (Kudu.Core.Environment.SkipSslValidation)
             {
                 ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
             }


### PR DESCRIPTION
In Azure test env, there exists registry to indicate whether to skip ssl verification.  We will use this as default if none is defined (appSettings).   This simplifies testing on Azure test env.   In addition, it is also consistent with Web Deploy and Scaling in Azure Functions Runtime.