### PR TITLE
Always enable ETW for request tracer

### DIFF
--- a/Kudu.Services.Web/Tracing/TraceModule.cs
+++ b/Kudu.Services.Web/Tracing/TraceModule.cs
@@ -104,7 +104,9 @@ namespace Kudu.Services.Web.Tracing
                 if (TraceServices.TraceLevel != TraceLevel.Verbose)
                 {
                     TraceServices.RemoveRequestTracer(httpContext);
-                    return;
+
+                    // enable just ETW tracer
+                    tracer = TraceServices.EnsureETWTracer(httpContext);
                 }
             }
 

--- a/Kudu.Services.Web/Tracing/TraceServices.cs
+++ b/Kudu.Services.Web/Tracing/TraceServices.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Web;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment;
+using Kudu.Core.Tracing;
 
 namespace Kudu.Services.Web.Tracing
 {
@@ -79,6 +80,16 @@ namespace Kudu.Services.Web.Tracing
             httpContext.Items.Remove(_traceKey);
             httpContext.Items.Remove(_loggerKey);
             httpContext.Items.Remove(_traceFileKey);
+        }
+
+        internal static ITracer EnsureETWTracer(HttpContext httpContext)
+        {
+            var etwTracer = new ETWTracer((string)httpContext.Items[Constants.RequestIdHeader], httpContext.Request.HttpMethod);
+
+            _traceFactory = new Func<ITracer>(() => etwTracer);
+            httpContext.Items[_traceKey] = etwTracer;
+
+            return etwTracer;
         }
 
         internal static ITracer CreateRequestTracer(HttpContext httpContext)


### PR DESCRIPTION
Fix for https://github.com/projectkudu/kudu/issues/2442.   For requests from browser, we currently disable file tracer.   This change is to always write to ETW.