### PR TITLE
remove redundant ajax call when select in file explorer

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -6,7 +6,7 @@ var statusbar = {
             try {
                 filename = viewModel.fileEdit.peek().name();
             }
-            catch(e) {
+            catch (e) {
                 filename = 'Can not get filename. See console for details.';
                 if (typeof console == 'object') {
                     console.error('Can not get filename: %s', e);
@@ -52,22 +52,22 @@ var statusbar = {
     errorState:
         {
             set: function () {
-                     // We could not save the file
-                     // Mild panic attack, turn statusbar red
-                     statusbar.showFilename();
-                     $('#statusbar').css('background', '#ffdddd');
-                 },
+                // We could not save the file
+                // Mild panic attack, turn statusbar red
+                statusbar.showFilename();
+                $('#statusbar').css('background', '#ffdddd');
+            },
             remove: function () {
-                        $('#statusbar').css('background', 'none');
-                        $('#statusbar').removeClass('statusbar-red');
-                 }
+                $('#statusbar').css('background', 'none');
+                $('#statusbar').removeClass('statusbar-red');
+            }
         }
 };
 
 function showAceHelpModal() {
     $('#ace-help-modal').modal();
     $('#ace-help-modal .modal-body').load('/DebugConsole/AceHelp.html',
-        function(response, status, xhr) {
+        function (response, status, xhr) {
             if (status == 'error') {
                 $(this).html('<div class="alert alert-warning" role="alert">' +
                              'Yikes! Can not load help page:<br>' +
@@ -77,19 +77,19 @@ function showAceHelpModal() {
                                   xhr.status + ' ' + xhr.statusText);
                 }
             }
-    });
+        });
 }
 
 
 var copyObjectsManager = {
-    init: function() {
+    init: function () {
         this._copyProgressObjects = {};
         this.infoMessage = '';
     },
-    getInfoMessage: function() {
+    getInfoMessage: function () {
         return this._infoMessage;
     },
-    setInfoMessage: function(message) {
+    setInfoMessage: function (message) {
         this._infoMessage = message;
     },
     addCopyStats: function (uri, loadedData, totalData) {
@@ -124,7 +124,7 @@ var copyObjectsManager = {
 
         for (var key in this._copyProgressObjects) {
             var co = this._copyProgressObjects[key];
-            if(co.copyPackEnded === false) {
+            if (co.copyPackEnded === false) {
                 foundItem = true;
                 currentTransfered += co.loadedData;
                 finalTransfered += co.totalData;
@@ -146,7 +146,7 @@ var copyObjectsManager = {
 
         return perc;
     },
-    removeAtIndex: function(index) {
+    removeAtIndex: function (index) {
         delete this._copyProgressObjects[index];
     },
     clearData: function () {
@@ -204,7 +204,7 @@ $.connection.hub.start().done(function () {
                 // https://github.com/projectkudu/kudu/wiki/REST-API
                 url: folder.href.replace(/#/g, encodeURIComponent("#")) + "/",
                 method: "PUT",
-                error:  function (xhr, status, error) {
+                error: function (xhr, status, error) {
                     if (xhr.statusText === 'error') {
                         showErrorAsToast('Error when calling virtual file system REST backend. Check F12 Console for more.');
                     }
@@ -317,9 +317,10 @@ $.connection.hub.start().done(function () {
                     that.parent.children.remove(that);
                     if (viewModel.selected() === this) {
                         viewModel.selected(this.parent);
+                        this.parent.fetchChildren(/* force */ true);
                     }
                     viewModel.processing(false);
-                }).fail(function(error) {
+                }).fail(function (error) {
                     showErrorAsToast(error);
                 });
             }
@@ -359,6 +360,7 @@ $.connection.hub.start().done(function () {
             if (that.parent) {
                 stashCurrentSelection(that);
                 viewModel.selected(that.parent);
+                that.parent.fetchChildren(/* force */ true);
             }
         }
 
@@ -368,8 +370,7 @@ $.connection.hub.start().done(function () {
             viewModel.editText('');
             statusbar.fetchingContents();
             viewModel.fileEdit(this);
-            if(this.mime === "text/xml")
-            {
+            if (this.mime === "text/xml") {
                 Vfs.getContent(this)
                    .done(function (data) {
                        viewModel.editText(vkbeautify.xml(data));
@@ -440,19 +441,19 @@ $.connection.hub.start().done(function () {
                     item.selectNode();
                 }
             },
-            showCopyProgressModal: function() {
+            showCopyProgressModal: function () {
                 $('#files-transfered-modal').modal();
-                copyProgressHandlingFunction(null,null,true);
+                copyProgressHandlingFunction(null, null, true);
             },
-            clearCopyProgressCache: function() {
+            clearCopyProgressCache: function () {
                 copyObjectsManager.clearData();
                 viewModel.copyProgStats("");
             },
-            getCopyPercentage: function(item) {
+            getCopyPercentage: function (item) {
                 return (item.loadedData * 100 / item.totalData).toFixed(1);
             },
             getCopyPercentageDisplay: function (item) {
-               return formatHandler.fileSize(item.loadedData, true) + " / " + formatHandler.fileSize(item.totalData, true);
+                return formatHandler.fileSize(item.loadedData, true) + " / " + formatHandler.fileSize(item.totalData, true);
             },
             errorText: ko.observable(),
             inprocessing: 0,
@@ -522,8 +523,6 @@ $.connection.hub.start().done(function () {
             ignoreWorkingDirChange = true;
             updateFileSystemWatcher(newValue.path());
             window.KuduExec.changeDir(newValue.path());
-
-            newValue.fetchChildren(/* force */ true);
         }
     });
 
@@ -563,7 +562,7 @@ $.connection.hub.start().done(function () {
     };
 
     //monitor file upload progress
-    function copyProgressHandlingFunction(e,uniqueUrl,forceUpdateModal) {
+    function copyProgressHandlingFunction(e, uniqueUrl, forceUpdateModal) {
         if (e && uniqueUrl && e.lengthComputable) {
             copyObjectsManager.addCopyStats(uniqueUrl, e.loaded, e.total); //add/update stats
         }
@@ -572,7 +571,7 @@ $.connection.hub.start().done(function () {
 
         $('#copy-percentage').text(perc + "%");
 
-        if(perc != 100 && perc != 0)  {
+        if (perc != 100 && perc != 0) {
             viewModel.isTransferInProgress(true);
         }
 
@@ -587,17 +586,17 @@ $.connection.hub.start().done(function () {
         }
 
         if ($('#files-transfered-modal').is(':visible') || forceUpdateModal) { // update if modal visible
-                viewModel.copyProgStats(copyObjs); // update viewmodel
+            viewModel.copyProgStats(copyObjs); // update viewmodel
 
-                var modalHeaderText = '';
-                if (perc < 100) {
-                    modalHeaderText = 'Transferred Files (<b>' + perc + '%</b>).';
-                } else {
-                    modalHeaderText = '<b style =\' color:green\'> Transferred Files (' + perc + '%).</b>';
-                }
-                    modalHeaderText += ' ' +((_temp = copyObjectsManager.getInfoMessage()) ? _temp : "");
-                $('#files-transfered-modal .modal-header').html(modalHeaderText);
+            var modalHeaderText = '';
+            if (perc < 100) {
+                modalHeaderText = 'Transferred Files (<b>' + perc + '%</b>).';
+            } else {
+                modalHeaderText = '<b style =\' color:green\'> Transferred Files (' + perc + '%).</b>';
             }
+            modalHeaderText += ' ' + ((_temp = copyObjectsManager.getInfoMessage()) ? _temp : "");
+            $('#files-transfered-modal .modal-header').html(modalHeaderText);
+        }
 
     }
 
@@ -645,6 +644,7 @@ $.connection.hub.start().done(function () {
             var selected = viewModel.selected();
             if (selected.parent) {
                 viewModel.selected(selected.parent);
+                selected.parent.fetchChildren(/* force */ true);
             }
         }
     };
@@ -727,23 +727,23 @@ $.connection.hub.start().done(function () {
         });
 
     $("#upload-unzip")
-        .on("dragenter dragover", function(e) {
+        .on("dragenter dragover", function (e) {
             $(".show-on-hover").addClass('upload-unzip-hover');
         })
-        .on("drop", function(evt) {
-        evt.preventDefault();
-        evt.stopPropagation();
+        .on("drop", function (evt) {
+            evt.preventDefault();
+            evt.stopPropagation();
 
-        $(".show-on-hover").removeClass('upload-unzip-show');
-        $(".show-on-hover").removeClass('upload-unzip-hover');
-        var dir = viewModel.selected();
-        viewModel.processing(true);
-        _getInputFiles(evt).done(function(files) {
-            Vfs.addFiles(files, _isZipFile(evt)).always(function() {
-                dir.fetchChildren( /* force */ true);
-                viewModel.processing(false);
+            $(".show-on-hover").removeClass('upload-unzip-show');
+            $(".show-on-hover").removeClass('upload-unzip-hover');
+            var dir = viewModel.selected();
+            viewModel.processing(true);
+            _getInputFiles(evt).done(function (files) {
+                Vfs.addFiles(files, _isZipFile(evt)).always(function () {
+                    dir.fetchChildren( /* force */ true);
+                    viewModel.processing(false);
+                });
             });
-        });
         }).on("dragleave", function (e) {
             $(".show-on-hover").removeClass('upload-unzip-hover');
         });
@@ -810,7 +810,7 @@ $.connection.hub.start().done(function () {
     function _isZipFile(evt) {
         var items = evt.originalEvent.dataTransfer.items || evt.originalEvent.dataTransfer.files;
         if (items) {
-            var filesArray = $.map(items, function(item) {
+            var filesArray = $.map(items, function (item) {
                 if (item.type === 'application/x-zip-compressed' || item.type === 'application/zip' || item.type === '')
                     return item;
             });
@@ -877,16 +877,16 @@ $.connection.hub.start().done(function () {
                 // (i.e. session expires and the 403 Forbidden response from App Service contains tons of markup)
                 // Let's just ignore it if that's the case. We would need Cortana or something to parse that and
                 // extract a meaningful message.
-                if ( !(/\<html\>/i.test(error.responseText)) ) {
+                if (!(/\<html\>/i.test(error.responseText))) {
                     var message = error.responseText;
                 }
             }
             var status = error.status;
             var statusText = error.statusText;
-            var textToRender =  status + ' ' + statusText + (typeof message  !== 'undefined' ? ': '+ message : '');
+            var textToRender = status + ' ' + statusText + (typeof message !== 'undefined' ? ': ' + message : '');
             toast(textToRender);
         }
-        // 'error' is a string
+            // 'error' is a string
         else toast(error);
     }
 
@@ -906,10 +906,10 @@ function toast(errorMsg) {
         </div>';
     var item = $(scaffold);
     $('#toast').append($(item));
-    $(item).animate({'right': '12px'}, 'fast');
-    $('#toast').on('click','#toast-close', function(){
+    $(item).animate({ 'right': '12px' }, 'fast');
+    $('#toast').on('click', '#toast-close', function () {
         var notification = $(this).parent();
-        notification.animate({'right': '-400px'}, function(){
+        notification.animate({ 'right': '-400px' }, function () {
             notification.remove();
         });
     });

--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -476,6 +476,8 @@ $.connection.hub.start().done(function () {
     ko.applyBindings(viewModel, document.getElementById("#main"));
     setupFileSystemWatcher();
 
+    // shunTODO window.fileExplorer.changeDir() to replace the following observable
+    // since we already have "window.KuduExec.changeDir()"
     window.KuduExec.workingDir.subscribe(function (newValue) {
         if (ignoreWorkingDirChange) {
             ignoreWorkingDirChange = false;
@@ -506,14 +508,14 @@ $.connection.hub.start().done(function () {
 
         // notify command line 
         ignoreWorkingDirChange = true;
-        updateFileSystemWatcher(newValue.path());
         window.KuduExec.changeDir(newValue.path());
     }
 
     // updateSelectedOnly return a promise since it also update its children
     updateSelectedOnly = function (newValue) {
         viewModel.selected(newValue); // update selected
-        // shunTODO in old code, if updateSelectedOnly is called from command line -> no FORCED fetch is required, but why???
+        updateFileSystemWatcher(newValue.path()); // update the filesystem watcher, always accompany selected(newValue)
+        // in old code, children are ONLY FORCE update if navigate using File Explorer, in NEW CODE, we standardize them
         return newValue.fetchChildren(/* force */ true); // update children of selected
     }
 

--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -476,8 +476,6 @@ $.connection.hub.start().done(function () {
     ko.applyBindings(viewModel, document.getElementById("#main"));
     setupFileSystemWatcher();
 
-    // shunTODO window.fileExplorer.changeDir() to replace the following observable
-    // since we already have "window.KuduExec.changeDir()"
     window.KuduExec.workingDir.subscribe(function (newValue) {
         if (ignoreWorkingDirChange) {
             ignoreWorkingDirChange = false;

--- a/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
+++ b/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
@@ -16,13 +16,11 @@ var curWorkingDir = ko.observable("");
 window.KuduExec = { workingDir: curWorkingDir };
 
 function LoadConsoleV2() {
-
-    var fileExplorerChanged = false;
     //diretory change callback from FileBrowser.js
     function _changeDir(value) {
         //for the very first time, value is empty but we know that the file explorer root is appRoot
         value = value || window.KuduExec.appRoot;
-        curWorkingDir(value);
+        // curWorkingDir(value); since _sendCommand will update the current working directory
         if (getShell().toUpperCase() === "POWERSHELL") {
             //PowerShell doesn't return a new line after CD, so let's add a new line in the UI 
             DisplayAndUpdate({ Error: "", Output: "\n" });
@@ -32,8 +30,6 @@ function LoadConsoleV2() {
             _sendCommand("cd /d \"" + value + "\"\n");
         }
         //the change notification goes both ways (console <--> file explorer)
-        //the console uses this flag to break the loop
-        fileExplorerChanged = true;
     };
 
     window.KuduExec.changeDir = _changeDir;
@@ -48,10 +44,10 @@ function LoadConsoleV2() {
     var heightOffset = height / 10;
     var controller = kuduExecConsole.console({
         continuedPrompt: true,
-        promptLabel: function() {
+        promptLabel: function () {
             return getJSONValue(lastLine);
         },
-        commandValidate: function() {
+        commandValidate: function () {
             return true;
         },
         commandHandle: function (line, reportFn) {
@@ -78,7 +74,6 @@ function LoadConsoleV2() {
                     Error: ""
                 };
                 DisplayAndUpdate(lastLine);
-                fileExplorerChanged = false;
                 if (line.trim().toUpperCase() == "EXIT") {
                     controller.enableInput();
                 }
@@ -120,7 +115,7 @@ function LoadConsoleV2() {
                         }
                         elm = prefix + elm;
                     }
-                     return elm;
+                    return elm;
                 });
                 var fullLength = result.length;
                 currentMatchIndex = (currentMatchIndex + (reverse ? -1 : 1)) % fullLength;
@@ -180,7 +175,7 @@ function LoadConsoleV2() {
     }
 
     function getJSONValue(input) {
-        return input? (input.Output || input.Error || "").toString() : "";
+        return input ? (input.Output || input.Error || "").toString() : "";
     }
 
     function getShell() {
@@ -240,7 +235,7 @@ function LoadConsoleV2() {
         //save last line for next time.
         lastLine = data;
         prompt = prompt.trim();
-        if (!endsWith(prompt, "\n") && endsWith(prompt, ">") && !fileExplorerChanged) {
+        if (!endsWith(prompt, "\n") && endsWith(prompt, ">")) {
             var windowsPath = prompt.replace("\n", "").replace(">", "");
             if (startsWith(windowsPath, "PS ")) {
                 windowsPath = windowsPath.substr(3);
@@ -250,8 +245,6 @@ function LoadConsoleV2() {
                     window.KuduExec.appRoot = windowsPath;
                 }
                 curWorkingDir(windowsPath);
-                if (window.KuduExec.updateFileSystemWatcher)
-                    window.KuduExec.updateFileSystemWatcher(windowsPath);
             }
         }
     }


### PR DESCRIPTION
current behavior when you click in file explorer:
![capture](https://user-images.githubusercontent.com/6531400/27460784-f3d66a3e-576a-11e7-9a5d-b66b85b733d7.JPG)
new behavior:
![image](https://user-images.githubusercontent.com/6531400/27460814-192f1dbc-576b-11e7-875f-5e79b1f080be.png)

@ahmelsayed 
while I am working on the front end routing...
I would suggest that we move the logic to **notify command line from explorer** out of the [selected observable.subscribe()](https://github.com/projectkudu/kudu/blob/master/Kudu.Services.Web/Content/Scripts/FileBrowser.js#L519-L528) (asking for approval :))

for file browser functions, we can notify command line explicitly, for example
`notify command line; selected(new value)`

and when command line wants to notify the file explorer about directory change, we just do
`select(new value)`

so we don't need the [flag variable](https://github.com/projectkudu/kudu/blob/master/Kudu.Services.Web/Content/Scripts/FileBrowser.js#L502) and the [extra promise](https://github.com/projectkudu/kudu/blob/master/Kudu.Services.Web/Content/Scripts/FileBrowser.js#L333)...and make the code readable