### PR TITLE
relax project GUID check for .sln

### DIFF
--- a/Kudu.Core/Infrastructure/FunctionAppHelper.cs
+++ b/Kudu.Core/Infrastructure/FunctionAppHelper.cs
@@ -1,10 +1,16 @@
-﻿namespace Kudu.Core.Infrastructure
+﻿using System.IO;
+
+namespace Kudu.Core.Infrastructure
 {
     internal static class FunctionAppHelper
     {
-        public static bool LooksLikeFunctionApp()
+        const string hostJson = "host.json";
+        public static bool LooksLikeFunctionApp(string projectFolder)
         {
-            return !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.FunctionRunTimeVersion));
+            // we look for host.json and make sure its a function web app
+            // if one of the two conditions is not met, user probably don't want to deploy this PROJECT
+            return FileSystemHelpers.FileExists(Path.Combine(projectFolder, hostJson)) &&
+                    !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.FunctionRunTimeVersion));
         }
     }
 }

--- a/Kudu.Core/Infrastructure/VsSolutionProject.cs
+++ b/Kudu.Core/Infrastructure/VsSolutionProject.cs
@@ -161,22 +161,11 @@ namespace Kudu.Core.Infrastructure
             {
                 // used to determine project type
                 _projectTypeGuids = VsHelper.GetProjectTypeGuids(_absolutePath);
-                if (AspNetCoreHelper.IsDotnetCoreFromProjectFile(_absolutePath, _projectTypeGuids))
-                {
-                    _isAspNetCore = true;
-                }
-                else if (projectType == SolutionProjectType.KnownToBeMSBuildFormat)
-                {
-                    // KnownToBeMSBuildFormat: C#, VB, and VJ# projects
-                    // Check if it's a wap
-                    _isWap = VsHelper.IsWap(_projectTypeGuids);
 
-                    _isExecutable = VsHelper.IsExecutableProject(_absolutePath);
-                }
-                else if (FunctionAppHelper.LooksLikeFunctionApp())
-                {
-                    _isFunctionApp = true;
-                }
+                _isAspNetCore = AspNetCoreHelper.IsDotnetCoreFromProjectFile(_absolutePath, _projectTypeGuids);
+                _isWap = VsHelper.IsWap(_projectTypeGuids);
+                _isExecutable = VsHelper.IsExecutableProject(_absolutePath);
+                _isFunctionApp = FunctionAppHelper.LooksLikeFunctionApp(Path.GetDirectoryName(_absolutePath));
             }
             else
             {
@@ -190,7 +179,7 @@ namespace Kudu.Core.Infrastructure
         private enum SolutionProjectType
         {
             Unknown,
-            KnownToBeMSBuildFormat,
+            KnownToBeMSBuildFormat,  // KnownToBeMSBuildFormat: C#, VB, and VJ# projects
             SolutionFolder,
             WebProject,
             WebDeploymentProject,


### PR DESCRIPTION
the functionApp created using VS2017 15.3 changed the project GUID to C# 
I decide to relax the GUID check, even if it returns a `SolutionProjectType.Unknown` 
we still let it go through our logic, if we still ended up finding a project to deploy
we continue with build and let build error out 