### PR TITLE
Docker logs API

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -465,6 +465,12 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHandlerDual<LogStreamHandler>(kernel, "logstream", "logstream/{*path}");
             routes.MapHttpRoute("recent-logs", "api/logs/recent", new { controller = "Diagnostics", action = "GetRecentLogs" }, new { verb = new HttpMethodConstraint("GET") });
 
+            if (!OSDetector.IsOnWindows())
+            {
+                routes.MapHttpRoute("current-docker-logs-zip", "api/logs/docker/zip", new { controller = "Diagnostics", action = "GetDockerLogsZip" }, new { verb = new HttpMethodConstraint("GET") });
+                routes.MapHttpRoute("current-docker-logs", "api/logs/docker", new { controller = "Diagnostics", action = "GetDockerLogs" }, new { verb = new HttpMethodConstraint("GET") });
+            }
+            
             var processControllerName = OSDetector.IsOnWindows() ? "Process" : "LinuxProcess";
 
             // Processes

--- a/Kudu.Services/Diagnostics/DiagnosticsController.cs
+++ b/Kudu.Services/Diagnostics/DiagnosticsController.cs
@@ -13,11 +13,18 @@ using Kudu.Core.Settings;
 using Kudu.Core.Tracing;
 using Kudu.Services.Diagnostics;
 using Kudu.Services.Infrastructure;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace Kudu.Services.Performance
 {
     public class DiagnosticsController : ApiController
     {
+        // Matches Docker log filenames of logs that haven't been rolled (are most current for a given machine name)
+        private static readonly Regex NONROLLED_DOCKER_LOG_FILENAME_REGEX = new Regex(@"^\d{4}_\d{2}_\d{2}_.*_docker\.log$");
+
         private readonly DiagnosticsSettingsManager _settingsManager;
         private readonly string[] _paths;
         private readonly ITracer _tracer;
@@ -64,6 +71,89 @@ namespace Kudu.Services.Performance
                 var results = _applicationLogsReader.GetRecentLogs(top);
                 return Request.CreateResponse(HttpStatusCode.OK, results);
             }
+        }
+
+        // Route only exists for this on Linux
+        // Grabs "currently relevant" Docker logs from the LogFiles folder
+        // and returns a JSON response with links to the files in the VFS API
+        [HttpGet]
+        public HttpResponseMessage GetDockerLogs()
+        {
+            using (_tracer.Step("DiagnosticsController.GetDockerLogs"))
+            {
+                var currentDockerLogFilenames = GetCurrentDockerLogFilenames();
+
+                // TODO Can we read the vfs route string from somewhere instead of hard-coding "/api/vfs"?
+                var vfsBaseAddress = Request.RequestUri.GetComponents(UriComponents.Scheme | UriComponents.Host, UriFormat.UriEscaped) + "/api/vfs";
+
+                var responseContent = currentDockerLogFilenames.Select(p => CurrentDockerLogFilenameToJson(p, vfsBaseAddress));
+
+                return Request.CreateResponse(HttpStatusCode.OK, responseContent);
+            }
+        }
+
+        // Route only exists for this on Linux
+        // Grabs "currently relevant" Docker logs from the LogFiles folder
+        // and returns them in a zip archive
+        [HttpGet]
+        [SuppressMessage("Microsoft.Usage", "CA2202", Justification = "The ZipArchive is instantiated in a way that the stream is not closed on dispose")]
+        public HttpResponseMessage GetDockerLogsZip()
+        {
+            using (_tracer.Step("DiagnosticsController.GetDockerLogsZip"))
+            {
+                var currentDockerLogFilenames = GetCurrentDockerLogFilenames().ToArray();
+
+                HttpResponseMessage response = Request.CreateResponse();
+                response.Content = ZipStreamContent.Create(String.Format("dockerlogs-{0:MM-dd-HH-mm-ss}.zip", DateTime.UtcNow), _tracer, zip =>
+                {
+                    foreach (var filename in currentDockerLogFilenames)
+                    {
+                        zip.AddFile(filename, _tracer);
+                    }
+                });
+                return response;
+            }
+        }
+
+        private IEnumerable<string> GetCurrentDockerLogFilenames()
+        {
+            //TODO get from environment
+            var path = "/home/LogFiles";
+
+            var nonRolledDockerLogFilenames =
+                FileSystemHelpers.GetFiles(path, "*", SearchOption.TopDirectoryOnly)
+                .Where(f => NONROLLED_DOCKER_LOG_FILENAME_REGEX.IsMatch(Path.GetFileName(f)))
+                .ToArray();
+
+            // Find the latest date stamp and filter out those that don't have it
+            var latestDatestamp = nonRolledDockerLogFilenames
+                .Select(p => Path.GetFileName(p).Substring(0, 10))
+                .OrderByDescending(s => int.Parse(s.Replace("_", String.Empty)))
+                .First();
+
+            return nonRolledDockerLogFilenames.Where(f => Path.GetFileName(f).StartsWith(latestDatestamp));
+        }
+
+        private JObject CurrentDockerLogFilenameToJson(string path, string vfsBaseAddress)
+        {
+            var info = new FileInfo(path);
+
+            // Machine name is the middle portion of the filename, between the datestamp prefix
+            // and the _docker.log suffix.
+            var machineName = info.Name.Substring(11, info.Name.Length - 22);
+
+            // TODO This should be more generalized; should be able to get root from environment
+            // Remove "/home" from the FullName, as it's implicit in the vfs url
+            var vfsPath = info.FullName.Remove(0, "/home".Length);
+
+            var vfsUrl = (vfsBaseAddress + Uri.EscapeUriString(vfsPath)).EscapeHashCharacter();
+
+            return new JObject(
+                new JProperty("machineName", machineName),
+                new JProperty("lastUpdated", info.LastWriteTimeUtc),
+                new JProperty("size", info.Length),
+                new JProperty("href", vfsUrl),
+                new JProperty("path", info.FullName));
         }
 
         private void AddFilesToZip(ZipArchive zip)


### PR DESCRIPTION
Dedicated endpoints for retrieving current Docker logs on Linux. This has been requested for GA.

**This is an early review** - mostly feeling out if anyone has a huge hole to shoot in this. There will be more changes and potentially functionality before this is complete.

Open to suggestions for the route URLs, the controller that this logic should go in, etc.