### PR TITLE
Mitigation for Process API errors on Linux

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -465,17 +465,19 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHandlerDual<LogStreamHandler>(kernel, "logstream", "logstream/{*path}");
             routes.MapHttpRoute("recent-logs", "api/logs/recent", new { controller = "Diagnostics", action = "GetRecentLogs" }, new { verb = new HttpMethodConstraint("GET") });
 
+            var processControllerName = OSDetector.IsOnWindows() ? "Process" : "LinuxProcess";
+
             // Processes
-            routes.MapHttpProcessesRoute("all-processes", "", new { controller = "Process", action = "GetAllProcesses" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("one-process-get", "/{id}", new { controller = "Process", action = "GetProcess" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("one-process-delete", "/{id}", new { controller = "Process", action = "KillProcess" }, new { verb = new HttpMethodConstraint("DELETE") });
-            routes.MapHttpProcessesRoute("one-process-dump", "/{id}/dump", new { controller = "Process", action = "MiniDump" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("start-process-profile", "/{id}/profile/start", new { controller = "Process", action = "StartProfileAsync" }, new { verb = new HttpMethodConstraint("POST") });
-            routes.MapHttpProcessesRoute("stop-process-profile", "/{id}/profile/stop", new { controller = "Process", action = "StopProfileAsync" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("all-threads", "/{id}/threads", new { controller = "Process", action = "GetAllThreads" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("one-process-thread", "/{processId}/threads/{threadId}", new { controller = "Process", action = "GetThread" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("all-modules", "/{id}/modules", new { controller = "Process", action = "GetAllModules" }, new { verb = new HttpMethodConstraint("GET") });
-            routes.MapHttpProcessesRoute("one-process-module", "/{id}/modules/{baseAddress}", new { controller = "Process", action = "GetModule" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("all-processes", "", new { controller = processControllerName, action = "GetAllProcesses" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("one-process-get", "/{id}", new { controller = processControllerName, action = "GetProcess" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("one-process-delete", "/{id}", new { controller = processControllerName, action = "KillProcess" }, new { verb = new HttpMethodConstraint("DELETE") });
+            routes.MapHttpProcessesRoute("one-process-dump", "/{id}/dump", new { controller = processControllerName, action = "MiniDump" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("start-process-profile", "/{id}/profile/start", new { controller = processControllerName, action = "StartProfileAsync" }, new { verb = new HttpMethodConstraint("POST") });
+            routes.MapHttpProcessesRoute("stop-process-profile", "/{id}/profile/stop", new { controller = processControllerName, action = "StopProfileAsync" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("all-threads", "/{id}/threads", new { controller = processControllerName, action = "GetAllThreads" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("one-process-thread", "/{processId}/threads/{threadId}", new { controller = processControllerName, action = "GetThread" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("all-modules", "/{id}/modules", new { controller = processControllerName, action = "GetAllModules" }, new { verb = new HttpMethodConstraint("GET") });
+            routes.MapHttpProcessesRoute("one-process-module", "/{id}/modules/{baseAddress}", new { controller = processControllerName, action = "GetModule" }, new { verb = new HttpMethodConstraint("GET") });
 
             // Runtime
             routes.MapHttpRouteDual("runtime", "diagnostics/runtime", new { controller = "Runtime", action = "GetRuntimeVersions" }, new { verb = new HttpMethodConstraint("GET") });

--- a/Kudu.Services/Diagnostics/LinuxProcessController.cs
+++ b/Kudu.Services/Diagnostics/LinuxProcessController.cs
@@ -11,77 +11,76 @@ namespace Kudu.Services.Performance
 
     public class LinuxProcessController : ApiController
     {
-        private const HttpStatusCode RETURNCODE = HttpStatusCode.BadRequest;
         private const string ERRORMSG = "Not supported on Linux";
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage GetThread(int processId, int threadId)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage GetAllThreads(int id)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage GetModule(int id, string baseAddress)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage GetAllModules(int id)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage GetAllProcesses(bool allUsers = false)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage GetProcess(int id)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpDelete]
         public HttpResponseMessage KillProcess(int id)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage MiniDump(int id, int dumpType = 0, string format = null)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpPost]
         public HttpResponseMessage StartProfileAsync(int id, bool iisProfiling = false)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
         [HttpGet]
         public HttpResponseMessage StopProfileAsync(int id)
         {
-            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ERRORMSG);
         }
     }
 }

--- a/Kudu.Services/Diagnostics/LinuxProcessController.cs
+++ b/Kudu.Services/Diagnostics/LinuxProcessController.cs
@@ -1,0 +1,87 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+
+namespace Kudu.Services.Performance
+{
+    // This is a placeholder for future process API functionality on Linux,
+    // the implementation of which will differ from Windows enought that it warrants
+    // a separate controller class. For now this returns 400s for all routes.
+
+    public class LinuxProcessController : ApiController
+    {
+        private const HttpStatusCode RETURNCODE = HttpStatusCode.BadRequest;
+        private const string ERRORMSG = "Not supported on Linux";
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage GetThread(int processId, int threadId)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage GetAllThreads(int id)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage GetModule(int id, string baseAddress)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage GetAllModules(int id)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage GetAllProcesses(bool allUsers = false)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage GetProcess(int id)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpDelete]
+        public HttpResponseMessage KillProcess(int id)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage MiniDump(int id, int dumpType = 0, string format = null)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpPost]
+        public HttpResponseMessage StartProfileAsync(int id, bool iisProfiling = false)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameters preserved for equivalent route binding")]
+        [HttpGet]
+        public HttpResponseMessage StopProfileAsync(int id)
+        {
+            return Request.CreateErrorResponse(RETURNCODE, ERRORMSG);
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Commands\PersistentCommandController.cs" />
     <Compile Include="Deployment\DeploymentController.cs" />
     <Compile Include="Diagnostics\HttpRequestExtensions.cs" />
+    <Compile Include="Diagnostics\LinuxProcessController.cs" />
     <Compile Include="Diagnostics\LogStreamHandler.cs" />
     <Compile Include="Diagnostics\LogStreamManager.cs" />
     <Compile Include="Diagnostics\ProfileManager.cs" />


### PR DESCRIPTION
Effectively disabling Kudu's process API on Linux, as current implementation doesn't work.
Returning 400's as suggested by Suwat.
Will revisit in the future.