### PR TITLE
Linux - Support for container restart trigger

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+.gitattributes text=auto
+
 *.doc  diff=astextplain
 *.DOC	diff=astextplain
 *.docx	diff=astextplain
@@ -48,3 +50,4 @@
 *.dbproj text=auto
 *.sln text=auto eol=crlf
 *.sh text eol=lf
+*.resx text=auto

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -218,5 +218,18 @@ namespace Kudu.Contracts.Settings
         {
             return settings.GetValue(SettingsKeys.TouchWebConfigAfterDeployment) != "0";
         }
+
+        public static bool IsDockerCiEnabled(this IDeploymentSettingsManager settings)
+        {
+            string value = settings.GetValue(SettingsKeys.DockerCiEnabled);
+            return StringUtils.IsTrueLike(value);
+        }
+
+        public static bool RestartAppContainerOnGitDeploy(this IDeploymentSettingsManager settings)
+        {
+            // Default is true
+            string value = settings.GetValue(SettingsKeys.LinuxRestartAppContainerAfterDeployment) ?? "true";
+            return StringUtils.IsTrueLike(value);
+        }
     }
 }

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -227,9 +227,10 @@ namespace Kudu.Contracts.Settings
 
         public static bool RestartAppContainerOnGitDeploy(this IDeploymentSettingsManager settings)
         {
+            string value = settings.GetValue(SettingsKeys.LinuxRestartAppContainerAfterDeployment);
+
             // Default is true
-            string value = settings.GetValue(SettingsKeys.LinuxRestartAppContainerAfterDeployment) ?? "true";
-            return StringUtils.IsTrueLike(value);
+            return value == null || StringUtils.IsTrueLike(value);
         }
     }
 }

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -39,5 +39,7 @@
         public const string DisableDeploymentOnPush = "SCM_DISABLE_DEPLOY_ON_PUSH";
         public const string TouchWebConfigAfterDeployment = "SCM_TOUCH_WEBCONFIG_AFTER_DEPLOYMENT";
         public const string MaxRandomDelayInSec = "SCM_MAX_RANDOM_START_DELAY";
+        public const string DockerCiEnabled = "DOCKER_ENABLE_CI";
+        public const string LinuxRestartAppContainerAfterDeployment = "SCM_RESTART_APP_CONTAINER_AFTER_DEPLOYMENT";
     }
 }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -230,7 +230,7 @@ namespace Kudu.Core.Deployment
                     if (!OSDetector.IsOnWindows() && _settings.RestartAppContainerOnGitDeploy())
                     {
                         logger.Log(Resources.Log_TriggeringContainerRestart);
-                        LinuxContainerRestartTrigger.RequestContainerRestart(RestartTriggerReason);
+                        LinuxContainerRestartTrigger.RequestContainerRestart(_environment, RestartTriggerReason);
                     }
                 }
                 catch (Exception ex)

--- a/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using Kudu.Core.Helpers;
+
+namespace Kudu.Core.Infrastructure
+{
+    // Utility for touching the restart trigger file on Linux, which will restart the
+    // site container.
+    // Contents of the trigger file are irrelevant but this leaves a small explanation for
+    // users who stumble on it.
+    public static class LinuxContainerRestartTrigger
+    {
+        // TODO look up root instead of hard-coding here
+        private const string RESTART_TRIGGER_PATH = "/home/site/config/restartTrigger.txt";
+
+        private static readonly string FILE_CONTENTS_FORMAT = String.Concat(
+            "Modifying this file will trigger a restart of the app container.",
+            System.Environment.NewLine, System.Environment.NewLine,
+            "The last modification Kudu made to this file was at {0}, for the following reason: {1}.",
+            System.Environment.NewLine);
+
+        public static void RequestContainerRestart(string reason)
+        {
+            if (OSDetector.IsOnWindows())
+            {
+                throw new NotSupportedException("RequestContainerRestart not supported on Windows");
+            }
+
+            FileSystemHelpers.CreateDirectory(Path.GetDirectoryName(RESTART_TRIGGER_PATH));
+
+            var fileContents = String.Format(
+                FILE_CONTENTS_FORMAT,
+                DateTimeOffset.UtcNow.ToString("o", CultureInfo.InvariantCulture),
+                reason);
+
+            FileSystemHelpers.WriteAllText(RESTART_TRIGGER_PATH, fileContents);
+        }
+    }
+}

--- a/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
@@ -11,6 +11,9 @@ namespace Kudu.Core.Infrastructure
     // users who stumble on it.
     public static class LinuxContainerRestartTrigger
     {
+        private const string CONFIG_DIR_NAME = "config";
+        private const string TRIGGER_FILENAME = "restartTrigger.txt";
+
         private static readonly string FILE_CONTENTS_FORMAT = String.Concat(
             "Modifying this file will trigger a restart of the app container.",
             System.Environment.NewLine, System.Environment.NewLine,
@@ -24,7 +27,7 @@ namespace Kudu.Core.Infrastructure
                 throw new NotSupportedException("RequestContainerRestart not supported on Windows");
             }
 
-            var restartTriggerPath = Path.Combine(environment.SiteRootPath, "config", "restartTrigger.txt");
+            var restartTriggerPath = Path.Combine(environment.SiteRootPath, CONFIG_DIR_NAME, TRIGGER_FILENAME);
 
             FileSystemHelpers.CreateDirectory(Path.GetDirectoryName(restartTriggerPath));
 

--- a/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
@@ -17,24 +17,14 @@ namespace Kudu.Core.Infrastructure
             "The last modification Kudu made to this file was at {0}, for the following reason: {1}.",
             System.Environment.NewLine);
 
-        private static string restartTriggerPath;
-
-        public static void Initialize(string siteRootPath)
-        {
-            restartTriggerPath = Path.Combine(siteRootPath, "config", "restartTrigger.txt");
-        }
-
-        public static void RequestContainerRestart(string reason)
+        public static void RequestContainerRestart(IEnvironment environment, string reason)
         {
             if (OSDetector.IsOnWindows())
             {
                 throw new NotSupportedException("RequestContainerRestart not supported on Windows");
             }
 
-            if (restartTriggerPath == null)
-            {
-                throw new InvalidOperationException("LinuxContainerRestartTrigger not initialized");
-            }
+            var restartTriggerPath = Path.Combine(environment.SiteRootPath, "config", "restartTrigger.txt");
 
             FileSystemHelpers.CreateDirectory(Path.GetDirectoryName(restartTriggerPath));
 

--- a/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/LinuxContainerRestartTrigger.cs
@@ -11,14 +11,18 @@ namespace Kudu.Core.Infrastructure
     // users who stumble on it.
     public static class LinuxContainerRestartTrigger
     {
-        // TODO look up root instead of hard-coding here
-        private const string RESTART_TRIGGER_PATH = "/home/site/config/restartTrigger.txt";
-
         private static readonly string FILE_CONTENTS_FORMAT = String.Concat(
             "Modifying this file will trigger a restart of the app container.",
             System.Environment.NewLine, System.Environment.NewLine,
             "The last modification Kudu made to this file was at {0}, for the following reason: {1}.",
             System.Environment.NewLine);
+
+        private static string restartTriggerPath;
+
+        public static void Initialize(string siteRootPath)
+        {
+            restartTriggerPath = Path.Combine(siteRootPath, "config", "restartTrigger.txt");
+        }
 
         public static void RequestContainerRestart(string reason)
         {
@@ -27,14 +31,19 @@ namespace Kudu.Core.Infrastructure
                 throw new NotSupportedException("RequestContainerRestart not supported on Windows");
             }
 
-            FileSystemHelpers.CreateDirectory(Path.GetDirectoryName(RESTART_TRIGGER_PATH));
+            if (restartTriggerPath == null)
+            {
+                throw new InvalidOperationException("LinuxContainerRestartTrigger not initialized");
+            }
+
+            FileSystemHelpers.CreateDirectory(Path.GetDirectoryName(restartTriggerPath));
 
             var fileContents = String.Format(
                 FILE_CONTENTS_FORMAT,
                 DateTimeOffset.UtcNow.ToString("o", CultureInfo.InvariantCulture),
                 reason);
 
-            FileSystemHelpers.WriteAllText(RESTART_TRIGGER_PATH, fileContents);
+            FileSystemHelpers.WriteAllText(restartTriggerPath, fileContents);
         }
     }
 }

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -254,6 +254,7 @@
     <Compile Include="Infrastructure\IFileSystemWatcher.cs" />
     <Compile Include="Infrastructure\InstanceIdUtility.cs" />
     <Compile Include="Infrastructure\IServerConfiguration.cs" />
+    <Compile Include="Infrastructure\LinuxContainerRestartTrigger.cs" />
     <Compile Include="Infrastructure\NaiveFileSystemWatcher.cs" />
     <Compile Include="Infrastructure\SecurityUtility.cs" />
     <Compile Include="Infrastructure\PathUtils\PathLinuxUtility.cs" />

--- a/Kudu.Core/Resources.Designer.cs
+++ b/Kudu.Core/Resources.Designer.cs
@@ -340,6 +340,15 @@ namespace Kudu.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to App container will begin restart within 10 seconds..
+        /// </summary>
+        internal static string Log_TriggeringContainerRestart {
+            get {
+                return ResourceManager.GetString("Log_TriggeringContainerRestart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An unknown error has occurred. Check the diagnostic log for details..
         /// </summary>
         internal static string Log_UnexpectedError {

--- a/Kudu.Core/Resources.resx
+++ b/Kudu.Core/Resources.resx
@@ -225,4 +225,7 @@
   <data name="Error_FailedToLocateBash" xml:space="preserve">
     <value>Unable to locate 'bash.exe'. Make sure it is installed.</value>
   </data>
+  <data name="Log_TriggeringContainerRestart" xml:space="preserve">
+    <value>App container will begin restart within 10 seconds.</value>
+  </data>
 </root>

--- a/Kudu.Core/Resources.resx
+++ b/Kudu.Core/Resources.resx
@@ -229,3 +229,4 @@
     <value>App container will begin restart within 10 seconds.</value>
   </data>
 </root>
+<!-- -->

--- a/Kudu.Core/Resources.resx
+++ b/Kudu.Core/Resources.resx
@@ -229,4 +229,3 @@
     <value>App container will begin restart within 10 seconds.</value>
   </data>
 </root>
-<!-- -->

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -347,6 +347,11 @@ namespace Kudu.Services.Web.App_Start
                     kernel.Get<IAnalytics>(),
                     kernel.Get<ITraceFactory>()));
             GlobalConfiguration.Configuration.Filters.Add(new EnsureRequestIdHandlerAttribute());
+
+            if (!OSDetector.IsOnWindows())
+            {
+                LinuxContainerRestartTrigger.Initialize(environment.SiteRootPath);
+            }
         }
 
         public static class SignalRStartup

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -347,11 +347,6 @@ namespace Kudu.Services.Web.App_Start
                     kernel.Get<IAnalytics>(),
                     kernel.Get<ITraceFactory>()));
             GlobalConfiguration.Configuration.Filters.Add(new EnsureRequestIdHandlerAttribute());
-
-            if (!OSDetector.IsOnWindows())
-            {
-                LinuxContainerRestartTrigger.Initialize(environment.SiteRootPath);
-            }
         }
 
         public static class SignalRStartup


### PR DESCRIPTION
Linux App Service now supports a generic file-based communication mechanism
for requesting a restart of the app container. This was previously implemented
in a limited fashion only for the "Docker CI" webhook. This generalizes the
implementation and also requests a restart after a git deployment by default,
in addition to receipt of a Docker webhook request.