### PR TITLE
use node template for njsproj and python template for pyproj

### DIFF
--- a/Kudu.Core/Deployment/DeploymentHelper.cs
+++ b/Kudu.Core/Deployment/DeploymentHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.SourceControl;
@@ -10,17 +9,19 @@ namespace Kudu.Core.Deployment
 {
     public static class DeploymentHelper
     {
+        // build using msbuild in Azure
+        // does not include njsproj(node), pyproj(python), they are built differently
         private static readonly string[] _projectFileExtensions = new[] { ".csproj", ".vbproj", ".fsproj", ".xproj" };
 
         public static readonly string[] ProjectFileLookup = _projectFileExtensions.Select(p => "*" + p).ToArray();
 
-        public static IList<string> GetProjects(string path, IFileFinder fileFinder, SearchOption searchOption = SearchOption.AllDirectories)
+        public static IList<string> GetMsBuildProjects(string path, IFileFinder fileFinder, SearchOption searchOption = SearchOption.AllDirectories)
         {
             IEnumerable<string> filesList = fileFinder.ListFiles(path, searchOption, ProjectFileLookup);
             return filesList.ToList();
         }
 
-        public static bool IsProject(string path)
+        public static bool IsMsBuildProject(string path)
         {
             return _projectFileExtensions.Any(extension => path.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
         }

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
@@ -219,7 +218,7 @@ namespace Kudu.Core.Deployment.Generator
         // unless user specifies which project to deploy, targetPath == repositoryRoot
         private ISiteBuilder ResolveProject(string repositoryRoot, string targetPath, IDeploymentSettingsManager perDeploymentSettings, IFileFinder fileFinder, bool tryWebSiteProject, SearchOption searchOption = SearchOption.AllDirectories, bool specificConfiguration = true)
         {
-            if (DeploymentHelper.IsProject(targetPath))
+            if (DeploymentHelper.IsMsBuildProject(targetPath))
             {
                 // needs to check for project file existence
                 if (!File.Exists(targetPath))
@@ -232,7 +231,7 @@ namespace Kudu.Core.Deployment.Generator
             }
 
             // Check for loose projects
-            var projects = DeploymentHelper.GetProjects(targetPath, fileFinder, searchOption);
+            var projects = DeploymentHelper.GetMsBuildProjects(targetPath, fileFinder, searchOption);
             if (projects.Count > 1)
             {
                 // Can't determine which project to build

--- a/Kudu.Core/Infrastructure/VsSolutionProject.cs
+++ b/Kudu.Core/Infrastructure/VsSolutionProject.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Kudu.Core.Deployment;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -157,9 +158,9 @@ namespace Kudu.Core.Infrastructure
             }
 
             _absolutePath = Path.Combine(Path.GetDirectoryName(_solutionPath), relativePath);
-            if (FileSystemHelpers.FileExists(_absolutePath))
+            if (FileSystemHelpers.FileExists(_absolutePath) && DeploymentHelper.IsMsBuildProject(_absolutePath))
             {
-                // used to determine project type
+                // used to determine project type from project file
                 _projectTypeGuids = VsHelper.GetProjectTypeGuids(_absolutePath);
 
                 _isAspNetCore = AspNetCoreHelper.IsDotnetCoreFromProjectFile(_absolutePath, _projectTypeGuids);


### PR DESCRIPTION
using `KnownToBeMSBuildFormat` will exclude preview projects (function app for example)
but removing the check, will include `pyproj`/`njsproj` (which are still VS webproj, but are built differently in Azure)

now we simply check for file extension, and it happened that there is already one function that does it
although I renamed it
now https://github.com/projectkudu/kudu/blob/5da2e47f725799ed432c91cd644f7ba48d89be51/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs#L303
and 
https://github.com/projectkudu/kudu/blob/5da2e47f725799ed432c91cd644f7ba48d89be51/Kudu.Core/Infrastructure/VsSolutionProject.cs#L166

2 places where we check for webproj are both guarded by `IsMsBuildProject`