### PR TITLE
update msbuild15dir to 15.3.4

### DIFF
--- a/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
@@ -98,7 +98,7 @@ namespace Kudu.Core.Infrastructure
         internal override string ResolveMSBuild15Dir()
         {
             string programFiles = SystemEnvironment.GetFolderPath(SystemEnvironment.SpecialFolder.ProgramFilesX86);
-            return Path.Combine(programFiles, "MSBuild-15.3-preview", "MSBuild", "15.0", "Bin");
+            return Path.Combine(programFiles, "MSBuild-15.3.409.57025", "MSBuild", "15.0", "Bin");
         }
 
         internal override string ResolveMSBuildPath()


### PR DESCRIPTION
this commit 5ab5fbcf795a24340b7b80ce694ad5dc66a907d1 is when we introduce `MSBUILD_15_DIR` as an environment variable in Kudu
now we are updating it's version to unblock https://github.com/projectkudu/kudu/issues/2521, https://github.com/Azure/azure-functions-vs-build-sdk/issues/102

Currently we are only using this for [functionApp](https://github.com/projectkudu/KuduScript/blob/master/lib/templates/deploy.batch.functionmsbuild.template) deployment by default