### PR TITLE
Linux: Fix links in VFS API

### DIFF
--- a/Kudu.Services/Infrastructure/VfsControllerBase.cs
+++ b/Kudu.Services/Infrastructure/VfsControllerBase.cs
@@ -15,6 +15,7 @@ using Kudu.Contracts.Tracing;
 using Kudu.Core;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
+using Kudu.Core.Helpers;
 
 namespace Kudu.Services.Infrastructure
 {
@@ -67,7 +68,7 @@ namespace Kudu.Services.Infrastructure
                 if (localFilePath[localFilePath.Length - 1] != Path.DirectorySeparatorChar)
                 {
                     HttpResponseMessage redirectResponse = Request.CreateResponse(HttpStatusCode.TemporaryRedirect);
-                    UriBuilder location = new UriBuilder(Request.RequestUri);
+                    UriBuilder location = new UriBuilder(UriHelper.GetRequestUri(Request));
                     location.Path += "/";
                     redirectResponse.Headers.Location = location.Uri;
                     return Task.FromResult(redirectResponse);
@@ -83,7 +84,7 @@ namespace Kudu.Services.Infrastructure
                 if (localFilePath[localFilePath.Length - 1] == Path.DirectorySeparatorChar)
                 {
                     HttpResponseMessage redirectResponse = Request.CreateResponse(HttpStatusCode.TemporaryRedirect);
-                    UriBuilder location = new UriBuilder(Request.RequestUri);
+                    UriBuilder location = new UriBuilder(UriHelper.GetRequestUri(Request));
                     location.Path = location.Path.TrimEnd(_uriSegmentSeparator);
                     redirectResponse.Headers.Location = location.Uri;
                     return Task.FromResult(redirectResponse);
@@ -167,7 +168,7 @@ namespace Kudu.Services.Infrastructure
                 if (localFilePath[localFilePath.Length - 1] == Path.DirectorySeparatorChar)
                 {
                     HttpResponseMessage redirectResponse = Request.CreateResponse(HttpStatusCode.TemporaryRedirect);
-                    UriBuilder location = new UriBuilder(Request.RequestUri);
+                    UriBuilder location = new UriBuilder(UriHelper.GetRequestUri(Request));
                     location.Path = location.Path.TrimEnd(_uriSegmentSeparator);
                     redirectResponse.Headers.Location = location.Uri;
                     return Task.FromResult(redirectResponse);
@@ -337,7 +338,7 @@ namespace Kudu.Services.Infrastructure
                 }
                 else
                 {
-                    string reqUri = Request.RequestUri.AbsoluteUri.Split('?').First();
+                    string reqUri = UriHelper.GetRequestUri(Request).AbsoluteUri.Split('?').First();
                     if (reqUri[reqUri.Length - 1] == UriSegmentSeparator)
                     {
                         result = Path.GetFullPath(result + Path.DirectorySeparatorChar);
@@ -349,8 +350,9 @@ namespace Kudu.Services.Infrastructure
 
         private IEnumerable<VfsStatEntry> GetDirectoryResponse(FileSystemInfoBase[] infos)
         {
-            string baseAddress = Request.RequestUri.AbsoluteUri.Split('?').First();
-            string query = Request.RequestUri.Query;
+            var requestUri = UriHelper.GetRequestUri(Request);
+            string baseAddress = requestUri.AbsoluteUri.Split('?').First();
+            string query = requestUri.Query;
             foreach (FileSystemInfoBase fileSysInfo in infos)
             {
                 bool isDirectory = (fileSysInfo.Attributes & FileAttributes.Directory) != 0;

--- a/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
+++ b/Kudu.Services/Infrastructure/VfsSpecialFolders.cs
@@ -97,7 +97,7 @@ namespace Kudu.Services.Infrastructure
             if (String.Equals(path, SystemDrivePath, StringComparison.OrdinalIgnoreCase))
             {
                 response = request.CreateResponse(HttpStatusCode.TemporaryRedirect);
-                UriBuilder location = new UriBuilder(request.RequestUri);
+                UriBuilder location = new UriBuilder(UriHelper.GetRequestUri(request));
                 location.Path += "/";
                 response.Headers.Location = location.Uri;
             }


### PR DESCRIPTION
On Linux, absolute URLs to Kudu resources cannot be based on
request.RequestUri, as it's altered by the way the request is handed off within
the worker. This fixes the absolute URL links generated by the VFS API.

No changes on Windows; exact same calls are made.