### PR TITLE
Update JobsManager to watch App_Data folder 

### DIFF
--- a/Kudu.Core/Jobs/JobsFileWatcher.cs
+++ b/Kudu.Core/Jobs/JobsFileWatcher.cs
@@ -214,7 +214,7 @@ namespace Kudu.Core.Jobs
         private void OnChanged(object sender, FileSystemEventArgs e)
         {
             string path = e.FullPath;
-            if (path != null && path.Length > _jobDirectoryPath.Length && path.StartsWith(_jobDirectoryPath, StringComparison.OrdinalIgnoreCase))
+            if (path != null && path.StartsWith(_jobDirectoryPath, StringComparison.OrdinalIgnoreCase))
             {
                 path = path.Substring(_jobDirectoryPath.Length).TrimStart(Path.DirectorySeparatorChar);
                 int firstSeparator = path.IndexOf(Path.DirectorySeparatorChar);

--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -87,15 +87,8 @@ namespace Kudu.Core.Jobs
 
             var appDataPath = Path.Combine(Environment.WebRootPath, Constants.AppDataPath);
 
-            if (JobsBinariesPath.StartsWith(appDataPath, StringComparison.OrdinalIgnoreCase))
-            {
-                // WebDeploy may need to delete the contents in App_Data folder. We need to watch App_Data folder to avoid blocking the deletion.
-                JobsWatcher = new JobsFileWatcher(appDataPath, JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
-            }
-            else
-            {
-                JobsWatcher = new JobsFileWatcher(JobsBinariesPath, JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
-            }
+            // WebDeploy may need to delete the contents in App_Data folder. We need to watch App_Data folder to avoid blocking the deletion.
+            JobsWatcher = new JobsFileWatcher(appDataPath, JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
 
             HostingEnvironment.RegisterObject(this);
         }

--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -84,7 +84,19 @@ namespace Kudu.Core.Jobs
 
             JobsBinariesPath = Path.Combine(Environment.JobsBinariesPath, jobsTypePath);
             JobsDataPath = Path.Combine(Environment.JobsDataPath, jobsTypePath);
-            JobsWatcher = new JobsFileWatcher(JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
+
+            var appDataPath = Path.Combine(Environment.WebRootPath, Constants.AppDataPath);
+
+            if (JobsBinariesPath.StartsWith(appDataPath, StringComparison.OrdinalIgnoreCase))
+            {
+                // WebDeploy may need to delete the contents in App_Data folder. We need to watch App_Data folder to avoid blocking the deletion.
+                JobsWatcher = new JobsFileWatcher(appDataPath, JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
+            }
+            else
+            {
+                JobsWatcher = new JobsFileWatcher(JobsBinariesPath, JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
+            }
+
             HostingEnvironment.RegisterObject(this);
         }
 


### PR DESCRIPTION
If we set up FileSystemWatcher to watch App_Data\jobs\continuous, it will hold the handler to App_Data\jobs\continuous. When we try to delete App_Data\jobs, it may block the deletion. It usually happens when WebDeploy tries to clean up App_Data folder.
The change sets up FileSystemWatcher to watch App_Data folder, it hold the handler to App_Data folder and still includes the sub directory changes.

@davidebbo @pharring @iusafaro