### PR TITLE
Assorted Linux fixes/updates

### DIFF
--- a/Kudu.Services.Web/Default.cshtml
+++ b/Kudu.Services.Web/Default.cshtml
@@ -118,11 +118,11 @@
         <li>
             <a href="api/scm/info">Source control info</a>
         </li>
+        <li>
+            <a href="api/vfs">Files</a>
+        </li>
         @if (Kudu.Core.Helpers.OSDetector.IsOnWindows())
         {
-            <li>
-                <a href="api/vfs">Files</a>
-            </li>
             <li>
                 <a href="api/processes">Processes and mini-dumps</a>
             </li>
@@ -141,6 +141,12 @@
             <li>
             Functions: <a href="api/functions">list</a> | <a href="api/functions/config">host config</a>
         </li>
+        }
+        else
+        {
+            <li>
+                <a href="api/logs/docker">Current Docker logs</a> (<a href="api/logs/docker/zip">Download as zip</a>)
+            </li>
         }
     </ul>
 

--- a/Kudu.Services/Infrastructure/UriHelper.cs
+++ b/Kudu.Services/Infrastructure/UriHelper.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Web;
 using Kudu.Core.Helpers;
 
 namespace Kudu.Services.Infrastructure
 {
     public static class UriHelper
     {
+        private const string DisguisedHostHeaderName = "DISGUISED-HOST";
+
         public static Uri GetBaseUri(HttpRequestMessage request)
         {
             return new Uri(GetRequestUri(request).GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped));
@@ -16,21 +18,35 @@ namespace Kudu.Services.Infrastructure
 
         public static Uri GetRequestUri(HttpRequestMessage request)
         {
-            var uri = request.RequestUri;
+            string disguisedHost = null;
 
+            IEnumerable<string> disguisedHostValues;
+            if (request.Headers.TryGetValues(DisguisedHostHeaderName, out disguisedHostValues)
+                && disguisedHostValues.Count() > 0)
+            {
+                disguisedHost = disguisedHostValues.First();
+            }
+
+            return GetRequestUriInternal(request.RequestUri, disguisedHost);
+        }
+
+        public static Uri GetRequestUri(HttpRequest request)
+        {
+            return GetRequestUriInternal(request.Url, request.Headers[DisguisedHostHeaderName]);
+        }
+
+        private static Uri GetRequestUriInternal(Uri uri, string disguisedHostValue)
+        {
             // On Linux, corrections to the request URI are needed due to the way the request is handled on the worker:
             // - Set scheme to https
             // - Set host to the value of DISGUISED-HOST
             // - Remove port value
-            IEnumerable<string> disguisedHostValues;
-            if (!OSDetector.IsOnWindows()
-                && request.Headers.TryGetValues("DISGUISED-HOST", out disguisedHostValues)
-                && disguisedHostValues.Count() > 0)
+            if (!OSDetector.IsOnWindows() && disguisedHostValue != null)
             {
                 uri = (new UriBuilder(uri)
                 {
                     Scheme = "https",
-                    Host = disguisedHostValues.First(),
+                    Host = disguisedHostValue,
                     Port = -1
                 }).Uri;
             }

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -20,6 +20,7 @@ using Kudu.Core.Tracing;
 using Kudu.Services.ServiceHookHandlers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Kudu.Services.Infrastructure;
 
 namespace Kudu.Services
 {
@@ -143,7 +144,7 @@ namespace Kudu.Services
                             _environment,
                             _settings,
                             _tracer.TraceLevel,
-                            context.Request.Url,
+                            UriHelper.GetRequestUri(context.Request),
                             waitForTempDeploymentCreation);
                     }
 
@@ -151,7 +152,7 @@ namespace Kudu.Services
                     if (isAsync)
                     {
                         // latest deployment keyword reserved to poll till deployment done
-                        context.Response.Headers["Location"] = new Uri(context.Request.Url,
+                        context.Response.Headers["Location"] = new Uri(UriHelper.GetRequestUri(context.Request),
                             String.Format("/api/deployments/{0}?deployer={1}&time={2}", Constants.LatestDeployment, deployInfo.Deployer, DateTime.UtcNow.ToString("yyy-MM-dd_HH-mm-ssZ"))).ToString();
                     }
                     context.Response.StatusCode = (int)HttpStatusCode.Accepted;


### PR DESCRIPTION
- Open the first 10 Docker logfiles before reading their FileInfos to update the CIFS metadata. CIFS metadata on Linux "lags", and fresh data (esp. size) may be needed for some callers.
- Fix "Location" header URL value in FetchHandler
- Put link to Docker logs (both API and zip endpoints) on Kudu homepage on Linux
- Restore VFS link on Kudu homepage on Linux