### PR TITLE
Reduce size of test_data for ARM requests to 8MB/2

### DIFF
--- a/Kudu.Contracts/Functions/FunctionTestData.cs
+++ b/Kudu.Contracts/Functions/FunctionTestData.cs
@@ -2,9 +2,9 @@
 {
     public class FunctionTestData
     {
-        // test shows test_data of size 8310000 bytes still delivers as an ARM package
-        // whereas test_data of size 8388608 bytes fails
-        public const long PackageMaxSizeInBytes = 8300000;
+        // ARM has a limit of 8 MB -> 8388608 bytes
+        // divid by 2 to limit the over all size of test data to half of arm requirement to be safe.
+        public const long PackageMaxSizeInBytes = 8388608 / 2;
 
         public long BytesLeftInPackage { get; set; } = PackageMaxSizeInBytes;
 


### PR DESCRIPTION
Closes #2576

/cc @paulbatum 