### PR TITLE
streamline csproj files

### DIFF
--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -11,11 +11,6 @@
     <DocumentationFile>bin\Debug\Kudu.Services.XML</DocumentationFile>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <NoWarn>1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/Kudu.SiteManagement/Kudu.SiteManagement.csproj
+++ b/Kudu.SiteManagement/Kudu.SiteManagement.csproj
@@ -10,10 +10,10 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;SITEMANAGEMENT</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>TRACE;SITEMANAGEMENT</DefineConstants>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The $(Platform) is redundant.  Plus, the difference between $(Platform) for 'AnyCPU' vs. 'Any CPU' causes problems when building using msbuild.exe vs. Visual Studio.