### PR TITLE
nmallick Pull Request

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -799,6 +799,11 @@ $.connection.hub.start().done(function () {
     }
 
     function _isZipFile(evt) {
+        if (evt.originalEvent.dataTransfer === null)
+		{
+			//dataTransfer is null in Edge / IE. Assume a zip file. Unzip will no-op
+			return true;
+		}
         var items = evt.originalEvent.dataTransfer.items || evt.originalEvent.dataTransfer.files;
         if (items) {
             var filesArray = $.map(items, function (item) {


### PR DESCRIPTION
Suggesting fix for https://github.com/projectkudu/kudu/issues/2546
Edge is throwing the following error as dataTransfer property is null.

SCRIPT5007: Unable to get property 'items' of undefined or null reference
filebrowser.js (802,9)

The OR statement results in an error and the function terminates, hence the file upload fails. Checking for null and assuming zip to allow the function to continue. 

Tested the code change in Edge.