### PR TITLE
Fix for bug #2546. 

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/FileBrowser.js
+++ b/Kudu.Services.Web/Content/Scripts/FileBrowser.js
@@ -799,6 +799,10 @@ $.connection.hub.start().done(function () {
     }
 
     function _isZipFile(evt) {
+        if (evt.originalEvent.dataTransfer === null) {
+            //dataTransfer is null in Edge / IE. Assume a zip file. Unzip will no-op 
+            return true;
+        }
         var items = evt.originalEvent.dataTransfer.items || evt.originalEvent.dataTransfer.files;
         if (items) {
             var filesArray = $.map(items, function (item) {


### PR DESCRIPTION
Checking to see if dataTransfer is null before calling a method on it. The dataTransfer object is null for IE and Edge hence the issue.