### PR TITLE
Add support for sending triggered webjobs logs to App Logs

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -110,6 +110,13 @@ namespace Kudu.Contracts.Settings
             return StringUtils.IsTrueLike(value);
         }
 
+        public static bool LogTriggeredJobsToAppLogs(this IDeploymentSettingsManager settings)
+        {
+            string value = settings.GetValue(SettingsKeys.WebJobsLogTriggeredJobsToAppLogs);
+
+            return StringUtils.IsTrueLike(value);
+        }
+
         public static string GetBranch(this IDeploymentSettingsManager settings)
         {
             string value = settings.GetValue(SettingsKeys.Branch, onlyPerSite: true);

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -33,6 +33,7 @@
         public const string WebJobsHistorySize = "WEBJOBS_HISTORY_SIZE";
         public const string WebJobsStopped = "WEBJOBS_STOPPED";
         public const string WebJobsDisableSchedule = "WEBJOBS_DISABLE_SCHEDULE";
+        public const string WebJobsLogTriggeredJobsToAppLogs = "WEBJOBS_LOG_TRIGGERED_JOBS_TO_APP_LOGS";
         public const string PostDeploymentActionsDirectory = "SCM_POST_DEPLOYMENT_ACTIONS_PATH";
         public const string DisableSubmodules = "SCM_DISABLE_SUBMODULES";
         public const string SiteExtensionsFeedUrl = "SCM_SITEEXTENSIONS_FEED_URL";

--- a/Kudu.Core/Jobs/TriggeredJobRunLogger.cs
+++ b/Kudu.Core/Jobs/TriggeredJobRunLogger.cs
@@ -8,6 +8,7 @@ using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Tracing;
+using System.Diagnostics;
 
 namespace Kudu.Core.Jobs
 {
@@ -20,8 +21,9 @@ namespace Kudu.Core.Jobs
         private readonly string _id;
         private readonly string _historyPath;
         private readonly string _outputFilePath;
+        private readonly bool _logToAppLogs;
 
-        private TriggeredJobRunLogger(string jobName, string id, IEnvironment environment, ITraceFactory traceFactory)
+        private TriggeredJobRunLogger(string jobName, string id, IEnvironment environment, ITraceFactory traceFactory, bool logToAppLogs)
             : base(TriggeredStatusFile, environment, traceFactory)
         {
             _id = id;
@@ -30,6 +32,8 @@ namespace Kudu.Core.Jobs
             FileSystemHelpers.EnsureDirectory(_historyPath);
 
             _outputFilePath = Path.Combine(_historyPath, OutputLogFileName);
+
+            _logToAppLogs = logToAppLogs;
         }
 
         [SuppressMessage("Microsoft.Design", "CA1011:ConsiderPassingBaseTypesAsParameters", Justification = "We do not want to accept jobs which are not TriggeredJob")]
@@ -38,7 +42,7 @@ namespace Kudu.Core.Jobs
             OldRunsCleanup(triggeredJob.Name, environment, traceFactory, settings);
 
             string id = DateTime.UtcNow.ToString("yyyyMMddHHmmssffff");
-            var logger = new TriggeredJobRunLogger(triggeredJob.Name, id, environment, traceFactory);
+            var logger = new TriggeredJobRunLogger(triggeredJob.Name, id, environment, traceFactory, settings.LogTriggeredJobsToAppLogs());
             var triggeredJobStatus = new TriggeredJobStatus
             {
                 Trigger = trigger,
@@ -134,11 +138,21 @@ namespace Kudu.Core.Jobs
 
         public override void LogStandardOutput(string message)
         {
+            if (_logToAppLogs)
+            {
+                Trace.TraceInformation(message);
+            }
+
             Log(Level.Info, message, isSystem: false);
         }
 
         public override void LogStandardError(string message)
         {
+            if (_logToAppLogs)
+            {
+                Trace.TraceError(message);
+            }
+
             Log(Level.Err, message, isSystem: false);
         }
 


### PR DESCRIPTION
Some big customers are asking for it, and it has come up before. Making it optional to make sure it doesn't surprise any existing customers.