### PR TITLE
Ace version up 1.2.9 and .csx syntax color

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ace-init.js
+++ b/Kudu.Services.Web/Content/Scripts/ace-init.js
@@ -46,18 +46,20 @@ function getCustomMode(filename) {
     var _csproj = (/.(cs|vb)proj$/i);
     var _xdt = (/.xdt$/i);
     var _aspnet = (/.(cshtml|asp|aspx)$/i);
+    var _csx = (/.csx$/i);
     var syntax_mode = 'ace/mode/text';
-    if (
-        filename.match(_config) ||
+    if (filename.match(_config) ||
         filename.match(_csproj) ||
-        filename.match(_xdt)
-       )
+        filename.match(_xdt))
     {
         syntax_mode = 'ace/mode/xml';
     }
-    if (filename.match(_aspnet)) {
+    if (filename.match(_aspnet) ||
+        filename.match(_csx))
+    {
         syntax_mode = 'ace/mode/csharp';
     }
+
     return syntax_mode;
 }
 

--- a/Kudu.Services.Web/DebugConsole/WindowsConsole.cshtml
+++ b/Kudu.Services.Web/DebugConsole/WindowsConsole.cshtml
@@ -7,8 +7,8 @@
     <link href="~/Content/Styles/FileBrowser.css" rel="stylesheet" />
     <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.2/css/font-awesome.css" rel="stylesheet" />
     <script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-2.2.1.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ext-modelist.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ace.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.9/ext-modelist.js" type="text/javascript"></script>
 }
 
 <div id="main" class="container">


### PR DESCRIPTION
Ace editor version bump 1.2.2 &rarr; 1.2.9. Added syntax color for `.csx`. Can't do anything for F# yet since there's no support in core Ace, but it's close to happening.

From the Changelog:

> 2017.10.17 Version 1.2.9
> 
> * added support for bidirectional text, with monospace font (Alex Shensis)
> * added support for emoji 😊
> 
> * new language modes
>   - Red (Toomas Vooglaid)
>   - CSound (Nathan Whetsell)
>   - JSSM (John Haugeland)
> 
> * New Themes
>   - Dracula (Austin Schwartz)
> 
> 2017.07.02 Version 1.2.8
> * Fixed small bugs in searchbox and autocompleter
> 
> 2017.06.18 Version 1.2.7
> 
> * Added Support for arrow keys on external IPad keyboard (Emanuele Tamponi)
> * added match counter to searchbox extension
> 
> - implemented higlighting of multiline strings in yaml mode (Maxim Trushin)
> - improved haml syntax highlighter (Andrés Álvarez)
> 
> 2016.12.03 Version 1.2.6
> 
> * Fixed IME handling on new Chrome
> * Support for php 7 in the syntax checker
> 
> 2016.08.16 Version 1.2.5
> 
> * Fixed regression in noconflict mode
> 
> 2016.07.27 Version 1.2.4
> 
> * Maintenance release with several new modes and small bugfixes
> 
> 2016.01.17 Version 1.2.3
> 
> * Bugfixes
>   - fix memory leak in setSession (Tyler Stalder)
>   - double click not working on linux/mac
>   
> * new language modes
>   - reStructuredText (Robin Jarry)
>   - NSIS (Jan T. Sott)