### PR TITLE
support function2.0 in project folder

### DIFF
--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -57,7 +57,7 @@ namespace Kudu.Core.Deployment.Generator
                 var projectPath = !String.IsNullOrEmpty(targetProjectPath) ? targetProjectPath : repositoryRoot;
                 return new BasicBuilder(_environment, settings, _propertyProvider, repositoryRoot, projectPath);
             }
-                        
+
             if (!String.IsNullOrEmpty(targetProjectPath))
             {
                 // Try to resolve the project
@@ -331,12 +331,25 @@ namespace Kudu.Core.Deployment.Generator
             }
             else if (FunctionAppHelper.LooksLikeFunctionApp())
             {
-                return new FunctionMsbuildBuilder(_environment,
-                                                perDeploymentSettings,
-                                                _propertyProvider,
-                                                repositoryRoot,
-                                                targetPath,
-                                                solutionPath);
+                if (FunctionAppHelper.IsCSharpFunctionFromProjectFile(targetPath))
+                {
+                    return new FunctionMsbuildBuilder(_environment,
+                                           perDeploymentSettings,
+                                           _propertyProvider,
+                                           repositoryRoot,
+                                           targetPath,
+                                           solutionPath);
+                }
+                else
+                {
+                    // csx or node function with extensions.csproj
+                    return new FunctionBasicBuilder(_environment,
+                                                    perDeploymentSettings,
+                                                    _propertyProvider,
+                                                    repositoryRoot,
+                                                    Path.GetDirectoryName(targetPath));
+                }
+
             }
 
             throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture,

--- a/Kudu.Core/Infrastructure/FunctionAppHelper.cs
+++ b/Kudu.Core/Infrastructure/FunctionAppHelper.cs
@@ -6,5 +6,11 @@
         {
             return !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable(Constants.FunctionRunTimeVersion));
         }
+
+        public static bool IsCSharpFunctionFromProjectFile(string projectPath)
+        {
+            return VsHelper.IncludesReferencePackage(projectPath, "Microsoft.NET.Sdk.Functions");
+        }
+
     }
 }

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/39c5665a08f2ae50c0f853f5d44f574265ed3118
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/b6b6bf8b44c13ab980255b9d7659b6d4110b17d9
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end


### PR DESCRIPTION
if the XYZ.csproj contains
`<PackageReference Include="Microsoft.NET.Sdk.Functions"  />`
we view it as a msbuild template candidate

otherwise we assume its extensions.csproj
we view it as a basic template candidate

this should resolve https://github.com/projectkudu/kudu/issues/2631