### PR TITLE
Support WAR file based deployments

### DIFF
--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -28,6 +28,21 @@ namespace Kudu.Core.Deployment
         public FetchDelegate Fetch { get; set; }
         public bool AllowDeploymentWhileScmDisabled { get; set; }
 
+        // Optional.
+        // Path of the directory to be deployed to. The path should be relative to the wwwroot directory.
+        // Example: "webapps/ROOT"
+        public string TargetPath { get; set; }
+
+        // Optional.
+        // Path of the file that is watched for changes by the web server.
+        // The path must be relative to the directory where deployment is performed.
+        //
+        // Example1: If SCM_TARGET_PATH is not defined, WatchedFilePath is "web.config",
+        // file to be touched would refer to "%HOME%\site\wwwroot\web.config".
+        // Example2: If SCM_TARGET_PATH is "dir1", WatchedFilePath is "dir2/web.xml",
+        // file to be touched would refer to "%HOME%\site\wwwroot\dir1\dir2\web.xml".
+        public string WatchedFilePath { get; set; }
+
         // this is only set by GenericHandler
         // the RepositoryUrl can specify specific commitid to deploy
         // for instance, http://github.com/kuduapps/hellokudu.git#<commitid>

--- a/Kudu.Contracts/Deployment/IDeploymentManager.cs
+++ b/Kudu.Contracts/Deployment/IDeploymentManager.cs
@@ -13,7 +13,7 @@ namespace Kudu.Core.Deployment
         IEnumerable<LogEntry> GetLogEntryDetails(string id, string logId);
 
         void Delete(string id);
-        Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, bool needFileUpdate = true, bool fullBuildByDefault = true);
+        Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, DeploymentInfoBase deploymentInfo = null, bool needFileUpdate = true, bool fullBuildByDefault = true);
 
         /// <summary>
         /// Creates a temporary deployment that is used as a placeholder until changeset details are available.

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -222,7 +222,7 @@ namespace Kudu.Contracts.Settings
             return settings.GetValue(SettingsKeys.UseLibGit2SharpRepository) != "0";
         }
 
-        public static bool TouchWebConfigAfterDeployment(this IDeploymentSettingsManager settings)
+        public static bool TouchWatchedFileAfterDeployment(this IDeploymentSettingsManager settings)
         {
             return settings.GetValue(SettingsKeys.TouchWebConfigAfterDeployment) != "0";
         }

--- a/Kudu.Core.Test/Deployment/FetchDeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/FetchDeploymentManagerFacts.cs
@@ -180,7 +180,7 @@ namespace Kudu.Core.Test
                 throw new NotImplementedException();
             }
 
-            public Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, bool needFileUpdate = true, bool fullBuildByDefault = true)
+            public Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, DeploymentInfoBase deploymentInfo = null, bool needFileUpdate = true, bool fullBuildByDefault = true)
             {
                 ++DeployCount;
                 return Task.FromResult(1);

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -738,7 +738,7 @@ namespace Kudu.Core.Deployment
             deploymentAnalytics.Error = ex.ToString();
         }
 
-        private string GetOutputPath(DeploymentInfoBase deploymentInfo, IEnvironment environment, IDeploymentSettingsManager perDeploymentSettings)
+        private static string GetOutputPath(DeploymentInfoBase deploymentInfo, IEnvironment environment, IDeploymentSettingsManager perDeploymentSettings)
         {
             string targetPath = perDeploymentSettings.GetTargetPath();
 

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -206,6 +206,7 @@ namespace Kudu.Core.Deployment
                                 changeSet,
                                 deploymentInfo.Deployer,
                                 clean: false,
+                                deploymentInfo: deploymentInfo,
                                 needFileUpdate: deploySpecificCommitId,
                                 fullBuildByDefault: deploymentInfo.DoFullBuildByDefault);
                         }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -446,6 +446,7 @@ namespace Kudu.Services.Web.App_Start
 
             // Zip push deployment
             routes.MapHttpRoute("zip-push-deploy", "api/zipdeploy", new { controller = "PushDeployment", action = "ZipPushDeploy" }, new { verb = new HttpMethodConstraint("POST") });
+            routes.MapHttpRoute("zip-war-deploy", "api/wardeploy", new { controller = "PushDeployment", action = "WarPushDeploy" }, new { verb = new HttpMethodConstraint("POST") });
 
             // Live Command Line
             routes.MapHttpRouteDual("execute-command", "command", new { controller = "Command", action = "ExecuteCommand" }, new { verb = new HttpMethodConstraint("POST") });

--- a/Kudu.Services/Deployment/DeploymentController.cs
+++ b/Kudu.Services/Deployment/DeploymentController.cs
@@ -158,7 +158,7 @@ namespace Kudu.Services.Deployment
 
                         try
                         {
-                            await _deploymentManager.DeployAsync(repository, changeSet, username, clean, needFileUpdate);
+                            await _deploymentManager.DeployAsync(repository, changeSet, username, clean, deploymentInfo: null, needFileUpdate: needFileUpdate);
                         }
                         catch (DeploymentFailedException ex)
                         {

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -41,7 +41,6 @@ namespace Kudu.Services.Deployment
 
         [HttpPost]
         public async Task<HttpResponseMessage> ZipPushDeploy(
-            HttpRequestMessage request,
             [FromUri] bool isAsync = false,
             [FromUri] string author = null,
             [FromUri] string authorEmail = null,
@@ -73,7 +72,6 @@ namespace Kudu.Services.Deployment
 
         [HttpPost]
         public async Task<HttpResponseMessage> WarPushDeploy(
-            HttpRequestMessage request,
             [FromUri] bool isAsync = false,
             [FromUri] string author = null,
             [FromUri] string authorEmail = null,
@@ -86,8 +84,8 @@ namespace Kudu.Services.Deployment
                 {
                     AllowDeploymentWhileScmDisabled = true,
                     Deployer = deployer,
-                    TargetPath = @"webapps\ROOT",
-                    WatchedFilePath = @"WEB-INF\web.xml",
+                    TargetPath = Path.Combine("webapps", "ROOT"),
+                    WatchedFilePath = Path.Combine("WEB-INF", "web.xml"),
                     IsContinuous = false,
                     AllowDeferredDeployment = false,
                     IsReusable = false,

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -55,7 +55,8 @@ namespace Kudu.TestHarness
             JobsManager = new RemoteJobsManager(site.ServiceUrl + "api", credentials);
             LogFilesManager = new RemoteLogFilesManager(site.ServiceUrl + "api/logs", credentials);
             SiteExtensionManager = new RemoteSiteExtensionManager(site.ServiceUrl + "api", credentials);
-            PushDeploymentManager = new RemotePushDeploymentManager(site.ServiceUrl + "api/zipdeploy", credentials);
+            ZipDeploymentManager = new RemotePushDeploymentManager(site.ServiceUrl + "api/zipdeploy", credentials);
+            WarDeploymentManager = new RemotePushDeploymentManager(site.ServiceUrl + "api/wardeploy", credentials);
 
             var repositoryInfo = RepositoryManager.GetRepositoryInfo().Result;
             GitUrl = repositoryInfo.GitUrl.OriginalString;
@@ -185,7 +186,13 @@ namespace Kudu.TestHarness
             private set;
         }
 
-        public RemotePushDeploymentManager PushDeploymentManager
+        public RemotePushDeploymentManager ZipDeploymentManager
+        {
+            get;
+            private set;
+        }
+
+        public RemotePushDeploymentManager WarDeploymentManager
         {
             get;
             private set;


### PR DESCRIPTION
This commit introduces a new API (`/api/wardeploy`) for publishing WAR files to Java Web Apps to address the deployment issues with scaled out Java apps.

### Background
Publishing a WAR file to a Java web app is a common scenario. The WAR file is published to the wwwroot/webapps directory. Tomcat monitors the wwwroot/webapps directory for the presence of new *.war files (or changes to existing ones). The moment it detects either of that, it unzips the war file into a new directory that matches the name of the war file and loads the unzipped web application from that directory (WAR files are just zip files with a war extension).

In a scaled out web app, multiple Tomcat instances (one on each worker) attempt to unzip the WAR file causing multiple issues. Here are some common problems: When a change to the WAR file is detected, multiple Tomcat instances attempt to lock and unzip it, causing locking problems. Another issues is Tomcat attempting to reload a webapp which is in the middle of being updated by another Tomcat instance resulting in the Tomcat instance going into a bad state. There are few more race conditions like these which eventually result in Tomcat responding to incoming requests with 404.

### wardeploy
This commit builds on top of the existing zipdeploy mechanism to perform unzipping of WAR files outside the wwwwroot directory and deploys the expanded WAR file to the wwwwroot/webapps/ROOT directory which is monitored by Tomcat. After the deployment is complete wardeploy touches the wwwroot/webapps/ROOT/WEB-INF/web.xml file which causes Tomcat to reload the web app (equivalent to touching web.config). The race conditions with scaled out Java web apps are avoided as WAR file is not directly published to the wwwroot/webapps directory.