### PR TITLE
wardeploy improvements to support custom app names

### DIFF
--- a/Kudu.Client/Deployment/RemotePushDeploymentManager.cs
+++ b/Kudu.Client/Deployment/RemotePushDeploymentManager.cs
@@ -16,7 +16,7 @@ namespace Kudu.Client.Deployment
         {
         }
 
-        public async Task<HttpResponseMessage> PushDeployFromStream(Stream zipFile, ZipDeployMetadata metadata)
+        public async Task<HttpResponseMessage> PushDeployFromStream(Stream zipFile, ZipDeployMetadata metadata, IList<KeyValuePair<string, string>> queryParams = null)
         {
             using (var request = new HttpRequestMessage())
             {
@@ -34,6 +34,11 @@ namespace Kudu.Client.Deployment
                     new KeyValuePair<string, string>("deployer", metadata.Deployer),
                     new KeyValuePair<string, string>("message", metadata.Message),
                 };
+
+                if (queryParams != null)
+                {
+                    map.AddRange(queryParams);
+                }
 
                 foreach (var item in map)
                 {

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -48,6 +48,8 @@ namespace Kudu.Core.Deployment
         // for instance, http://github.com/kuduapps/hellokudu.git#<commitid>
         public string CommitId { get; set; }
 
+        public bool CleanupTargetDirectory { get; set; }
+
         // Can set to false for deployments where we assume that the repository contains the entire
         // built site, meaning we can skip app stack detection and simply use BasicBuilder
         // (KuduSync only)

--- a/Kudu.Core/Deployment/DeploymentContext.cs
+++ b/Kudu.Core/Deployment/DeploymentContext.cs
@@ -14,6 +14,8 @@ namespace Kudu.Core.Deployment
         /// </summary>
         public string NextManifestFilePath { get; set; }
 
+        public bool IgnoreManifest { get; set; }
+
         /// <summary>
         /// Writes diagnostic output to the trace.
         /// </summary>

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -624,6 +624,7 @@ namespace Kudu.Core.Deployment
                 {
                     NextManifestFilePath = GetDeploymentManifestPath(id),
                     PreviousManifestFilePath = GetActiveDeploymentManifestPath(),
+                    IgnoreManifest = deploymentInfo.CleanupTargetDirectory,
                     Tracer = tracer,
                     Logger = logger,
                     GlobalLogger = _globalLogger,

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -624,7 +624,11 @@ namespace Kudu.Core.Deployment
                 {
                     NextManifestFilePath = GetDeploymentManifestPath(id),
                     PreviousManifestFilePath = GetActiveDeploymentManifestPath(),
-                    IgnoreManifest = deploymentInfo.CleanupTargetDirectory,
+                    IgnoreManifest = deploymentInfo.CleanupTargetDirectory, // Ignoring the manifest will cause kudusync to delete sub-directories / files
+                                                                            // in the destination directory that are not present in the source directory,
+                                                                            // without checking the manifest to see if the file was copied over to the destination
+                                                                            // during a previous kudusync operation. This effectively performs a clean deployment
+                                                                            // from the source to the destination directory.
                     Tracer = tracer,
                     Logger = logger,
                     GlobalLogger = _globalLogger,

--- a/Kudu.Core/Deployment/Generator/CustomBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/CustomBuilder.cs
@@ -21,7 +21,7 @@ namespace Kudu.Core.Deployment.Generator
 
             try
             {
-                RunCommand(context, _command);
+                RunCommand(context, _command, ignoreManifest: false);
 
                 tcs.SetResult(null);
             }

--- a/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/ExternalCommandBuilder.cs
@@ -69,11 +69,11 @@ namespace Kudu.Core.Deployment.Generator
                 {
                     scriptFilePath = string.Format(CultureInfo.InvariantCulture, "\"{0}\"", file);
                 }
-                RunCommand(context, scriptFilePath, Path.GetFileNameWithoutExtension(file));
+                RunCommand(context, scriptFilePath, false, Path.GetFileNameWithoutExtension(file));
             }
         }
 
-        protected void RunCommand(DeploymentContext context, string command, string message = "Running deployment command...")
+        protected void RunCommand(DeploymentContext context, string command, bool ignoreManifest, string message = "Running deployment command...")
         {
             ILogger customLogger = context.Logger.Log(message);
             customLogger.Log("Command: " + command);
@@ -84,6 +84,7 @@ namespace Kudu.Core.Deployment.Generator
 
             exe.EnvironmentVariables[WellKnownEnvironmentVariables.PreviousManifestPath] = context.PreviousManifestFilePath ?? String.Empty;
             exe.EnvironmentVariables[WellKnownEnvironmentVariables.NextManifestPath] = context.NextManifestFilePath;
+            exe.EnvironmentVariables[WellKnownEnvironmentVariables.IgnoreManifest] = ignoreManifest ? "1" : "0";
 
             exe.EnvironmentVariables[WellKnownEnvironmentVariables.BuildTempPath] = context.BuildTempPath;
 

--- a/Kudu.Core/Deployment/Generator/GeneratorSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/GeneratorSiteBuilder.cs
@@ -37,7 +37,7 @@ namespace Kudu.Core.Deployment.Generator
             {
                 GenerateScript(context, buildLogger);
                 string deploymentScriptPath = String.Format("\"{0}\"", DeploymentManager.GetCachedDeploymentScriptPath(Environment));
-                RunCommand(context, deploymentScriptPath);
+                RunCommand(context, deploymentScriptPath, context.IgnoreManifest);
                 tcs.SetResult(null);
             }
             catch (Exception ex)

--- a/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
+++ b/Kudu.Core/Deployment/WellKnownEnvironmentVariables.cs
@@ -16,6 +16,7 @@
         public const string BuildTempPath = "DEPLOYMENT_TEMP";
         public const string PreviousManifestPath = "PREVIOUS_MANIFEST_PATH";
         public const string NextManifestPath = "NEXT_MANIFEST_PATH";
+        public const string IgnoreManifest = "IGNORE_MANIFEST";
         public const string InPlaceDeployment = "IN_PLACE_DEPLOYMENT";
         public const string ApplicationPoolId = "APP_POOL_ID";
 

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -80,15 +80,23 @@ namespace Kudu.Services.Deployment
         {
             using (_tracer.Step("WarPushDeploy"))
             {
+                var appName = Request.RequestUri.ParseQueryString()["name"];
+
+                if (string.IsNullOrWhiteSpace(appName))
+                {
+                    appName = "ROOT";
+                }
+
                 var deploymentInfo = new ZipDeploymentInfo(_environment, _traceFactory)
                 {
                     AllowDeploymentWhileScmDisabled = true,
                     Deployer = deployer,
-                    TargetPath = Path.Combine("webapps", "ROOT"),
+                    TargetPath = Path.Combine("webapps", appName),
                     WatchedFilePath = Path.Combine("WEB-INF", "web.xml"),
                     IsContinuous = false,
                     AllowDeferredDeployment = false,
                     IsReusable = false,
+                    CleanupTargetDirectory = true, // For now, always cleanup the target directory. If needed, make it configurable
                     TargetChangeset = DeploymentManager.CreateTemporaryChangeSet(message: "Deploying from pushed war file"),
                     CommitId = null,
                     RepositoryType = RepositoryType.None,


### PR DESCRIPTION
- This change allows deploying war files to web apps other than ROOT.
- Posting war file contents to /api/wardeploy?name=myappname will create the myappname webapp by deploying the war contents to wwwroot/webapps/<appname> directory. If no app name is specified, ROOT is inferred.