### PR TITLE
[WIP] Support Run-From-Zip in ZipDeploy

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -121,5 +121,7 @@ namespace Kudu
         public const string AzureWebJobsSecretStorageType = "AzureWebJobsSecretStorageType";
         public const string HubName = "HubName";
         public const string DurableTask = "durableTask";
+        public const string SitePackages = "SitePackages";
+        public const string SiteVersionTxt = "siteversion.txt";
     }
 }

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -61,5 +61,12 @@ namespace Kudu.Core.Deployment
         }
 
         public abstract IRepository GetRepository();
+
+        // If this is not set, sync triggers will look under d:\home\site\wwwroot
+        // for functionsRoot. Otherwise it'll use this path for that
+        // This is used in Run-From-Zip deployments where the content of wwwroot
+        // won't update until after a process restart. Therefore, we copy the needed
+        // files into a separate folders and run sync triggers from there.
+        public string SyncFunctionsTriggersPath { get; set; } = null;
     }
 }

--- a/Kudu.Contracts/Deployment/FetchDeploymentRequestResult.cs
+++ b/Kudu.Contracts/Deployment/FetchDeploymentRequestResult.cs
@@ -8,6 +8,7 @@
         ConflictAutoSwapOngoing,
         RanSynchronously,
         Pending,
-        ConflictDeploymentInProgress
+        ConflictDeploymentInProgress,
+        ConflictRunFromRemoteZipConfigured
     }
 }

--- a/Kudu.Contracts/IEnvironment.cs
+++ b/Kudu.Contracts/IEnvironment.cs
@@ -28,5 +28,6 @@
         string AppBaseUrlPrefix { get; }        // e.g. siteName.azurewebsites.net
         string RequestId { get; }               // e.g. x-arr-log-id or x-ms-request-id header value
         string SiteRestrictedJwt { get; }       // e.g. x-ms-site-restricted-jwt header value
+        string SitePackagesPath { get; }        // e.g. /data/SitePackages
     }
 }

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -249,5 +249,17 @@ namespace Kudu.Contracts.Settings
             // returning true by default here as an indicator of generally expected behavior
             return value == null || StringUtils.IsTrueLike(value);
         }
+
+        public static bool RunFromLocalZip(this IDeploymentSettingsManager settings)
+        {
+            return settings.GetValue(SettingsKeys.RunFromZip) == "1";
+        }
+
+        public static bool RunFromRemoteZip(this IDeploymentSettingsManager settings)
+        {
+            var value = settings.GetValue(SettingsKeys.RunFromZip);
+
+            return value != null && value.StartsWith("http", StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -43,5 +43,6 @@
         public const string DockerCiEnabled = "DOCKER_ENABLE_CI";
         public const string LinuxRestartAppContainerAfterDeployment = "SCM_RESTART_APP_CONTAINER_AFTER_DEPLOYMENT";
         public const string DoBuildDuringDeployment = "SCM_DO_BUILD_DURING_DEPLOYMENT";
+        public const string RunFromZip = "WEBSITE_USE_ZIP";
     }
 }

--- a/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
+++ b/Kudu.Core.Test/Infrastructure/EnvironmentFacts.cs
@@ -15,7 +15,7 @@ namespace Kudu.Core.Test
 
             // Act and Assert
             var ex = Assert.Throws<ArgumentNullException>(() =>
-                new Environment(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
+                new Environment(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
 
             Assert.Equal("repositoryPath", ex.ParamName);
         }
@@ -127,7 +127,8 @@ namespace Kudu.Core.Test
             string scriptPath = null,
             string nodeModulesPath = null,
             string dataPath = null,
-            string siteExtensionSettingsPath = null)
+            string siteExtensionSettingsPath = null,
+            string sitePackagesPath = null)
         {
             fileSystem = fileSystem ?? Mock.Of<IFileSystem>();
             repositoryPath = repositoryPath ?? "";
@@ -149,6 +150,7 @@ namespace Kudu.Core.Test
                     nodeModulesPath,
                     dataPath,
                     siteExtensionSettingsPath,
+                    sitePackagesPath,
                     null,
                     null);
         }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -661,11 +661,16 @@ namespace Kudu.Core.Deployment
                         await builder.Build(context);
                         builder.PostBuild(context);
 
-                        await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, _environment.SiteRestrictedJwt, new PostDeploymentTraceListener(tracer, logger));
+                        await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, _environment.SiteRestrictedJwt, new PostDeploymentTraceListener(tracer, logger), deploymentInfo.SyncFunctionsTriggersPath);
 
                         if (_settings.TouchWatchedFileAfterDeployment())
                         {
                             TryTouchWatchedFile(context, deploymentInfo);
+                        }
+
+                        if (_settings.RunFromLocalZip() && deploymentInfo is ZipDeploymentInfo zipDeploymentInfo)
+                        {
+                            await PostDeploymentHelper.UpdateSiteVersion(zipDeploymentInfo, _environment, logger);
                         }
 
                         FinishDeployment(id, deployStep);

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using Kudu.Contracts;
 using Kudu.Contracts.Infrastructure;
 using Kudu.Contracts.Settings;
-using Kudu.Contracts.SourceControl;
 using Kudu.Contracts.Tracing;
 using Kudu.Core.Deployment.Generator;
 using Kudu.Core.Helpers;
@@ -73,6 +71,12 @@ namespace Kudu.Core.Deployment
             if (!(_settings.IsScmEnabled() || deployInfo.AllowDeploymentWhileScmDisabled))
             {
                 return FetchDeploymentRequestResult.ForbiddenScmDisabled;
+            }
+            // Else if this app is configured with a url in WEBSITE_USE_ZIP, then fail the deployment
+            // since this is a RunFromZip site and the deployment has no chance of succeeding.
+            else if (_settings.RunFromRemoteZip())
+            {
+                return FetchDeploymentRequestResult.ConflictRunFromRemoteZipConfigured;
             }
 
             // for CI payload, we will return Accepted and do the task in the BG

--- a/Kudu.Core/Deployment/Generator/RunFromZipSiteBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/RunFromZipSiteBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+
+namespace Kudu.Core.Deployment.Generator
+{
+    public class RunFromZipSiteBuilder : ISiteBuilder
+    {
+        public string ProjectType => "Run-From-Zip";
+
+        public Task Build(DeploymentContext context)
+        {
+            // no-op
+            context.Logger.Log($"Skipping build. Project type: {ProjectType}");
+            return Task.CompletedTask;
+        }
+
+        public void PostBuild(DeploymentContext context)
+        {
+            // no-op
+            context.Logger.Log($"Skipping post build. Project type: {ProjectType}");
+        }
+    }
+}

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -52,6 +52,11 @@ namespace Kudu.Core.Deployment.Generator
                 targetProjectPath = Path.GetFullPath(Path.Combine(repositoryRoot, targetProjectPath.TrimStart('/', '\\')));
             }
 
+            if (settings.RunFromLocalZip())
+            {
+                return new RunFromZipSiteBuilder();
+            }
+
             if (!settings.DoBuildDuringDeployment())
             {
                 var projectPath = !String.IsNullOrEmpty(targetProjectPath) ? targetProjectPath : repositoryRoot;

--- a/Kudu.Core/Deployment/ZipDeploymentInfo.cs
+++ b/Kudu.Core/Deployment/ZipDeploymentInfo.cs
@@ -1,6 +1,5 @@
-﻿using System;
+﻿using System.IO;
 using Kudu.Core.SourceControl;
-using System.IO;
 using Kudu.Core.Tracing;
 
 namespace Kudu.Core.Deployment
@@ -29,5 +28,7 @@ namespace Kudu.Core.Deployment
         public string AuthorEmail { get; set; }
 
         public string Message { get; set; }
+
+        public string ZipName { get; set; }
     }
 }

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -34,6 +34,7 @@ namespace Kudu.Core
         private readonly string _dataPath;
         private readonly string _jobsDataPath;
         private readonly string _jobsBinariesPath;
+        private readonly string _sitePackagesPath;
 
         // This ctor is used only in unit tests
         public Environment(
@@ -51,6 +52,7 @@ namespace Kudu.Core
                 string nodeModulesPath,
                 string dataPath,
                 string siteExtensionSettingsPath,
+                string sitePackagesPath,
                 string requestId,
                 string siteRestrictedJwt)
         {
@@ -84,6 +86,7 @@ namespace Kudu.Core
             _tracePath = Path.Combine(rootPath, Constants.TracePath);
             _analyticsPath = Path.Combine(tempPath ?? _logFilesPath, Constants.SiteExtensionLogsDirectory);
             _deploymentTracePath = Path.Combine(rootPath, Constants.DeploymentTracePath);
+            _sitePackagesPath = sitePackagesPath;
 
             RequestId = !string.IsNullOrEmpty(requestId) ? requestId : Guid.Empty.ToString();
             SiteRestrictedJwt = siteRestrictedJwt;
@@ -139,6 +142,7 @@ namespace Kudu.Core
                 // if userDefinedWebJobRoot = "D:/home/functionfolder", _jobsBinariesPath = "D:/home/functionfolder"
                 _jobsBinariesPath = Path.Combine(_webRootPath, userDefinedWebJobRoot);
             }
+            _sitePackagesPath = Path.Combine(_dataPath, Constants.SitePackages);
 
             RequestId = !string.IsNullOrEmpty(requestId) ? requestId : Guid.Empty.ToString();
             SiteRestrictedJwt = siteRetrictedJwt;
@@ -320,6 +324,14 @@ namespace Kudu.Core
             get
             {
                 return this.WebRootPath;
+            }
+        }
+
+        public string SitePackagesPath
+        {
+            get
+            {
+                return _sitePackagesPath;
             }
         }
 

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Kudu.Contracts.Settings;
+using Kudu.Core.Deployment;
 using Kudu.Core.Infrastructure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -99,7 +100,7 @@ namespace Kudu.Core.Helpers
             await PerformAutoSwap(requestId, siteRestrictedJwt, tracer);
         }
 
-        public static async Task SyncFunctionsTriggers(string requestId, string siteRestrictedJwt, TraceListener tracer)
+        public static async Task SyncFunctionsTriggers(string requestId, string siteRestrictedJwt, TraceListener tracer, string functionsPath = null)
         {
             _tracer = tracer;
 
@@ -117,7 +118,9 @@ namespace Kudu.Core.Helpers
 
             VerifyEnvironments();
 
-            var functionsPath = System.Environment.ExpandEnvironmentVariables(@"%HOME%\site\wwwroot");
+            functionsPath = !string.IsNullOrEmpty(functionsPath)
+                ? functionsPath
+                : System.Environment.ExpandEnvironmentVariables(@"%HOME%\site\wwwroot");
 
             // Read host.json 
             // Get HubName property for Durable Functions
@@ -601,6 +604,13 @@ namespace Kudu.Core.Helpers
             {
                 tracer.TraceEvent(null, "PostDeployment", eventType, (int)eventType, format, args);
             }
+        }
+
+        public static async Task UpdateSiteVersion(ZipDeploymentInfo deploymentInfo, IEnvironment environment, ILogger logger)
+        {
+            var siteVersionPath = Path.Combine(environment.SitePackagesPath, Constants.SiteVersionTxt);
+            logger.Log($"Updating {siteVersionPath} with deployment {deploymentInfo.ZipName}");
+            await FileSystemHelpers.WriteAllTextToFileAsync(siteVersionPath, deploymentInfo.ZipName);
         }
     }
 }

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Deployment\Generator\GoSiteBuilder.cs" />
     <Compile Include="Deployment\Generator\GoSiteEnabler.cs" />
     <Compile Include="Deployment\Generator\MicrosoftSiteBuilder.cs" />
+    <Compile Include="Deployment\Generator\RunFromZipSiteBuilder.cs" />
     <Compile Include="Deployment\Generator\PHPSiteBuilder.cs" />
     <Compile Include="Deployment\Generator\PHPSiteEnabler.cs" />
     <Compile Include="Deployment\Generator\PythonSiteEnabler.cs" />

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -1,19 +1,20 @@
 ﻿using System;
+using System.Globalization;
+using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
+using Kudu.Core;
 using Kudu.Core.Deployment;
 using Kudu.Core.Infrastructure;
+using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 using Kudu.Services.Infrastructure;
-using System.IO;
-using Kudu.Core.SourceControl;
-using System.Globalization;
-using Kudu.Core;
-using System.Linq;
 
 namespace Kudu.Services.Deployment
 {
@@ -26,17 +27,20 @@ namespace Kudu.Services.Deployment
         private readonly IFetchDeploymentManager _deploymentManager;
         private readonly ITracer _tracer;
         private readonly ITraceFactory _traceFactory;
+        private readonly IDeploymentSettingsManager _settings;
 
         public PushDeploymentController(
             IEnvironment environment,
             IFetchDeploymentManager deploymentManager,
             ITracer tracer,
-            ITraceFactory traceFactory)
+            ITraceFactory traceFactory,
+            IDeploymentSettingsManager settings)
         {
             _environment = environment;
             _deploymentManager = deploymentManager;
             _tracer = tracer;
             _traceFactory = traceFactory;
+            _settings = settings;
         }
 
         [HttpPost]
@@ -59,11 +63,18 @@ namespace Kudu.Services.Deployment
                     TargetChangeset = DeploymentManager.CreateTemporaryChangeSet(message: "Deploying from pushed zip file"),
                     CommitId = null,
                     RepositoryType = RepositoryType.None,
-                    Fetch = LocalZipFetch,
+                    Fetch = LocalZipHandler,
                     DoFullBuildByDefault = false,
                     Author = author,
                     AuthorEmail = authorEmail,
-                    Message = message
+                    Message = message,
+                    // This is used if the deployment is Run-From-Zip
+                    // the name of the deployed file in D:\home\data\SitePackages\{name}.zip is the 
+                    // timestamp in the format yyyMMddHHmmss. 
+                    ZipName = $"{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}.zip",
+                    // This is also for Run-From-Zip where we need to extract the triggers
+                    // for post deployment sync triggers.
+                    SyncFunctionsTriggersPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
                 };
 
                 return await PushDeployAsync(deploymentInfo, isAsync);
@@ -111,22 +122,27 @@ namespace Kudu.Services.Deployment
             }
         }
 
-        private async Task<HttpResponseMessage> PushDeployAsync(
-            ZipDeploymentInfo deploymentInfo,
-            bool isAsync)
+        private async Task<HttpResponseMessage> PushDeployAsync(ZipDeploymentInfo deploymentInfo, bool isAsync)
         {
-            var zipFileName = Path.ChangeExtension(Path.GetRandomFileName(), "zip");
-            var zipFilePath = Path.Combine(_environment.ZipTempPath, zipFileName);
-
-            using (_tracer.Step("Writing content to {0}", zipFilePath))
+            if (_settings.RunFromLocalZip())
             {
-                using (var file = FileSystemHelpers.CreateFile(zipFilePath))
-                {
-                    await Request.Content.CopyToAsync(file);
-                }
+                await WriteSitePackageZip(deploymentInfo, _tracer);
             }
+            else
+            {
+                var zipFileName = Path.ChangeExtension(Path.GetRandomFileName(), "zip");
+                var zipFilePath = Path.Combine(_environment.ZipTempPath, zipFileName);
 
-            deploymentInfo.RepositoryUrl = zipFilePath;
+                using (_tracer.Step("Writing content to {0}", zipFilePath))
+                {
+                    using (var file = FileSystemHelpers.CreateFile(zipFilePath))
+                    {
+                        await Request.Content.CopyToAsync(file);
+                    }
+                }
+
+                deploymentInfo.RepositoryUrl = zipFilePath;
+            }
 
             var result = await _deploymentManager.FetchDeploy(deploymentInfo, isAsync, UriHelper.GetRequestUri(Request), "HEAD");
 
@@ -163,12 +179,82 @@ namespace Kudu.Services.Deployment
                     response.StatusCode = HttpStatusCode.Conflict;
                     response.Content = new StringContent(Resources.Error_DeploymentInProgress);
                     break;
+                case FetchDeploymentRequestResult.ConflictRunFromRemoteZipConfigured:
+                    response.StatusCode = HttpStatusCode.Conflict;
+                    response.Content = new StringContent(Resources.Error_RunFromRemoteZipConfigured);
+                    break;
                 default:
                     response.StatusCode = HttpStatusCode.BadRequest;
                     break;
             }
 
             return response;
+        }
+
+        private async Task LocalZipHandler(IRepository repository, DeploymentInfoBase deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
+        {
+            if (_settings.RunFromLocalZip() && deploymentInfo is ZipDeploymentInfo zipDeploymentInfo)
+            {
+                // If this is a Run-From-Zip deployment, then we need to extract function.json
+                // from the zip file into path zipDeploymentInfo.SyncFunctionsTrigersPath
+                ExtractTriggers(repository, zipDeploymentInfo);
+            }
+            else
+            {
+                await LocalZipFetch(repository, deploymentInfo, targetBranch, logger, tracer);
+            }
+        }
+
+        private void ExtractTriggers(IRepository repository, ZipDeploymentInfo zipDeploymentInfo)
+        {
+            FileSystemHelpers.EnsureDirectory(zipDeploymentInfo.SyncFunctionsTriggersPath);
+            // Loading the zip file depends on how fast the file system is.
+            // Tested Azure Files share with a zip containing 120k files (160 MBs)
+            // takes 20 seconds to load. On my machine it takes 900 msec.
+            using (var zip = ZipFile.OpenRead(Path.Combine(_environment.SitePackagesPath, zipDeploymentInfo.ZipName)))
+            {
+                var entries = zip.Entries
+                    // Only select host.json, proxies.json, or top level directories.
+                    // Tested with a zip containing 120k files, and this took 90 msec
+                    // on my machine.
+                    .Where(e => e.FullName.Equals(Constants.FunctionsHostConfigFile, StringComparison.OrdinalIgnoreCase) ||
+                                e.FullName.Equals(Constants.ProxyConfigFile, StringComparison.OrdinalIgnoreCase) ||
+                                isTopLevelDirectory(e.FullName))
+                    // If entry is a top level dir, select the function.json in it.
+                    // otherwise that must be host.json, or proxies.json. Leave it as is.
+                    .Select(e => isTopLevelDirectory(e.FullName)
+                        ? zip.GetEntry($"{e.FullName}{Constants.FunctionsConfigFile}")
+                        : e
+                    )
+                    // if a top level folder wasn't a function, it won't contain a function.json
+                    // and GetEntry above will return null
+                    .Where(e => e != null);
+
+                foreach (var entry in entries)
+                {
+                    var path = Path.Combine(zipDeploymentInfo.SyncFunctionsTriggersPath, entry.FullName);
+                    FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(path));
+                    entry.ExtractToFile(path, overwrite: true);
+                }
+            }
+
+            CommitRepo(repository, zipDeploymentInfo);
+
+            bool isTopLevelDirectory(string fullName)
+            {
+                for (var i = 0; i < fullName.Length; i++)
+                {
+                    // Zip entries use '/' separators.
+                    // If the first '/' we find also the last in the string
+                    // It's a top level dir, otherwise it's not
+                    if (fullName[i] == '/')
+                    {
+                        return i + 1 == fullName.Length;
+                    }
+                }
+                // Top level file
+                return false;
+            }
         }
 
         private async Task LocalZipFetch(IRepository repository, DeploymentInfoBase deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
@@ -217,9 +303,33 @@ namespace Kudu.Services.Deployment
                 await Task.WhenAll(cleanTask, extractTask);
             }
 
+            CommitRepo(repository, zipDeploymentInfo);
+        }
+
+        private static void CommitRepo(IRepository repository, ZipDeploymentInfo zipDeploymentInfo)
+        {
             // Needed in order for repository.GetChangeSet() to work.
             // Similar to what OneDriveHelper and DropBoxHelper do.
+            // We need to make to call respository.Commit() since deployment flow expects at
+            // least 1 commit in the IRepository. Even though there is no repo per se in this
+            // scenario, deployment pipeline still generates a NullRepository
             repository.Commit(zipDeploymentInfo.Message, zipDeploymentInfo.Author, zipDeploymentInfo.AuthorEmail);
+        }
+
+        private async Task WriteSitePackageZip(ZipDeploymentInfo zipDeploymentInfo, ITracer tracer)
+        {
+            var filePath = Path.Combine(_environment.SitePackagesPath, zipDeploymentInfo.ZipName);
+
+            // Make sure D:\home\data\SitePackages exists
+            FileSystemHelpers.EnsureDirectory(_environment.SitePackagesPath);
+
+            using (tracer.Step("Writing content to {0}", filePath))
+            {
+                using (var file = FileSystemHelpers.CreateFile(filePath))
+                {
+                    await Request.Content.CopyToAsync(file);
+                }
+            }
         }
 
         private void DeleteFilesAndDirsExcept(string fileToKeep, string dirToKeep, ITracer tracer)

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -33,6 +33,7 @@
       <HintPath>..\packages\System.IO.Abstractions.1.4.0.74\lib\net35\System.IO.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>

--- a/Kudu.Services/Resources.Designer.cs
+++ b/Kudu.Services/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Kudu.Services {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -327,6 +327,15 @@ namespace Kudu.Services {
         internal static string Error_RepositoryNotFound {
             get {
                 return ResourceManager.GetString("Error_RepositoryNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run-From-Zip is set to a remote URL using WEBSITE_USE_ZIP app setting. Deployment is not supported in this configuration..
+        /// </summary>
+        internal static string Error_RunFromRemoteZipConfigured {
+            get {
+                return ResourceManager.GetString("Error_RunFromRemoteZipConfigured", resourceCulture);
             }
         }
         

--- a/Kudu.Services/Resources.resx
+++ b/Kudu.Services/Resources.resx
@@ -312,4 +312,7 @@
   <data name="Error_DeploymentInProgress" xml:space="preserve">
     <value>There is a deployment currently in progress. Please try again when it completes.</value>
   </data>
+  <data name="Error_RunFromRemoteZipConfigured" xml:space="preserve">
+    <value>Run-From-Zip is set to a remote URL using WEBSITE_USE_ZIP app setting. Deployment is not supported in this configuration.</value>
+  </data>
 </root>

--- a/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
+++ b/Kudu.Services/ServiceHookHandlers/FetchHandler.cs
@@ -117,6 +117,11 @@ namespace Kudu.Services
                         context.Response.Write(Resources.Error_DeploymentInProgress);
                         context.ApplicationInstance.CompleteRequest();
                         break;
+                    case FetchDeploymentRequestResult.ConflictRunFromRemoteZipConfigured:
+                        context.Response.StatusCode = (int)HttpStatusCode.Conflict;
+                        context.Response.Write(Resources.Error_RunFromRemoteZipConfigured);
+                        context.ApplicationInstance.CompleteRequest();
+                        break;
                     case FetchDeploymentRequestResult.RanSynchronously:
                     default:
                         break;

--- a/Kudu.TestHarness/TestEnvironment.cs
+++ b/Kudu.TestHarness/TestEnvironment.cs
@@ -149,6 +149,12 @@ namespace Kudu.TestHarness
             set;
         }
 
+        public string SitePackagesPath
+        {
+            get;
+            set;
+        }
+
         public string RequestId
         {
             get;


### PR DESCRIPTION
This is still a work in progress, but it works. If you would like to try it here is a private site extension build
[Kudu.zip](https://github.com/projectkudu/kudu/files/1834130/Kudu.zip)

To use run from zip:

1. Set `WEBSITE_USE_ZIP = 1`
2. `curl -X POST -u <user> --data-binary @<zipfile> https://{sitename}.scm.azurewebsites.net/api/zipdeploy`

Remaining work:
- [ ] Add unit tests
- [ ] Add an e2e deployment test
- [x] Run some more manual validations
- [x] handle some error cases