### PR TITLE
Make BaseJobRunner get the path from the Job object

### DIFF
--- a/Kudu.Core/Jobs/BaseJobRunner.cs
+++ b/Kudu.Core/Jobs/BaseJobRunner.cs
@@ -29,18 +29,18 @@ namespace Kudu.Core.Jobs
         private string _inPlaceWorkingDirectory;
         private Dictionary<string, FileInfoBase> _cachedSourceDirectoryFileMap;
 
-        protected BaseJobRunner(string jobName, string jobsTypePath, IEnvironment environment,
+        protected BaseJobRunner(JobBase job, string jobsTypePath, IEnvironment environment,
             IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
         {
             TraceFactory = traceFactory;
             Environment = environment;
             Settings = settings;
-            JobName = jobName;
+            JobName = job.Name;
             _analytics = analytics;
 
-            JobBinariesPath = Path.Combine(Environment.JobsBinariesPath, jobsTypePath, jobName);
-            JobTempPath = Path.Combine(Environment.TempPath, Constants.JobsPath, jobsTypePath, jobName);
-            JobDataPath = Path.Combine(Environment.DataPath, Constants.JobsPath, jobsTypePath, jobName);
+            JobBinariesPath = job.JobBinariesRootPath;
+            JobTempPath = Path.Combine(Environment.TempPath, Constants.JobsPath, jobsTypePath, JobName);
+            JobDataPath = Path.Combine(Environment.DataPath, Constants.JobsPath, jobsTypePath, JobName);
 
             _externalCommandFactory = new ExternalCommandFactory(Environment, Settings, Environment.RepositoryPath);
         }

--- a/Kudu.Core/Jobs/ContinuousJobRunner.cs
+++ b/Kudu.Core/Jobs/ContinuousJobRunner.cs
@@ -29,7 +29,7 @@ namespace Kudu.Core.Jobs
         private bool? _isSingleton;
 
         public ContinuousJobRunner(ContinuousJob continuousJob, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
-            : base(continuousJob.Name, Constants.ContinuousPath, environment, settings, traceFactory, analytics)
+            : base(continuousJob, Constants.ContinuousPath, environment, settings, traceFactory, analytics)
         {
             _analytics = analytics;
             _continuousJobLogger = new ContinuousJobLogger(continuousJob.Name, Environment, TraceFactory);

--- a/Kudu.Core/Jobs/TriggeredJobRunner.cs
+++ b/Kudu.Core/Jobs/TriggeredJobRunner.cs
@@ -15,8 +15,8 @@ namespace Kudu.Core.Jobs
         private ManualResetEvent _currentRunningJobWaitHandle;
         private readonly LockFile _lockFile;
 
-        public TriggeredJobRunner(string jobName, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
-            : base(jobName, Constants.TriggeredPath, environment, settings, traceFactory, analytics)
+        public TriggeredJobRunner(TriggeredJob job, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, IAnalytics analytics)
+            : base(job, Constants.TriggeredPath, environment, settings, traceFactory, analytics)
         {
             _lockFile = BuildTriggeredJobRunnerLockFile(JobDataPath, TraceFactory);
         }

--- a/Kudu.Core/Jobs/TriggeredJobsManager.cs
+++ b/Kudu.Core/Jobs/TriggeredJobsManager.cs
@@ -240,7 +240,7 @@ namespace Kudu.Core.Jobs
             TriggeredJobRunner triggeredJobRunner =
                 _triggeredJobRunners.GetOrAdd(
                     jobName,
-                    _ => new TriggeredJobRunner(triggeredJob.Name, Environment, Settings, TraceFactory, Analytics));
+                    _ => new TriggeredJobRunner(triggeredJob, Environment, Settings, TraceFactory, Analytics));
 
             JobSettings jobSettings = triggeredJob.Settings;
 


### PR DESCRIPTION
Currently it computes it itself from Environment, breaking encapsulation. This is a small step to be able to have multiple folders.