### PR TITLE
Make ZipDeploy test cases also run RunFromZip tests

### DIFF
--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -210,6 +210,8 @@ namespace Kudu.TestHarness
             set;
         }
 
+        public bool IsAzure { get; } = false;
+
         public string GetCustomGitUrl(string path)
         {
             // Return a custom git url, e.g. http://kuduservice/git/foo/bar


### PR DESCRIPTION
I'm not sure what is the right thing to do with tests here. 

ZipDeploy test cases target the CI machine as well, but Run-From-Zip has to be Azure only. 

ApplicationManager is a different object. It's `ApplicationManager.cs` and `ApplicationManager.Private.cs`. So was thinking each can have an `IsAzure` flag? I can't find any other place in the test code that does something like that. Do you know?
