### PR TITLE
Fixed clippy img in IE

### DIFF
--- a/Kudu.Web/Content/Site.css
+++ b/Kudu.Web/Content/Site.css
@@ -114,4 +114,5 @@ a.site-item {
 
 .btn-clipboard img {
   max-width: 13px;
+  max-height: 13px;
 }


### PR DESCRIPTION
Without max height clippy image has height of over 100px in IE

![image](https://user-images.githubusercontent.com/11884348/38247785-b202e058-3746-11e8-922f-cabc74b3d265.png)
