### PR TITLE
Durable Functions - Support storage connection string in host.json

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -120,6 +120,7 @@ namespace Kudu
         public const string DynamicSku = "Dynamic";
         public const string AzureWebJobsSecretStorageType = "AzureWebJobsSecretStorageType";
         public const string HubName = "HubName";
+        public const string DurableTaskStorageConnection = "connection";
         public const string DurableTask = "durableTask";
         public const string SitePackages = "SitePackages";
         public const string SiteVersionTxt = "siteversion.txt";


### PR DESCRIPTION
Adding support for reading storage connection string from host.json. Customers of Durable Function can now configure their Durable Functions to use a separate storage connection string for better perf. Sample configuration is as follows, where **OrchestrationConnection** is an app setting:

```
{
    "durableTask" : {
        "connection" : "OrchestrationConnection"
    }
}
```