### PR TITLE
Durable Functions: Modified storage connection name

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -121,6 +121,7 @@ namespace Kudu
         public const string AzureWebJobsSecretStorageType = "AzureWebJobsSecretStorageType";
         public const string HubName = "HubName";
         public const string DurableTaskStorageConnection = "connection";
+        public const string DurableTaskStorageConnectionName = "azureStorageConnectionStringName";
         public const string DurableTask = "durableTask";
         public const string SitePackages = "SitePackages";
         public const string SiteVersionTxt = "siteversion.txt";

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -354,7 +354,7 @@ namespace Kudu.Core.Helpers
                     config.Add(Constants.HubName, nameValue.ToString());
                 }
 
-                if (kvp.TryGetValue(Constants.DurableTaskStorageConnection, StringComparison.OrdinalIgnoreCase, out nameValue) && nameValue != null)
+                if (kvp.TryGetValue(Constants.DurableTaskStorageConnectionName, StringComparison.OrdinalIgnoreCase, out nameValue) && nameValue != null)
                 {
                     config.Add(Constants.DurableTaskStorageConnection, nameValue.ToString());
                 }


### PR DESCRIPTION
Existing Durable Functions customer is using the following name for the storage connection string property. This change is to ensure that adding support for reading the connection string does not break existing customers.

```
{
    "durableTask" : {
        "azureStorageConnectionStringName" : "OrchestrationConnection"
    }
}
```