### PR TITLE
Don't include nuget.org when using custom feed

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -211,9 +211,10 @@ namespace Kudu.Contracts.Settings
             return defaultValue;
         }
 
-        public static string GetSiteExtensionRemoteUrl(this IDeploymentSettingsManager settings)
+        public static string GetSiteExtensionRemoteUrl(this IDeploymentSettingsManager settings, out bool isDefault)
         {
             string value = settings.GetValue(SettingsKeys.SiteExtensionsFeedUrl);
+            isDefault = String.IsNullOrEmpty(value);
             return !String.IsNullOrEmpty(value) ? value : DefaultSiteExtensionFeedUrl;
         }
 

--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -758,8 +758,15 @@ namespace Kudu.Core.SiteExtensions
             }
             else
             {
-                repos.Add(GetSourceRepository(DeploymentSettingsExtension.NuGetSiteExtensionFeedUrl));
-                repos.Add(GetSourceRepository(_settings.GetSiteExtensionRemoteUrl()));
+                // The remote feed URL can either be the default siteextensions.net, or some user override via
+                // SCM_SITEEXTENSIONS_FEED_URL. We only want to add nuget.org to the list if the user
+                // is *not* overriding the feed URL
+                string remoteUrl = _settings.GetSiteExtensionRemoteUrl(out bool isDefault);
+                if (isDefault)
+                {
+                    repos.Add(GetSourceRepository(DeploymentSettingsExtension.NuGetSiteExtensionFeedUrl));
+                }
+                repos.Add(GetSourceRepository(remoteUrl));
             }
             return repos;
         }


### PR DESCRIPTION
This fixes a regression from when we didn't use nuget.org.