### PR TITLE
add detection for core 2.1 project, fixes #2757

### DIFF
--- a/Kudu.Core/Infrastructure/AspNetCoreHelper.cs
+++ b/Kudu.Core/Infrastructure/AspNetCoreHelper.cs
@@ -55,6 +55,7 @@ namespace Kudu.Core.Infrastructure
                 return !projectTypeGuids.Any() &&
                        (VsHelper.IncludesReferencePackage(projectPath, "Microsoft.AspNetCore") ||
                         VsHelper.IncludesReferencePackage(projectPath, "Microsoft.AspNetCore.All") ||
+                        VsHelper.IncludesReferencePackage(projectPath, "Microsoft.AspNetCore.App") ||
                         IsWebAppFromFolderStruct(projectPath));
             }
             else if (projectPath.EndsWith(".xproj", StringComparison.OrdinalIgnoreCase))

--- a/Kudu.Core/Infrastructure/AspNetCoreHelper.cs
+++ b/Kudu.Core/Infrastructure/AspNetCoreHelper.cs
@@ -51,12 +51,14 @@ namespace Kudu.Core.Infrastructure
                 // 2ndly, look for sign of web project
                 // either <PackageReference Include="Microsoft.AspNetCore" Version="..." />
                 // for dotnet core project created with 2.0 toolings look for "Microsoft.AspNetCore.All"
+                // for dotnet core project created with 2.1 toolings look for "Microsoft.AspNetCore.App"
                 // for preview3 its web.config file
                 return !projectTypeGuids.Any() &&
-                       (VsHelper.IncludesReferencePackage(projectPath, "Microsoft.AspNetCore") ||
-                        VsHelper.IncludesReferencePackage(projectPath, "Microsoft.AspNetCore.All") ||
-                        VsHelper.IncludesReferencePackage(projectPath, "Microsoft.AspNetCore.App") ||
-                        IsWebAppFromFolderStruct(projectPath));
+                       (VsHelper.IncludesAnyReferencePackage(projectPath,
+                       "Microsoft.AspNetCore",
+                       "Microsoft.AspNetCore.All",
+                       "Microsoft.AspNetCore.App") ||
+                       IsWebAppFromFolderStruct(projectPath));
             }
             else if (projectPath.EndsWith(".xproj", StringComparison.OrdinalIgnoreCase))
             {

--- a/Kudu.Core/Infrastructure/FunctionAppHelper.cs
+++ b/Kudu.Core/Infrastructure/FunctionAppHelper.cs
@@ -9,7 +9,7 @@
 
         public static bool IsCSharpFunctionFromProjectFile(string projectPath)
         {
-            return VsHelper.IncludesReferencePackage(projectPath, "Microsoft.NET.Sdk.Functions");
+            return VsHelper.IncludesAnyReferencePackage(projectPath, "Microsoft.NET.Sdk.Functions");
         }
 
     }

--- a/Kudu.Core/Infrastructure/VsHelper.cs
+++ b/Kudu.Core/Infrastructure/VsHelper.cs
@@ -83,11 +83,12 @@ namespace Kudu.Core.Infrastructure
             return guids;
         }
 
-        public static bool IncludesReferencePackage(string path, string packageName)
+        // takes mulitple package names, return true if at least one is presented
+        public static bool IncludesAnyReferencePackage(string path, params string[] packageNames)
         {
             var packages = from packageReferences in XDocument.Load(path).Descendants("PackageReference")
                            let packageReferenceName = packageReferences.Attribute("Include")
-                           where packageReferenceName != null && String.Equals(packageReferenceName.Value, packageName, StringComparison.OrdinalIgnoreCase)
+                           where packageReferenceName != null && packageNames.Contains(packageReferenceName.Value, StringComparer.OrdinalIgnoreCase)
                            select packageReferenceName.Value;
 
             return packages.Any();


### PR DESCRIPTION
currently it does not break for all scenarios, for example: https://github.com/dotnet/cli/issues/8745
but it will break when user create a webapi app (where we cannot find `/wwwroot` folder or `web.config`)

I manually tested it, for automated deployment test...its easier to wait for 2.1 sdk, otherwise I need to setup site extension as test context
