### PR TITLE
fail deployment when function version mismatch

### DIFF
--- a/Kudu.Core/Deployment/Generator/FunctionMsbuildBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/FunctionMsbuildBuilder.cs
@@ -1,12 +1,15 @@
 ﻿using Kudu.Contracts.Settings;
+using Kudu.Core.Infrastructure;
 
 namespace Kudu.Core.Deployment.Generator
 {
     class FunctionMsbuildBuilder : MicrosoftSiteBuilder
     {
+        // we want to fail early (before running msbuild) if the deployment environment mismatch with the target framework
         public FunctionMsbuildBuilder(IEnvironment environment, IDeploymentSettingsManager settings, IBuildPropertyProvider propertyProvider, string sourcePath, string projectFilePath, string solutionPath)
             : base(environment, settings, propertyProvider, sourcePath, projectFilePath, solutionPath, "--functionApp")
         {
+            FunctionAppHelper.ThrowsIfVersionMismatch(projectFilePath);
         }
 
         public override string ProjectType

--- a/Kudu.Core/Infrastructure/FunctionAppHelper.cs
+++ b/Kudu.Core/Infrastructure/FunctionAppHelper.cs
@@ -1,4 +1,7 @@
-﻿namespace Kudu.Core.Infrastructure
+﻿using System;
+using System.Linq;
+
+namespace Kudu.Core.Infrastructure
 {
     internal static class FunctionAppHelper
     {
@@ -12,5 +15,33 @@
             return VsHelper.IncludesAnyReferencePackage(projectPath, "Microsoft.NET.Sdk.Functions");
         }
 
+        public static void ThrowsIfVersionMismatch(string projectPath)
+        {
+            // "<AzureFunctionsVersion>v2</AzureFunctionsVersion>" exists in v2 csproj
+            var properties = VsHelper.GetPropertyValues(projectPath, "AzureFunctionsVersion", VsHelper.Csproj.newFormat);
+            var projectMajorVersion = String.Equals(properties.FirstOrDefault(), "v2", StringComparison.OrdinalIgnoreCase) ? FuncVersion.V2 : FuncVersion.V1;
+            var runtimeMajorVersion = GetFunctionRuntimeMajorVersion();
+
+            if (runtimeMajorVersion == projectMajorVersion)
+            {
+                // check succeeded
+                return;
+            }
+
+            throw new InvalidOperationException($@"Your function app is targeting {projectMajorVersion}, but Azure host has function version {runtimeMajorVersion}, 
+please change the version using the portal or update your 'FUNCTIONS_EXTENSION_VERSION' appsetting and retry");
+        }
+
+        public static FuncVersion GetFunctionRuntimeMajorVersion()
+        {
+            // startswith "1." or is "~1" => function v1
+            // else => function v2
+            var environmentValue = System.Environment.GetEnvironmentVariable(Constants.FunctionRunTimeVersion);
+            return (environmentValue.StartsWith("1.", StringComparison.OrdinalIgnoreCase)
+                || String.Equals(environmentValue, "~1", StringComparison.OrdinalIgnoreCase))
+                ? FuncVersion.V1 : FuncVersion.V2;
+        }
+
+        public enum FuncVersion { V1, V2 };
     }
 }

--- a/Kudu.Core/Infrastructure/VsHelper.cs
+++ b/Kudu.Core/Infrastructure/VsHelper.cs
@@ -73,12 +73,11 @@ namespace Kudu.Core.Infrastructure
 
         public static IEnumerable<Guid> GetProjectTypeGuids(string path)
         {
-            var document = XDocument.Parse(File.ReadAllText(path));
+            // only exist in old csprojs
+            var projectTypeGuids = GetPropertyValues(path, "ProjectTypeGuids", Csproj.oldFormat);
 
-            var guids = from propertyGroup in document.Root.Elements(GetName("PropertyGroup"))
-                        let projectTypeGuids = propertyGroup.Element(GetName("ProjectTypeGuids"))
-                        where projectTypeGuids != null
-                        from guid in projectTypeGuids.Value.Split(';')
+            var guids = from value in projectTypeGuids
+                        from guid in value.Split(';')
                         select new Guid(guid.Trim('{', '}'));
             return guids;
         }
@@ -94,49 +93,43 @@ namespace Kudu.Core.Infrastructure
             return packages.Any();
         }
 
-        public static bool IsExecutableProject(string projectPath)
-        {
-            var document = XDocument.Parse(File.ReadAllText(projectPath));
-
-            var root = document.Root;
-            if (root == null)
-            {
-                return false;
-            }
-
-            var outputTypes = from propertyGroup in root.Elements(GetName("PropertyGroup"))
-                              let outputType = propertyGroup.Element(GetName("OutputType"))
-                              where outputType != null && String.Equals(outputType.Value, "exe", StringComparison.OrdinalIgnoreCase)
-                              select outputType.Value;
-
-            if (!outputTypes.Any())
-            {
-                // new csproj does not have a namespace:http://schemas.microsoft.com/developer/msbuild/2003
-                outputTypes = from propertyGroup in root.Elements(XName.Get("PropertyGroup"))
-                              let outputType = propertyGroup.Element(XName.Get("OutputType"))
-                              where outputType != null && String.Equals(outputType.Value, "exe", StringComparison.OrdinalIgnoreCase)
-                              select outputType.Value;
-            }
-
-            return outputTypes.Any();
-        }
-
-        public static string GetProjectExecutableName(string path)
+        public static IEnumerable<string> GetPropertyValues(string path, string propertyName, Csproj projectFormat)
         {
             var document = XDocument.Parse(File.ReadAllText(path));
+            IEnumerable<string> propertyValues = Enumerable.Empty<string>();
 
             var root = document.Root;
             if (root == null)
             {
-                return null;
+                return propertyValues;
             }
 
-            var assemblyNames = from propertyGroup in root.Elements(GetName("PropertyGroup"))
-                                let assemblyName = propertyGroup.Element(GetName("AssemblyName"))
-                                where assemblyName != null
-                                select assemblyName.Value;
+            if (((int)projectFormat & 1) != 0)
+            {
+                propertyValues = from propertyGroup in document.Root.Elements(GetName("PropertyGroup"))
+                                 let property = propertyGroup.Element(GetName(propertyName))
+                                 where property != null
+                                 select property.Value;
 
-            return assemblyNames.FirstOrDefault();
+            }
+            // if found already, we can return
+            // else if the property possibly exists in the new csproj, we run query without namespace
+            if (!propertyValues.Any() && ((int)projectFormat & 2) != 0)
+            {
+                // new csproj does not have a namespace:http://schemas.microsoft.com/developer/msbuild/2003
+                propertyValues = from propertyGroup in root.Elements(GetName("PropertyGroup"))
+                                 let property = propertyGroup.Element(XName.Get(propertyName))
+                                 where property != null
+                                 select property.Value;
+            }
+
+            return propertyValues;
+        }
+
+        public static bool IsExecutableProject(string projectPath)
+        {
+            var outputTypes = GetPropertyValues(projectPath, "OutputType", Csproj.bothFormat);
+            return outputTypes.Contains("exe", StringComparer.OrdinalIgnoreCase);
         }
 
         private static bool ExistsInSolution(VsSolution solution, string targetPath)
@@ -150,5 +143,8 @@ namespace Kudu.Core.Infrastructure
         {
             return XName.Get(name, "http://schemas.microsoft.com/developer/msbuild/2003");
         }
+
+        // 01, 10, 11 in binares
+        public enum Csproj { oldFormat = 1, newFormat, bothFormat }
     }
 }


### PR DESCRIPTION
new behavior compared to vsdeploy:
![image](https://user-images.githubusercontent.com/6531400/39729689-16b3fc0e-5212-11e8-8f04-f208aa9bc63a.png)
![image](https://user-images.githubusercontent.com/6531400/39729678-098e8e4a-5212-11e8-866e-e984aff0356a.png)

this PR is still in progress:
1. add deployment tests
2. currently, if user updated appsettings and do a `git push`, they will see `"Everything up-to-date"` instead of a rebuild of their function app...this is because kudu logic is only triggered when there's a change in repository, not in appsettings