### PR TITLE
Supporting Docker CI webhook for Windows Containers

### DIFF
--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -234,10 +234,10 @@ namespace Kudu.Core.Deployment
                     // Perform the build deployment of this changeset
                     await Build(changeSet, tracer, deployStep, repository, deploymentInfo, deploymentAnalytics, fullBuildByDefault);
 
-                    if (!OSDetector.IsOnWindows() && _settings.RestartAppContainerOnGitDeploy())
+                    if (!(OSDetector.IsOnWindows() && !EnvironmentHelper.IsWindowsContainers()) && _settings.RestartAppContainerOnGitDeploy())
                     {
                         logger.Log(Resources.Log_TriggeringContainerRestart);
-                        LinuxContainerRestartTrigger.RequestContainerRestart(_environment, RestartTriggerReason);
+                        DockerContainerRestartTrigger.RequestContainerRestart(_environment, RestartTriggerReason);
                     }
                 }
                 catch (Exception ex)

--- a/Kudu.Core/Helpers/EnvironmentHelper.cs
+++ b/Kudu.Core/Helpers/EnvironmentHelper.cs
@@ -23,5 +23,19 @@ namespace Kudu.Core.Helpers
 
             return binPath;
         }
+
+        // Is this a Windows Containers site?
+        public static bool IsWindowsContainers()
+        {
+            string xenon = System.Environment.GetEnvironmentVariable("XENON");
+            int parsedXenon = 0;
+            bool isXenon = false;
+            if (int.TryParse(xenon, out parsedXenon))
+            {
+                isXenon = (parsedXenon == 1);
+            }
+
+            return isXenon;
+        }
     }
 }

--- a/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
@@ -5,11 +5,11 @@ using Kudu.Core.Helpers;
 
 namespace Kudu.Core.Infrastructure
 {
-    // Utility for touching the restart trigger file on Linux, which will restart the
+    // Utility for touching the restart trigger file on Linux and Windows Containers, which will restart the
     // site container.
     // Contents of the trigger file are irrelevant but this leaves a small explanation for
     // users who stumble on it.
-    public static class LinuxContainerRestartTrigger
+    public static class DockerContainerRestartTrigger
     {
         private const string CONFIG_DIR_NAME = "config";
         private const string TRIGGER_FILENAME = "restartTrigger.txt";
@@ -22,9 +22,9 @@ namespace Kudu.Core.Infrastructure
 
         public static void RequestContainerRestart(IEnvironment environment, string reason)
         {
-            if (OSDetector.IsOnWindows())
+            if (OSDetector.IsOnWindows() && !EnvironmentHelper.IsWindowsContainers())
             {
-                throw new NotSupportedException("RequestContainerRestart not supported on Windows");
+                throw new NotSupportedException("RequestContainerRestart is only supported on Linux and Windows Containers");
             }
 
             var restartTriggerPath = Path.Combine(environment.SiteRootPath, CONFIG_DIR_NAME, TRIGGER_FILENAME);

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -258,7 +258,7 @@
     <Compile Include="Infrastructure\IFileSystemWatcher.cs" />
     <Compile Include="Infrastructure\InstanceIdUtility.cs" />
     <Compile Include="Infrastructure\IServerConfiguration.cs" />
-    <Compile Include="Infrastructure\LinuxContainerRestartTrigger.cs" />
+    <Compile Include="Infrastructure\DockerContainerRestartTrigger.cs" />
     <Compile Include="Infrastructure\NaiveFileSystemWatcher.cs" />
     <Compile Include="Infrastructure\SecurityUtility.cs" />
     <Compile Include="Infrastructure\PathUtils\PathLinuxUtility.cs" />

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -570,7 +570,7 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRoute("download-functions", "api/functions/admin/download", new { controller = "Function", action = "DownloadFunctions" }, new { verb = new HttpMethodConstraint("GET") });
 
             // Docker Hook Endpoint
-            if (!OSDetector.IsOnWindows())
+            if (!OSDetector.IsOnWindows() || (OSDetector.IsOnWindows() && EnvironmentHelper.IsWindowsContainers()))
             {
                 routes.MapHttpRoute("docker", "docker/hook", new { controller = "Docker", action = "ReceiveHook" }, new { verb = new HttpMethodConstraint("POST") });
             }

--- a/Kudu.Services/Docker/DockerController.cs
+++ b/Kudu.Services/Docker/DockerController.cs
@@ -27,7 +27,7 @@ namespace Kudu.Services.Docker
         [HttpPost]
         public HttpResponseMessage ReceiveHook()
         {
-            if (OSDetector.IsOnWindows())
+            if (OSDetector.IsOnWindows() && !EnvironmentHelper.IsWindowsContainers())
             {
                 return Request.CreateResponse(HttpStatusCode.NotFound);
             }
@@ -39,7 +39,7 @@ namespace Kudu.Services.Docker
                 {
                     if (_settings.IsDockerCiEnabled())
                     {
-                        LinuxContainerRestartTrigger.RequestContainerRestart(_environment, RESTART_REASON);
+                        DockerContainerRestartTrigger.RequestContainerRestart(_environment, RESTART_REASON);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
Leveraging what already exists for App Service for Linux to allow Docker continuous integration for the upcoming Azure App Service Windows Containers.