### PR TITLE
Enabling Docker logs APIs for Windows Containers.

### DIFF
--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -492,7 +492,8 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHandlerDual<LogStreamHandler>(kernel, "logstream", "logstream/{*path}");
             routes.MapHttpRoute("recent-logs", "api/logs/recent", new { controller = "Diagnostics", action = "GetRecentLogs" }, new { verb = new HttpMethodConstraint("GET") });
 
-            if (!OSDetector.IsOnWindows())
+            // Enable these for Linux and Windows Containers.
+            if (!OSDetector.IsOnWindows() || (OSDetector.IsOnWindows() && EnvironmentHelper.IsWindowsContainers()))
             {
                 routes.MapHttpRoute("current-docker-logs-zip", "api/logs/docker/zip", new { controller = "Diagnostics", action = "GetDockerLogsZip" }, new { verb = new HttpMethodConstraint("GET") });
                 routes.MapHttpRoute("current-docker-logs", "api/logs/docker", new { controller = "Diagnostics", action = "GetDockerLogs" }, new { verb = new HttpMethodConstraint("GET") });

--- a/Kudu.Services/Diagnostics/DiagnosticsController.cs
+++ b/Kudu.Services/Diagnostics/DiagnosticsController.cs
@@ -87,7 +87,7 @@ namespace Kudu.Services.Performance
         {
             using (_tracer.Step("DiagnosticsController.GetDockerLogs"))
             {
-                var currentDockerLogFilenames = GetCurrentDockerLogFilenames();
+                var currentDockerLogFilenames = GetCurrentDockerLogFilenames(SearchOption.TopDirectoryOnly);
 
                 var vfsBaseAddress = UriHelper.MakeRelative(UriHelper.GetBaseUri(request), "api/vfs");
 
@@ -118,7 +118,9 @@ namespace Kudu.Services.Performance
         {
             using (_tracer.Step("DiagnosticsController.GetDockerLogsZip"))
             {
-                var currentDockerLogFilenames = GetCurrentDockerLogFilenames();
+                // Also search for "today's" files in sub folders. Windows containers archives log files
+                // when they reach a certain size.
+                var currentDockerLogFilenames = GetCurrentDockerLogFilenames(SearchOption.AllDirectories);
 
                 HttpResponseMessage response = Request.CreateResponse();
                 response.Content = ZipStreamContent.Create(String.Format("dockerlogs-{0:MM-dd-HH-mm-ss}.zip", DateTime.UtcNow), _tracer, zip =>
@@ -132,11 +134,11 @@ namespace Kudu.Services.Performance
             }
         }
 
-        private string[] GetCurrentDockerLogFilenames()
+        private string[] GetCurrentDockerLogFilenames(SearchOption searchOption)
         {
             // Get all non-rolled Docker log filenames from the LogFiles directory
             var nonRolledDockerLogFilenames =
-                FileSystemHelpers.ListFiles(_environment.LogFilesPath, SearchOption.TopDirectoryOnly, new[] { "*" })
+                FileSystemHelpers.ListFiles(_environment.LogFilesPath, searchOption, new[] { "*" })
                 .Where(f => NONROLLED_DOCKER_LOG_FILENAME_REGEX.IsMatch(Path.GetFileName(f)))
                 .ToArray();
 


### PR DESCRIPTION
NOTE: Since Windows Containers archives log files after their a certain size, the "api/logs/docker/zip" also searches for "today's" logs in sub folders.

@suwatch, @jvano, @JennyLawrance, @EricSten-MSFT @rramachand21