### PR TITLE
Deprecating Support Portal and created a Landing page

### DIFF
--- a/Kudu.Services.Web/Support/Default.cshtml
+++ b/Kudu.Services.Web/Support/Default.cshtml
@@ -1,33 +1,194 @@
-﻿@using System.Configuration
-
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="EN">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Azure Websites Support</title>
-        <style type="text/css">
-            html {
-                overflow: auto;
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Azure Websites Support</title>
+    <style type="text/css">
+        html {
+            font-size: 100%;
+            overflow-y: scroll;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+
+        body {
+            margin: 0;
+            line-height: 1.231;
+            font-family: sans-serif;
+            color: #222;
+            background: #525252;
+            margin: 0;
+            padding: 0;
+            text-rendering: optimizeLegibility;
+            font-family: wf_segoe-ui_normal,"Segoe UI","Segoe WP",Tahoma,Arial,sans-serif;
+            font-weight: 400;
+            font-size: 14px;
+            line-height: 1.5em;
+            color: #505050;
+        }
+
+
+        a {
+            color: #00abec;
+            text-decoration: none;
+            -webkit-transition: all .1s ease-in-out;
+            transition: all .1s ease-in-out;
+        }
+
+            a:active, a:hover {
+                color: #0072c6;
+                text-decoration: none;
+                -webkit-transition: all .1s ease-in-out;
+                transition: all .1s ease-in-out;
             }
-            html, body, div, iframe {
-                margin: 0;
-                padding: 0;
-                height: 100%;
-                border: none;
+
+        header {
+            background-color: #1a1a1a;
+            color: #fff;
+            display: block;
+            margin-left: -90px;
+            padding: 23px 0 0 0;
+            position: fixed;
+            top: 0;
+            width: 960px;
+            z-index: 9999;
+        }
+
+            header .wa-content {
+                background-color: #1a1a1a;
+                padding-left: 40px;
+                position: relative;
+                width: 780px;
             }
-            iframe {
+
+
+            header .logo-1 {
                 display: block;
-                width: 100%;
-                border: none;
-                overflow-y: auto;
-                overflow-x: hidden;
+                float: left;
+                height: 30px;
+                width: 400px;
+                font-size: 28px;
+                font-weight: 400;
             }
-        </style>
-    </head>
-    <body>
-        <iframe id="tree" name="tree"
-                src=@("https://mawssupport.trafficmanager.net/?SiteName=" + @Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"))
-                marginheight="0" marginwidth="0" width="100%" height="100%" scrolling="auto">
-        </iframe>
-    </body>
+
+        footer {
+            background-color: #1a1a1a;
+            margin: 0 -90px;
+        }
+
+
+        .footer-bottom {
+            border-top: 1px solid #6a6a6a;
+            clear: both;
+            color: #fff;
+            min-height: 62px;
+            padding: 0 190px 10px 0;
+            position: relative;
+        }
+
+            .footer-bottom a {
+                color: #fff;
+            }
+
+            .footer-bottom ul {
+                float: left;
+                margin: 20px 0 0 90px;
+                padding: 0;
+                list-style: none;
+            }
+
+                .footer-bottom ul.legal {
+                    font-size: 11px;
+                }
+
+                .footer-bottom ul li {
+                    float: left;
+                    height: 24px;
+                    margin-right: 10px;
+                }
+
+
+
+            .footer-bottom .footer-copyright {
+                position: absolute;
+                right: 90px;
+                top: 20px;
+            }
+
+
+                .footer-bottom .footer-copyright a, .footer-bottom .footer-copyright span {
+                    clear: both;
+                    color: #fff;
+                    float: left;
+                    font-size: 10px;
+                    margin: 0;
+                }
+
+        .wa-container {
+            background-color: #fff;
+            margin: 0 auto;
+            width: 780px;
+            padding-left: 90px;
+            padding-right: 90px;
+            padding-top: 88px;
+        }
+
+        .wa-section {
+            background-color: transparent;
+            display: block;
+            margin: 0 -90px;
+            min-height: 0;
+            overflow: hidden;
+            padding-bottom: 50px;
+            padding-left: 35px;
+            padding-right: 25px;
+            position: relative;
+        }
+    </style>
+</head>
+<body>
+    <div class="wa-container">
+        <header>
+            <div class="wa-content">
+                <a class="logo-1" style="">Azure App Service Support</a>
+            </div>
+        </header>
+
+        <section class="wa-section ">
+            <h2>This portal is deprecated!</h2>
+
+            <div>
+                To run the Diagnostic tools, go to <a href="https://portal.azure.com">Azure Portal</a>, choose your web app and click
+                on <strong>Diagnose and Solve</strong> blade. Under the <strong>Diagnostic Tools</strong> category, you can run the tools based on your technology stack.
+
+                <br />
+                <br />
+                Here is a screenshot:
+            </div>
+            <img style="border:2px solid #0072c6;margin-top:15px" id='base64image'
+                 src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAnUAAACYCAYAAACCsh8hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAACCgSURBVHhe7Z37qy1nmefnj8qAiNjgD4pIREREpTVBUeIgXnAQcSJii1GDl9agji1kVDRRBJnY2kyMth3NhUAf0mMmJmrnpjEniW0udsdjQnQN3zrne/o5z3nWbe9n713rXZ8PfFmr6r08b616q57vqqq1939ZAAAAAMDOg6kDAAAAGABMHQAAAMAAYOoAAAAABgBTBwAAADAAmDoAAACAAcDUAQAAAAwApg4AAABgADB1AAAAAAOAqQMAAAAYAEwdAAAAwABg6gAAAAAGAFMHAAAAMACYOgAAAIABwNQBAAAADACmDgAAAGAAMHUAAAAAA4CpAwAAABgATB0AAADAAJyIqXvyyScXl19++eKSSy45r9e//vWLr33ta1OZ+d3vfrf44Ac/uPjpT396bs3ucJCxV59L1KlTp87VPBju/5prrjm3BgAAAEbhRE3dBz7wgcUdd9yxuO222xZf+tKXFi972csWr33taxf33XffVO+BBx5YvOY1r1l873vfm5bnzPe///3F+973vvOm9CBjf/bZZxd33nnn9JnccMMNi5e+9KWLz372s9Oy9MQTT5yreTAwdQAAAONyoqYumwuZuVe/+tWLq666ajI4u4S2RdtkU3dY7r///sWll146mbsuMHUAAADjMitTJ6699trFG97whsVjjz12kbHRuo9+9KOLl7zkJdPtyLe//e2LBx98cCoTP//5z6d1LvvWt751wW1LG6+f/OQnize+8Y2LF77whdOVsGeeeWYqf/755xc33njjVKZ2unL41a9+dfGnP/1pKpfR/MY3vjGtV/nb3va26YrclVdeOS1bipPH/pe//GVx9913L97xjncsXvCCF0zbcPPNN09lFZWpWzc+xdAVvSuuuOJ8jE9/+tOLp556airPn/vjjz8+3SLW5yB97nOfWzz33HNTGQAAAOwWszN1MjEyMzI12djcddddi29/+9vT82oyarqqJ0N15syZxW9+85vp1u273/3uxT333DOZm8suu2wyP9HUyexcffXVi4ceemjx9a9/fVr+4Q9/OBkixdEtz29+85tTf4olY/TlL395MlSq9+IXv3gyVhqDDJ7G+Ic//GHxyU9+cjJb6lcmMY9dY1BfMqW//OUvp/HptvMycvtNxqc+Vf6FL3xhGsePfvSjqY8Pf/jD02cUP3eZN41Fy7/61a+meDLUqgcAAAC7x1JT9/TTTy/e8pa3XHAFKupDH/rQgW+RHtTUZdRe/ag/PdP28pe/fDJMRj9S0FijqZMRlCESv//97xdvetObpvXe3s985jOTQRIyUvHKYTR1MkUq//Of/zzVjWMRcew2UO95z3smA7gJedvXje/hhx+e9ome6/OVR6Gxyujde++9S02dbntrOyT1CQAAALvHgU2dr5AdhGWmTobi85///OLNb37z9KOAbGxkwvQLWd1efOUrXzmNw0bqi1/84gWmSsjMqU40dbFOHIeubL3qVa+6yEBq2SZTtzm/8pWvTFfHpOuuu+68sV1l6vxZ5u1dRd72deP72c9+VsaIn0HcXvHII49MJlBXK1/3utdNdTB1AAAAu8nK26+64iMjUOkwt+nUPpoL84tf/GIyKLq9KHMRjY3GIgPy3ve+dzI4uuKlZ8BspL7zne9MddXG6CrVpqZu1ZUwm0wjc6cxvuhFL1rceuut07rcdxy7jF91FW0V2dStG5+uJC67UufPZdnnrmfr9EtkXbXUewAAANg9TvSZuvgnTWTQ9LD+Rz7ykfOmJBobmxqZlt/+9rdTG91KtZHSbVfdfn3/+98/3WrUjyF09WlTUyeD5Ktwfmbtu9/97rSs9Sr/8Y9/vLj99tundjJLKrOp05VCjVW3fPVnSbIpu+mmmyYT+LGPfezAz9StG59j+Jk6fQbx18Rxe2XKr7/++qmeng/81Kc+hakDAADYYU7U1MlwSTJz+lWoDJOfURPR2Mi0/OAHP1i84hWvmOrLRH3iE584b9JULpMkI6dymRQ9A6dbizJZYpWpEzI+MkoyQhqXXrXsW6w2ki7T36DzVTP9Cvetb33rFE9Xz7Ip03bphwv+5arab2PqxLrxKYZMZvx1rAzfH//4x6k8bq+eqdMPLGQKNWZ9/vr1MAAAAOwmJ2LqjgOZPD3zpufQdDUKAAAAYGSGMXW6PasrZPqzJ6dPn55uUeoqlK7Y+WoaAAAAwKgMY+r0HF78w8T6dWy89QgAAAAwMsPefgUAAADYJzB1AAAAAAOw0tTpT7MhhBBCCKH5iyt1AAAAAAOAqQMAAAAYAEwdAAAAwABg6gAAAAAGAFMHAAAAMACYOgAAAIABwNQBAAAADACmDgAAAGAAMHUAAAAAA4CpAwAAABiAYzd1t179D4tr/+qqxZf+64fQANK+1D49KpgvY4n5grYR8wVto6OeL7vAsZo6fdjVjkC7r6M4kJgv44r5grYR8wVto6OYL7vCsZo6vhGNK+3bbpgv44r5grYR8wVto6OYL7vCsZq66sNH46ibKgYaR91UMdA46qaKgcbRvoKpQ23qpoqBxlE3VQw0jrqpYqBxtK9g6lCbuqlioHHUTRUDjaNuqhhoHO0rmDrUpm6qGGgcdVPFQOOomyoGGkf7CqYOtambKgYaR91UMdA46qaKgcbRvoKpQ23qpoqBxlE3VQw0jrqpYqBxtK9g6lCbuqlioHHUTRUDjaNuqhhoHO0rmDrUpm6qGHPUE/c9fm7EZ9FyVS/rHz/4ncWZJ59ZnPryP03LD99x38ZtR1A3VYw5657/fercyM/y3DN/mubE3/+3ryz+47Gnp/Kq3UGV59uuqZsqBhpH+wqmDrWpmyrGnKQkqUScjdjpf3loKovrKh2FqVNf6nOT+CetbqoYc5X2s02c18nESZi6Wt1UMdA42lcwdahN3VQx5iInXhmxqnwTYep6qWLMUdrPmjuaQ1U5pq5WN1UMNI72FUwdalM3VYy5aFPzpMQciaZtnamLbf/83PMXJWPVNbrq88ipB88tneWwBvGo1U0VY27axLC5zoM33zvtV5H3v+uYvK/zvNNynm+us2osc1I3VQw0jvYVTB1qUzdVjLlIiXDV1RZJdWIydiL21b1Vpk5t4+25HE/1YiL/1xvvmuqqr03M5hzUTRVjbsr7vJLnSdz/2tfe/3keednmLM8dxbrrutsviJ3n5i6omyoGGkf7CqYOtambKsZclE1WJSViJ14rtssJPpq63Fb1n374iamutMy4rSqbm7qpYsxNeZ9XyiZNivu12seqqzlTtbUc21cAV41hjuqmioHG0b6CqUNt6qaKMRetM0/Lkmts5yTr5GpT57YV6k+yMYx95/5z2dzUTRVjblpluqyqTtyvWl+hNnf+r59eMKei1Na3c1fFn6u6qWKgcbSvYOpQm7qpYsxFmyTn6kqdkq2uuKn9MlPntsv6XmXcVpXNTd1UMeaouJ8rrTN1cQ7FdtKqeen5pit1uvW6a8aumyoGGkf7CqYOtambKsacpKQosnHznzRRedczdVHuJxoDnqnbnfOL9o32rfZhNGba51JlzOJ+zfMoS+vXPVMn7Zqx66aKgcbRvoKpQ23qpooxNzlBR2KyVdKMxLKYZLUcTZ2XI9EEOLGbWKY+xKqrQXNQN1WMOcv7yXgfet8uM3VaruZdrB/njr9Y5PnmuTn3eWJ1U8VA42hfGdLU5ZPlpietfDLNSfY4pHjVr9LyCVmvqhfR2G//zI3Ta4WTRuy3U91UMdA46qaKgcZRN1WMOeqg+Wzdl8bRta8MZer87TVP3E3/wv9RmLp8YK2T4p156pmL4lamTsurtmvb2IdVN1UMNI66qWKgcdRNFWNO0vn7MPksn/878tkmeWcu2leGMXU2ZJq4Vfkmmoup+909j0wHc7ydkvvZ5ODaNvZh1U0VA42jbqoYaBx1U8WYizryWT7/Y+r2g2FM3aaTTeXxWRS9d5t1pi63zQec6hrVe+DH91xwi1R9K0Zsk6U+1K/GEMem13iAbrK9uc1Rq5sqBhpH3VQx0DjqpooxF22az5QnIjlfxfN/zmexbfXIT85n+/4fa3aFYUydJug606RJrskZzZjeu90qU+e2LssHjOrFSe5fI+Z666Q+PL7YZ+5Hr/mZurhdVZujVjdVDDSOuqlioHHUTRVjLtokn6lONGPOX84D+fwf85naxosGOV7MPRK/rt8d9srUVXXixPdBoXoqywdBbqtyadVEj/3nskqKVx2UuZ9VMa1tYx9W3VQx0DjqpoqBxlE3VYy5aJN8FnOFFdvl83/MZ7mt6vMfa8Zgr26/xkltRSMX3+f6el+h8lUH4LbGKh9seq++b/vU/7mgn022d9vYh1U3VQw0jrqpYqBx1E0VYy5ad37PucqK7fL53/nMbSvU36p8tknemYv2leF+KJEneVQ1WfXe31ByH9HUaZ3fZ62a6PnAWqds6jwm/Xgi9rPJwbVt7MOqmyoGGkfdVDHQOOqmijEXbZLPcq6QdK7nP9ac1b4yjKmTNElFnuj+CbjU9UxdlNu5rrTpM3Var35dvuxA1bMT8fkJva47uNbF7lY3VQw0jrqpYqBx1E0VY05al89U3vVMXdSqfLZJ3pmL9pWhTJ2kyabJGokHRS63oVPZKlMnaULHHydUB5SJ/aqfvC72uc7USVqXTV0ci8gHqd5j6tBc1U0VA42jbqoYc9O6fGbjZ2JZPv+rLOYzLUeqXGhimfoQsa85al8ZztShk1M3VYyTkk5g2TRH+eTqLwRovbqpYhyV8peq+IVrV6Txxi+Uc1c3VQw0jvYVTB1qUzdVjJOSTJ3+00f8JmzFb7WYus3VTRXjKKQ5kE2c3j94870X1Jub8pWaXVM3VQw0jvYVTB1qUzdVjJOSTV11C11GTrc5JEzd5uqmitEt7d9VV2znLEzdhVQx0DjaVzB1qE3dVDFOSkqGj/7fX0+mLhs3lelB4lyWn4fxVT5f2dOVHZerj3jFL18JimUil6tv/epNdVT2b/eent5HAzo3Q9JNFaNb2k/ej6ukOpHYRvtB+0bzyUSzta5civ3nfZrnit7/4ZEnzy2dRTHUJj9ze5hxH7W6qWKgcbSvYOpQm7qpYpyUnMyd2GyWlBCVGPV3BLVe5VpvQxeXnUCddJ2MXTcaNcVzwnT9mEDVb0zmGltsH+O5jbfByyetbqoYnfJ+8D5dJn3Gcd94/7qdXoX3hfaR9t2m5Vof56CW81xxW0lfHrQ+1pPyHFH5YcZ91OqmioHG0b6CqUNt6qaKcVKyIcqJ0OtzwtdrTLyS6lV13U9MuLG9Yimmk62U+1C/sX1el8c9B3VTxehUtd+yltWJ+yLuW5erTHXWlVf9a99qnV6rtlaeI3FOdIz7qNVNFQONo30FU4fa1E0V46QUk5cT3aqkqDoValclUNWPyTEm0CqZStWYYnk0g+ojl5+0uqlidCt+5pXinIjr1+3P2O+qcvWvq2cZX6Wt5oGVy+JYO8Z91OqmioHG0b6CqUNt6qaKcVKKyUsJUMlN/+XDSVKJTuuU+LSs12XJNdeV1HdMjjGBRnPmckn9u4+csKUYJ9adi7qpYnQr7peqvNq3kveB3+c+VOb9v6pc6/wfcFwWtWp8eY5EI9cx7qNWN1UMNI72FUwdalM3VYyTUk5eWo7PsOWkqIQZn0eKqhKo+o79xwTq+jEhqzw+/5QTdq7nfx2Uy09S3VQxuuV9ET97SfPAf9JE+yKW57kQ963bx/m1rlyvudxyLNeVOp+pWzWuo1Y3VQw0jvYVTB1qUzdVjJNSTl5KhNEo6VUJzwnQdWT8jE1gVVd9x/5zAnUbE5Ov28eEbVVJfi7qpopxVNLnGan2RyTu63XmaF25lyNx33ufG5fF9Yqh5XzL9TDjPmp1U8VA42hf2XlTl09u+eR6ULlfvVpaX50ID6o8dtO1DcetbqoYaDt1ztdudVPFQOOomyrGNvIXrep8reNNx90cz+OVOa+kesuIZn+u2leGMHXxm6LeH9YUrZr0R5EkfXLYhQNllbqpYqDtFL+QzE3dVDHQOOqmirGNdN7W1Xrlm3y1chtTdxQ5ZZU2NXVR2r65nkeWaV8ZztT5QDvMAbJqAmPqlqubKgbaTJpLYtuT93GqmyoGGkfdVDG2kc/b+mPMMnYxJ2DqTl77ynCmLh4gfu+/gO5JqfU6CE28sqc6ER0AcULnA9AHtokT3wePTKZYZtoqU6eYaqf1fhZL5ZG43VIud395e3O7LnVTxUDjqJsqBhpH3VQxtlE8b+ucqvc2SpWpUx3jnKN68blb9fHQLb+8qK9oGnMOyuf9mINcN+ZA1Y/9a13MgZU09nW5Te1jnokxpLytzkP+HE2McxjtK0PefvVk8iSLk8TrlrXxcmwTl32QaIJ6MrovL2uCa9kHm5eXKbeT1KfNnNed/peHzh94qhsPxLysdnddd/v57XXfcfxa7lQ3VQw0jrqpYqBx1E0VYxvF83bOBTq/RlOn9SpXPS9XOaVaVl0R+5aZUl+KHfNEHofP/zGfqY3HovVxXMsUxyupD+G84nVedlwva3xajtuof62Yx+vl2O9Bta8M90OJOEHzwSFpsuRJXB1EcQLH5VhX0nutc13177pVrErVRM5jyIrjWHUgVGNQ3z6IOtVNFQONo26qGGgcdVPF2Eb5vBvzQXxfnZ+1Xuv0Gs/lLte53/X19zB1pc35IJ6/tS6fy+M5v+rb5erT9WL7SooR81GMEetFxbFV45Ti5+R16jvGOqj2leGu1EVVEzpPTikfdLlOXI59qn6FJ/smE1/K8aVqnIoZL1/7G1q1nZb6qch9d6ibKgYaR91UMdA46qaKsY2q87bOq5LOxTYrkq5SZVadv33+V5le/b+l9epnxqv4Uo6d+3be0phUHtsuU85HVW7zeCJqt2yckseSyX0fRPvK3pm6ZZPRB4qW8wSOy7FPyZfBXTeqilVJ5XnS5zEolg9ULcdxVO0trYv9HKW6qWKgcdRNFQONo26qGNuoOu/qvCyzpKtgPl+rXswvWfFc7nU+3+sPRzu/6TyuZcV0HtC6nP/U1nmp6tt5SWPc1NjlfOQ+FEPL1WcRx1aNU4pjzWWH1b6yd6ZO6zSRYxu9jxNUy3ECx+XYpyfysvh54i9TdUDkMeS+tByfpVD9eIBqffVM3VGqmyoGGkfdVDHQOOqmirGNqvO2pGURz8c6Py/LBTGneJ3qyeyceeo/16tfLee8sO6ZumWmTnVz3limdfkox9FyzLN5nCqvnqnr1L6yd6bO6zXhTD7Y8gSOy8smb0QTWGV54i+TJ7bbSXkMrmP0Pm+b2ph4AOlVyyaWdaqbKgYaR91UMdA46qaKsY2q87alc3c2S1oXyTlGxHyhdXHZ5/EcT8sRtXNZlQNzXvK4qu2wcj7KfbiO0barPI4lj9PxVuXQw2hf2XlTh+ajbqoYc1Q+WYt8wkMXq5sqxpyk+aB5Ybb9cpWT/L6pmyoGGkf7CqYOtambKsYcJVMXv5F63VFdER1F3VQx5iJfjYhXIDQ39IiE3ucrIehidVPFQONoX8HUoTZ1U8WYoypTJ5GoV6ubKsZcJAOn22DxdlwUc2W9uqlioHG0r2DqUJu6qWLMUctMXUzkVVKPiVzrVa5ft/n5R5X7Co+Iz+i4vq78uHzXrgx2U8WYi7wfq2eFNAciquP9u+w/AfhWrubLsv0f547KVDfOQc0vE+fWXNVNFQONo30FU4fa1E0VY45aZuqcmJVoNzF1SqxO2qqvROxk6yTuOK4fk7ENXowxZ3VTxZiT8j6NZXEuSN6/cV1l6mJfqutyt7eJzPXzfDz1d2f/XppjzVHdVDHQONpXMHWoTd1UMeaoLlPnulrOJm5d/djGiXzu6qaKMUdp/4ho2CpTl/dvZerivo5zLNatyvVeBi/2P3d1U8VA42hfwdShNnVTxZijlpm6nET93uXrTJrKYtJeV1/KbeasbqoYc1U27d2mLveXy72sK4diF+ZMN1UMNI72FUwdalM3VYw5SsnTyXnZ+pxQpZh4qySusm1MXZXo56xuqhhzVtyf8b1U7d9tTZ3rxvbxdq2l5Xirdq7qpoqBxtG+gqlDbeqmijFHKRkriXrZCTcm1Zw4lYB1lWSVSVNZTLTZ1Km/aASqRD5ndVPFmIu0X/VDBS97jnjexH0rVfNBc8H71+3j/IimzvPL5a5vU6f1uSz2NUd1U8VA42hfwdShNnVTxZijlIwzVYLUOqMkql82RpO2ralTff86UlRXYeasbqoYc5H2i/ZPxIYul2ufV/NB6zc1da5vZPDir19t+kwcy1zVTRUDjaN9BVOH2tRNFQOdVZX0d03dVDHQfyqawqp87uqmioHG0b6CqUNt6qaKgc4KU3cxVQx0VpovuhK4C1fklqmbKgYaR/sKpg61qZsqBjorTN3FVDH2VTZxkV02dFI3VQw0jvYVTB1qUzdVDDSOuqlioHHUTRUDjaN9BVOH2tRNFQONo26qGGgcdVPFQONoX8HUoTZ1U8VA46ibKgYaR91UMdA42lcwdahN3VQx0DjqpoqBxlE3VQw0jvaVYzV11/7VVeWHj3Zf2rfdMF/GFfMFbSPmC9pGRzFfdoVjNXW3Xv0P5Q5Auy/t226YL+OK+YK2EfMFbaOjmC+7wrGaOqEPm29I40j78igPIObLWGK+oG3EfEHb6Kjnyy5w7KYOAAAAAPrB1AEAAAAMAKYOAAAAYAAwdQAAAAADgKkDAAAAGABMHQAAAMAAYOoAAAAABgBTBwAAADAAmDoAAACAAcDUAQAAAAwApg4AAABgADB1AAAAAAOAqQMAAAAYAEwdAAAAwABg6gAAAAAGYBam7syZM4srr7xycckll0y69NJLF/fff/9UdurUqalMdY4SxbvsssvOx90FbrjhhsU111xzbmlztI36jOPn3IXG4/2ofZfRmF1uaZ1Q/Vwm5X6efPLJxeWXXz6V5bnhPo56zjzx7POL/37HbxZ//U/3n9f/vOfxqUyvf3PnI9P7ufPAvz+7uOLWB89vg95rXRf+nP7+10+dWwMAAEfFiZs6J+iYuGU07r777um91h+HqTtqDmrAVnGQPm2gs1HqIJotKY+tMnTSOlMnxfHmOLHMfWw6Z9yXpPebcNtj/754808eOG/ihMzL3/6/R6fXXTF12o4rbnlwejU3/fbp88vahriNBwFTBwBwfJy4qZOBe9e73rU0oSpJY+pqDtKnPmd93kdxRdKm7eMf//h0FTAaJZtJldvECY3jpptumt5nQxbbxO20EdN6KcbZ1tQpfh7rKnxla5VJ2RVTp22Q4ZLxqsDUAQDsFrO8Uhexqbv++uvPJ/FsZJzIc3k2jDmWTYOWVWaz4/UyGzYP+VZlNByS6i4zSxqP60mO7/F4fTYWOUYeQzZ1MY7aZVOjtuoj11k1Do9Bn7/aVv2KONZbbrnl/Pv8Wef+I96PMYaNYlzn8Wo8MpAq9+dQ9ZG3z2WuGxUNZ8U6IyRs6qR8a1bkW56xv3VthZZd5rqxjsbocl1RjFfiItWVOmEjlvvI6/OtWtVRXZdrTNnUuU7eJgAAODyzeKbOZqNK9k68Traua7OgVy3b7Ng8qL7fx7rqywZAsVSuVymbujgetbEZiDGMyuM4MqrruEL9qv/Yh97nGLGNxh/HFPtUmdsK3b72+0jcTi9vMo7Yd4X3i8enPuJnLfz5W3FbhMtz7NyPx6x42k7XUfvch8eldVHqL49Hip9DhcyITNQqbLpsZPQazZWWXZav/K1rq/JoAlVuA+XlaLa0HOtn3L6qk82ixvDVX/3b9N5mzeUqiwZR8b/1wO8vMHUq07boPQAA9DMLU2ecZLMRyIZC5U6+8b2JbVTmcr3qipOu7qhM9Rwrmh2bCZUbrVe56sX3JravUOx12xX7qGLkccU+tS6bpIo8znXjqD6LCo0l7ju1jSbP6L3WRSPlvvUa11vZLLsPr3c7jVNXCf1eY8/jcluPa9k4lyETs4mpi3WisamI5mlV22X9xPbxvVCb//HPD583W8tQm2gORe4rozKPdVldj1lmcN1tawAAOByzMnXCJkLJWFSmQwla5csMhxK1DZHb673anT59ejJ1qqNlt1X5KiNT9RnHFNtXRAMm8rKIcasYwtsuch9qU5mgSB7nunFUn0XGdRS7UtU2tvF2evxRldnScjR1Qtug+u985zunV/fp9VkHNXUyJTIpMivLiGZHZDPmZZkoy4ZoVVtd/Xrn7b++yKDZUFX9WpuYqXzVsDJqWhf71XLevkgcU+4LAAB6mZ2pE9FoKNE7QRuV2djE90aJ2lfjbGL0zNu11147lau+r9jZFLielm04ohnR+mjqsglQ+ao/iZLNU7Vdeu8xxXgR9eFx5T7NqrHE7RTrxlF9FhnVkzGqzJOkMaofvcbt0fhV7viKEZeXoT6yqfM6x3QfiukxVHjsm5q6ZcYqssqYVQYomqdVbbPpEi53e7WtzNWmxLHE9yIvx7HmMuPx+UpdVQcAAHo4cVOnpOpfPwqbCBu1ynQoQcfymNxze6H6uoJjY6K6WrbxE9HsuI9oZLTeJssGIseI48iobjQWVR967231GGIbjSeaj9inPkPHjtuSyWWbjiN+FhnVr8yY2mi9+n/00UencpuuKMd2/dyPxhqNl8ecP2+3j324rddb3p5crrGoLH7OGRmTfPVL5mXZnzTJxiyaQhs1m51VbYXKtKz1QuvjVTAtqz/1uw7Vdb8im8Zo1PI4vOyxan189k995Wfq8rYCAEAvJ27qnKBjwo0GQwk2J3kZmVxnWXuRk7Rjxnpat6mp83I0A6t+/SridrrfuE7K2+lxuDxug9D4beryZxDHHonbaVaNo/osIrFt/txzmcbqGFZs423In4M/a2+/+82mTjhG7CPvKyluTxyXxqMyx1qGzItMjG9DRpO3zpip3G1kclRmo7OurZfdXnWj+RKxf0n11S6zahuEy23WVOZ6Wqdn9eJYY7n7yuN3n8vGBAAAB2eWt193ERmHaPoAjoNsmgAAYH/B1DXgq1m+agZwXOiq3Ka3WwEAYGwwdQfAJi7ezsPQwXGQb61i6AAAwGDqAAAAAAYAUwcAAAAwAJg6AAAAgAHA1AEAAAAMAKYOAAAAYAAwdQAAAAADgKkDAAAAGABMHQAAAMAAYOoAAAAAdp7F4v8Df3uMQtrCiZUAAAAASUVORK5CYII=' />
+        </section>
+        <footer>
+            <div class="wa-content">
+                <div class="footer-bottom">
+                    <ul class="legal">
+                        <li>
+                            <a href="http://azure.microsoft.com/en-us/support/legal/website-terms-of-use">Terms of Use</a>
+                        </li>
+                        <li>
+                            <a href="http://www.windowsazure.com/en-us/support/legal/privacy-statement">Privacy Statement</a>
+                        </li>
+                        <li>
+                            <a href="http://azure.microsoft.com/en-us/support/legal/subscription-agreement">Azure Agreement</a>
+                        </li>
+                    </ul>
+                    <div class="footer-copyright">
+                        <span>&copy; 2018 Microsoft</span>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+</body>
 </html>
+


### PR DESCRIPTION
Removing the redirect for mawssupport.trafficmanager.net and created a landing page that helps customers find the Diagnostic tools easily.

![image](https://user-images.githubusercontent.com/5299838/44209745-f9e22280-a181-11e8-8d49-0a09387cf423.png)
