### PR TITLE
Add support to sync triggers for Premium Functions

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -117,7 +117,9 @@ namespace Kudu
         public const string FunctionKeyNewFormat = "~0.7";
         public const string FunctionRunTimeVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string WebSiteSku = "WEBSITE_SKU";
+        public const string WebSiteElasticScaleEnabled = "WEBSITE_ELASTIC_SCALING_ENABLED";
         public const string DynamicSku = "Dynamic";
+        public const string ElasticScaleEnabled = "1";
         public const string AzureWebJobsSecretStorageType = "AzureWebJobsSecretStorageType";
         public const string HubName = "HubName";
         public const string DurableTaskStorageConnection = "connection";

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -81,6 +81,12 @@ namespace Kudu.Core.Helpers
             get { return System.Environment.GetEnvironmentVariable(Constants.WebSiteSku); }
         }
 
+        // WEBSITE_ELASTIC_SCALING_ENABLED = 1
+        private static string WebSiteElasticScaleEnabled
+        {
+            get { return System.Environment.GetEnvironmentVariable(Constants.WebSiteElasticScaleEnabled); }
+        }
+
         // WEBSITE_INSTANCE_ID not null or empty
         public static bool IsAzureEnvironment()
         {
@@ -129,7 +135,8 @@ namespace Kudu.Core.Helpers
                 return;
             }
 
-            if (!string.Equals(Constants.DynamicSku, WebSiteSku, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(Constants.DynamicSku, WebSiteSku, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(Constants.ElasticScaleEnabled, WebSiteElasticScaleEnabled, StringComparison.OrdinalIgnoreCase))
             {
                 Trace(TraceEventType.Verbose, string.Format("Skip function trigger and logicapp sync because sku ({0}) is not dynamic (consumption plan).", WebSiteSku));
                 return;


### PR DESCRIPTION
A Premium Functions site have the following site environment variable 

WEBSITE_ELASTIC_SCALING_ENABLED = 1

We use this variable to detect if we should sync the trigger for the Function with ScaleController.

Tested change with a private Kudu site extension deployed on a private stamp.