### PR TITLE
Change python stack detection logic for linux

### DIFF
--- a/Kudu.Core/Deployment/Generator/PythonSiteEnabler.cs
+++ b/Kudu.Core/Deployment/Generator/PythonSiteEnabler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Abstractions;
+using Kudu.Core.Helpers;
 using Kudu.Core.Infrastructure;
 
 namespace Kudu.Core.Deployment.Generator
@@ -13,6 +14,19 @@ namespace Kudu.Core.Deployment.Generator
 
         public static bool LooksLikePython(string siteFolder)
         {
+            if (!OSDetector.IsOnWindows())
+            {
+                // For Linux web apps: Rely on WEBSITE_PYTHON_VERSION environment variable to
+                // detect if this is a python app
+                string pythonVersion = System.Environment.GetEnvironmentVariable("WEBSITE_PYTHON_VERSION");
+                if (!string.IsNullOrEmpty(pythonVersion) && pythonVersion.StartsWith("3"))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
             var reqsFilePath = Path.Combine(siteFolder, RequirementsFileName);
             if (!FileSystemHelpers.FileExists(reqsFilePath))
             {

--- a/Kudu.Services.Web/updateNodeModules.cmd
+++ b/Kudu.Services.Web/updateNodeModules.cmd
@@ -10,7 +10,7 @@ set counter=0
 set /a counter+=1
 echo Attempt %counter% out of %attempts%
 
-cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/b27b514505b3d85ccb1396ab3dc7ed64d1dfd455
+cmd /c npm install https://github.com/projectkudu/KuduScript/tarball/6f8085cef949e47a38eef03345d683dc4ca9ad7d
 IF %ERRORLEVEL% NEQ 0 goto error
 
 goto end


### PR DESCRIPTION
Kudu now detects python app on linux based off of WEBSITE_PYTHON_VERSION environment variable.