### PR TITLE
Fix: Read TaskHub from host.json for FunctionsV2

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -125,6 +125,7 @@ namespace Kudu
         public const string DurableTaskStorageConnection = "connection";
         public const string DurableTaskStorageConnectionName = "azureStorageConnectionStringName";
         public const string DurableTask = "durableTask";
+        public const string Extensions = "extensions";
         public const string SitePackages = "SitePackages";
         public const string PackageNameTxt = "packagename.txt";
     }

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -349,6 +349,13 @@ namespace Kudu.Core.Helpers
             var json = JObject.Parse(File.ReadAllText(hostConfigPath));
             JToken durableTaskValue;
 
+            // For Functions V2: the 'durableTask' property is set under the 'extensions' property.
+            JToken extensionsValue;
+            if (json.TryGetValue(Constants.Extensions, StringComparison.OrdinalIgnoreCase, out extensionsValue) && extensionsValue != null)
+            {
+                json = (JObject)extensionsValue;
+            }
+
             // we will allow case insensitivity given it is likely user hand edited
             // see https://github.com/Azure/azure-functions-durable-extension/issues/111
             if (json.TryGetValue(Constants.DurableTask, StringComparison.OrdinalIgnoreCase, out durableTaskValue) && durableTaskValue != null)


### PR DESCRIPTION
The TaskHub used for Durable Functions is moved under the 'extensions' property in Functions V2's host.json. 

We need to add this support for Durable Functions customers using Functions V2.