### PR TITLE
Add detectors link

### DIFF
--- a/Kudu.Services.Web/Detectors/Default.cshtml
+++ b/Kudu.Services.Web/Detectors/Default.cshtml
@@ -1,0 +1,32 @@
+@{
+    var ownerName = Environment.GetEnvironmentVariable("WEBSITE_OWNER_NAME") ?? "";
+    var subscriptionId = ownerName;
+    var resourceGroup = Environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP") ?? "";
+    var siteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? "";
+    
+    var index = ownerName.IndexOf('+');
+    if (index >= 0)
+    {
+        subscriptionId = ownerName.Substring(0, index);
+    }
+    
+    string detectorPath;
+    if (Kudu.Core.Helpers.OSDetector.IsOnWindows())
+    {
+        detectorPath = "diagnostics/availability/analysis";
+    }
+    else
+    {
+        detectorPath = "detectors/LinuxAppDown";
+    }
+    
+    var detectorDeepLink = "https://portal.azure.com/?websitesextension_ext=asd.featurePath="
+            + detectorPath
+            + "#resource/subscriptions/" + subscriptionId
+            + "/resourceGroups/" + resourceGroup
+            + "/providers/Microsoft.Web/sites/"
+            + siteName
+            + "/troubleshoot";
+    
+    Response.Redirect(detectorDeepLink);
+}

--- a/Kudu.Services.Web/Kudu.Services.Web.csproj
+++ b/Kudu.Services.Web/Kudu.Services.Web.csproj
@@ -272,6 +272,9 @@
   <ItemGroup>
     <Content Include="Support\Default.cshtml" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Detectors\Default.cshtml" />
+  </ItemGroup>
   <ItemGroup />
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>


### PR DESCRIPTION
This change will allow content developers to directly go to the Diagnose and solve problems page (aka App Service Diagnostics) in the Azure portal from the 503 error page.