### PR TITLE
Fixes 2893: only assume json for arm requests

### DIFF
--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -157,7 +157,7 @@ namespace Kudu.Services.Deployment
         {
             var content = Request.Content;
             var isRequestJSON = content.Headers?.ContentType?.MediaType?.Equals("application/json", StringComparison.OrdinalIgnoreCase);
-            if (isRequestJSON == true)
+            if (isRequestJSON == true && ArmUtils.IsArmRequest(Request))
             {
                 try
                 {


### PR DESCRIPTION
I am yet to test this out extensively. But just wanted to make the PR to get any feedback/opinions.
This should fix the issue for now. But, other suggestions are- 

1) make exclusive /zipdeploy for ARM/JSON requests with PUT requests
2) Only check for JSON requests in PUT requests and keep POST how it was initially

