### PR TITLE
Improved portability

### DIFF
--- a/Kudu.Core.Test/FileSystemHubFacts.cs
+++ b/Kudu.Core.Test/FileSystemHubFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Kudu.Contracts.Tracing;
 using Kudu.Services.Editor;
@@ -23,13 +24,12 @@ namespace Kudu.Core.Test
             var context = new HubCallerContext(Mock.Of<IRequest>(), Guid.NewGuid().ToString());
             var groups = new Mock<IGroupManager>();
             var clients = new Mock<HubConnectionContext>();
-
             using (
                 var fileSystemHubTest = new FileSystemHubTest(env.Object, tracer.Object, context, groups.Object,
                     clients.Object))
             {
                 // Test
-                fileSystemHubTest.TestRegister(@"C:\");
+                fileSystemHubTest.TestRegister(GetEmptyDir());
 
                 // Assert
                 Assert.Equal(1, FileSystemHubTest.FileWatchersCount);
@@ -37,7 +37,7 @@ namespace Kudu.Core.Test
                 if (update)
                 {
                     // Test
-                    fileSystemHubTest.TestRegister(@"C:\");
+                    fileSystemHubTest.TestRegister(GetEmptyDir());
 
                     // Assert
                     Assert.Equal(1, FileSystemHubTest.FileWatchersCount);
@@ -66,7 +66,7 @@ namespace Kudu.Core.Test
                     clients.Object))
             {
                 // Test
-                fileSystemHubTest.TestRegister(@"C:\");
+                fileSystemHubTest.TestRegister(GetEmptyDir());
 
                 // Assert
                 Assert.Equal(1, FileSystemHubTest.FileWatchersCount);
@@ -98,7 +98,7 @@ namespace Kudu.Core.Test
                     var fileSystemHubTest = new FileSystemHubTest(env.Object, tracer.Object, context, groups.Object,
                         clients.Object);
                     listOfFileSystemHubs.Add(fileSystemHubTest);
-                    fileSystemHubTest.TestRegister(@"C:\");
+                    fileSystemHubTest.TestRegister(GetEmptyDir());
 
                     // Assert
                     Assert.Equal(Math.Min(i + 1, FileSystemHub.MaxFileSystemWatchers), FileSystemHubTest.FileWatchersCount);
@@ -111,6 +111,13 @@ namespace Kudu.Core.Test
                     fileSystemHub.Dispose();
                 }
             }
+        }
+
+        private string GetEmptyDir()
+        {
+            var dir = Path.GetTempPath();
+            var info = Directory.CreateDirectory(Guid.NewGuid().ToString());
+            return info.FullName;
         }
     }
 

--- a/Kudu.Core.Test/LockFileTests.cs
+++ b/Kudu.Core.Test/LockFileTests.cs
@@ -66,7 +66,7 @@ namespace Kudu.Core.Test
 
                         using (var reader = new StreamReader(FileSystemHelpers.OpenFile(file, FileMode.Open, FileAccess.Read, FileShare.Write)))
                         {
-                            Assert.Contains("at Kudu.Core.Test.LockFileTests", reader.ReadToEnd());
+                            Assert.Contains(" Kudu.Core.Test.LockFileTests", reader.ReadToEnd());
                         }
 
                     }, "operationName", TimeSpan.FromSeconds(60));

--- a/build.cmd
+++ b/build.cmd
@@ -14,6 +14,8 @@ if exist "%PROGRAMFILES%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\
     set MsBuildExe="%PROGRAMFILES(X86)%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"
 ) else if exist "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe" (
     set MsBuildExe="%PROGRAMFILES(X86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
+) else if exist "%PROGRAMFILES(X86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe" (
+    set MsBuildExe="%PROGRAMFILES(X86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"
 ) else if exist "%PROGRAMFILES%\MSBuild\14.0\Bin\MsBuild.exe" (
     set MsBuildExe="%PROGRAMFILES%\MSBuild\14.0\Bin\MsBuild.exe"
 ) else if exist "%PROGRAMFILES(X86)%\MSBuild\14.0\Bin\MsBuild.exe" (


### PR DESCRIPTION
**Building in non-US based hosts**
There was a hardcoded "at " string in test code leading to assert failure when localization is set to use language different to English.

**Testing in hosts lacking C: drive**
FileSystem watching test code was hardcoding reference to "C:" drive leading to risky test failure on noisy machines where modifications to C: may happen or C drive is not present. The proposed solution is to use an empty temp directory.

**Support VS2017 Community Edition in build script**
C'mon guys we need a more inclusive society...  :)