### PR TITLE
Fix the detector deeplink

### DIFF
--- a/Kudu.Services.Web/Detectors/Default.cshtml
+++ b/Kudu.Services.Web/Detectors/Default.cshtml
@@ -13,14 +13,14 @@
     string detectorPath;
     if (Kudu.Core.Helpers.OSDetector.IsOnWindows())
     {
-        detectorPath = "diagnostics/availability/analysis";
+        detectorPath = "diagnostics%2Favailability%2Fanalysis";
     }
     else
     {
-        detectorPath = "detectors/LinuxAppDown";
+        detectorPath = "detectors%2FLinuxAppDown";
     }
     
-    var detectorDeepLink = "https://portal.azure.com/?websitesextension_ext=asd.featurePath="
+    var detectorDeepLink = "https://portal.azure.com/?websitesextension_ext=asd.featurePath%3D"
             + detectorPath
             + "#resource/subscriptions/" + subscriptionId
             + "/resourceGroups/" + resourceGroup


### PR DESCRIPTION
We have an issue where the deeplink to the detector only takes to the top page of App Service Diagnostics instead of the particular detector. This change will fix the issue.