### PR TITLE
Use PssCaptureSnapshot for memory dump

### DIFF
--- a/Kudu.Core.Test/ProcessExtensionsFacts.cs
+++ b/Kudu.Core.Test/ProcessExtensionsFacts.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
 using Kudu.Core.Deployment;
 using Kudu.Core.Infrastructure;
 using Xunit;
@@ -58,6 +62,67 @@ namespace Kudu.Core.Test
             }
 
             Assert.Equal(expectedValue, ProcessExtensions.GetDescription(environment));
+        }
+
+        [Fact]
+        public void SnapshotAndDump_CreatesAMinidump()
+        {
+            const int minimumReasonableDmpFileLength = 256 * 1024; // 256 KB
+
+            // MINIDUMP_HEADER constants from minidumpapiset.h
+            const uint MINIDUMP_SIGNATURE = 0x504d444d; // 'PMDM'
+            const ushort MINIDUMP_VERSION = 42899;
+            const int timeStampToleranceInSeconds = 30;
+
+            var process = Process.GetCurrentProcess();
+            var dmpFile = Path.GetTempFileName();
+            try
+            {
+                var utcTimeBeforeSnapshot = DateTime.UtcNow;
+
+                ProcessExtensions.SnapshotAndDump(process, dmpFile, MINIDUMP_TYPE.Normal);
+                var dmpFileInfo = new FileInfo(dmpFile);
+                Assert.True(dmpFileInfo.Exists);
+                Assert.True(dmpFileInfo.Length > minimumReasonableDmpFileLength);
+
+                // Check for sensible values in the minidump header.
+                using (var stream = File.OpenRead(dmpFile))
+                {
+                    using (var reader = new BinaryReader(stream))
+                    {
+                        var signature = reader.ReadUInt32();
+                        Assert.Equal(MINIDUMP_SIGNATURE, signature);
+
+                        var version = reader.ReadUInt32();
+                        Assert.Equal(MINIDUMP_VERSION, (ushort)version);
+
+                        var numberOfStreams = reader.ReadUInt32();
+                        Assert.True(numberOfStreams > 0 && numberOfStreams < 40);
+
+                        var streamDirectoryRva = reader.ReadUInt32();
+                        var checkSum = reader.ReadUInt32();
+
+                        var timeDateStamp = reader.ReadUInt32();
+                        // Convert from time_t to FILETIME
+                        var filetimeUtc = timeDateStamp * 10000000L + 116444736000000000L;
+                        var dmpTimeStamp = DateTime.FromFileTimeUtc(filetimeUtc);
+                        Assert.True(dmpTimeStamp - utcTimeBeforeSnapshot < TimeSpan.FromSeconds(timeStampToleranceInSeconds));
+
+                        var flags = reader.ReadUInt64();
+                        Assert.Equal((MINIDUMP_TYPE)flags, MINIDUMP_TYPE.Normal | MINIDUMP_TYPE.IgnoreInaccessibleMemory);
+                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    File.Delete(dmpFile);
+                }
+                catch
+                {
+                }
+            }
         }
     }
 }

--- a/Kudu.Core/Infrastructure/MiniDumpNativeMethods.cs
+++ b/Kudu.Core/Infrastructure/MiniDumpNativeMethods.cs
@@ -23,6 +23,60 @@ namespace Kudu.Core.Infrastructure
             IntPtr expParam,
             IntPtr userStreamParam,
             IntPtr callbackParam);
+
+        [DllImport("dbghelp.dll",
+            EntryPoint = "MiniDumpWriteDump",
+            CallingConvention = CallingConvention.StdCall,
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool MiniDumpWriteDump(
+            PssSnapshotSafeHandle hpss,
+            uint processId,
+            SafeHandle hFile,
+            MINIDUMP_TYPE dumpType,
+            IntPtr expParam,
+            IntPtr userStreamParam,
+            [In] ref MINIDUMP_CALLBACK_INFORMATION callbackParam);
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct MINIDUMP_CALLBACK_INFORMATION
+        {
+            public MINIDUMP_CALLBACK_ROUTINE CallbackRoutine;
+            public IntPtr CallbackParam;
+        }
+
+        public enum MINIDUMP_CALLBACK_TYPE : uint
+        {
+            ReadMemoryFailureCallback = 14,
+            IsProcessSnapshotCallback = 16
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct MINIDUMP_CALLBACK_INPUT_UNION
+        {
+            [FieldOffset(0)] public readonly uint Status;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct MINIDUMP_CALLBACK_INPUT
+        {
+            public readonly uint ProcessId;
+            public readonly IntPtr ProcessHandle;
+            public readonly MINIDUMP_CALLBACK_TYPE CallbackType;
+            public readonly MINIDUMP_CALLBACK_INPUT_UNION CallbackUnion;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Pack = 4, Size = 52)]
+        public struct MINIDUMP_CALLBACK_OUTPUT
+        {
+            [FieldOffset(0)] public int Status;
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public delegate bool MINIDUMP_CALLBACK_ROUTINE(IntPtr CallbackParam, [In] ref MINIDUMP_CALLBACK_INPUT CallbackInput, [In, Out] ref MINIDUMP_CALLBACK_OUTPUT CallbackOutput);
     }
 
     [Flags]

--- a/Kudu.Core/Infrastructure/ProcessExtensions.cs
+++ b/Kudu.Core/Infrastructure/ProcessExtensions.cs
@@ -16,6 +16,7 @@ using Kudu.Core.Deployment;
 using Kudu.Core.Helpers;
 using Kudu.Core.Tracing;
 using Microsoft.Win32.SafeHandles;
+using static Kudu.Core.Infrastructure.MiniDumpNativeMethods;
 
 namespace Kudu.Core.Infrastructure
 {
@@ -186,9 +187,50 @@ namespace Kudu.Core.Infrastructure
         {
             using (var fs = new FileStream(dumpFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
             {
-                if (!MiniDumpNativeMethods.MiniDumpWriteDump(process.Handle, (uint)process.Id, fs.SafeFileHandle, dumpType, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
+                if (!MiniDumpWriteDump(process.Handle, (uint)process.Id, fs.SafeFileHandle, dumpType, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
                 {
                     throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+        }
+
+        public static void SnapshotAndDump(this Process process, string dumpFile, MINIDUMP_TYPE dumpType)
+        {
+            using (var fs = new FileStream(dumpFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                using (var pssSnapshot = PssSnapshotSafeHandle.CaptureSnapshot(process.Handle))
+                {
+                    bool PssSnapshotMinidumpCallback(IntPtr unused, ref MINIDUMP_CALLBACK_INPUT input, ref MINIDUMP_CALLBACK_OUTPUT output)
+                    {
+                        const int S_OK = 0;
+                        const int S_FALSE = 1;
+
+                        switch (input.CallbackType)
+                        {
+                            case MINIDUMP_CALLBACK_TYPE.IsProcessSnapshotCallback:
+                                // The target is always a snapshot.
+                                output.Status = S_FALSE;
+                                break;
+
+                            case MINIDUMP_CALLBACK_TYPE.ReadMemoryFailureCallback:
+                                // Ignore any read failures during dump generation.
+                                output.Status = S_OK;
+                                break;
+                        }
+
+                        return true;
+                    }
+
+                    var callbackParam = new MINIDUMP_CALLBACK_INFORMATION
+                    {
+                        CallbackParam = IntPtr.Zero,
+                        CallbackRoutine = PssSnapshotMinidumpCallback
+                    };
+
+                    if (!MiniDumpWriteDump(pssSnapshot, (uint)process.Id, fs.SafeFileHandle, dumpType | MINIDUMP_TYPE.IgnoreInaccessibleMemory, IntPtr.Zero, IntPtr.Zero, ref callbackParam))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
                 }
             }
         }
@@ -919,6 +961,22 @@ namespace Kudu.Core.Infrastructure
                 public ushort MaximumLength;
                 public int Buffer;
             }
+
+            [DllImport("kernel32")]
+            public static extern uint GetProcessId(IntPtr hProcess);
+
+            [DllImport("kernel32", SetLastError = true)]
+            public static extern IntPtr OpenProcess(uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwProcessId);
+
+            [DllImport("kernel32", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+
+            [DllImport("kernel32", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool CloseHandle(IntPtr handle);
+
+            public const uint PROCESS_TERMINATE = 0x0001;
         }
     }
 }

--- a/Kudu.Core/Infrastructure/PssSnapshotNativeMethods.cs
+++ b/Kudu.Core/Infrastructure/PssSnapshotNativeMethods.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Kudu.Core.Infrastructure
+{
+    [SuppressUnmanagedCodeSecurity]
+    internal static class PssSnapshotNativeMethods
+    {
+        public enum PSS_QUERY_INFORMATION_CLASS
+        {
+            PSS_QUERY_VA_CLONE_INFORMATION = 1,
+        }
+
+        [Flags]
+        public enum PSS_CAPTURE_FLAGS : uint
+        {
+            PSS_CAPTURE_NONE = 0x00000000,
+            PSS_CAPTURE_VA_CLONE = 0x00000001,
+            PSS_CAPTURE_THREADS = 0x00000080,
+            PSS_CAPTURE_THREAD_CONTEXT = 0x00000100,
+            PSS_CAPTURE_VA_SPACE = 0x00000800,
+            PSS_CAPTURE_VA_SPACE_SECTION_INFORMATION = 0x00001000,
+            PSS_CREATE_USE_VM_ALLOCATIONS = 0x20000000
+        }
+
+        public struct PSS_VA_CLONE_INFORMATION
+        {
+            public IntPtr VaCloneHandle;
+        }
+
+        [DllImport(c_Kernel32)]
+        public static extern int PssCaptureSnapshot(IntPtr processHandle, PSS_CAPTURE_FLAGS captureFlags, uint threadContextFlags, out PssSnapshotSafeHandle snapshotHandle);
+
+        [DllImport(c_Kernel32)]
+        public static extern int PssFreeSnapshot(IntPtr processHandle, IntPtr snapshotHandle);
+
+        [DllImport(c_Kernel32)]
+        public static extern int PssQuerySnapshot(IntPtr snapshotHandle, PSS_QUERY_INFORMATION_CLASS informationClass, out PSS_VA_CLONE_INFORMATION vaCloneInformation, int bufferLength);
+
+        private const string c_Kernel32 = "kernel32";
+    }
+}

--- a/Kudu.Core/Infrastructure/PssSnapshotSafeHandle.cs
+++ b/Kudu.Core/Infrastructure/PssSnapshotSafeHandle.cs
@@ -1,0 +1,105 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using static Kudu.Core.Infrastructure.PssSnapshotNativeMethods;
+using static Kudu.Core.Infrastructure.ProcessExtensions.ProcessNativeMethods;
+using static System.Diagnostics.Process;
+
+namespace Kudu.Core.Infrastructure
+{
+    /// <summary>
+    /// A safe handle for process snapshots created via PssCaptureSnapshot.
+    /// </summary>
+    internal sealed class PssSnapshotSafeHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        /// <summary>
+        /// This constructor will be called by interop.
+        /// </summary>
+        private PssSnapshotSafeHandle() : base(ownsHandle: true)
+        {
+        }
+
+        /// <summary>
+        /// Capture a snapshot of the given process.
+        /// </summary>
+        /// <param name="originalProcessHandle">The process to snapshot.</param>
+        /// <returns>A safe handle to the captured snapshot.</returns>
+        public static PssSnapshotSafeHandle CaptureSnapshot(IntPtr originalProcessHandle)
+        {
+            const PSS_CAPTURE_FLAGS captureFlags =
+                PSS_CAPTURE_FLAGS.PSS_CAPTURE_VA_CLONE |
+                PSS_CAPTURE_FLAGS.PSS_CAPTURE_VA_SPACE |
+                PSS_CAPTURE_FLAGS.PSS_CAPTURE_VA_SPACE_SECTION_INFORMATION |
+                PSS_CAPTURE_FLAGS.PSS_CAPTURE_THREADS |
+                PSS_CAPTURE_FLAGS.PSS_CAPTURE_THREAD_CONTEXT |
+                PSS_CAPTURE_FLAGS.PSS_CREATE_USE_VM_ALLOCATIONS;
+
+            const uint CONTEXT_AMD64 = 0x00100000;
+            const uint CONTEXT_CONTROL = CONTEXT_AMD64 | 0x00000001;
+            const uint CONTEXT_INTEGER = CONTEXT_AMD64 | 0x00000002;
+            const uint CONTEXT_SEGMENTS = CONTEXT_AMD64 | 0x00000004;
+            const uint CONTEXT_FLOATING_POINT = CONTEXT_AMD64 | 0x00000008;
+            const uint CONTEXT_DEBUG_REGISTERS = CONTEXT_AMD64 | 0x00000010;
+            const uint CONTEXT_ALL = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS | CONTEXT_FLOATING_POINT | CONTEXT_DEBUG_REGISTERS;
+
+            ThrowIfFailed(PssCaptureSnapshot(originalProcessHandle, captureFlags, CONTEXT_ALL, out var pssSnapshotHandle));
+            return pssSnapshotHandle;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            // Kill the process before freeing the snapshot. Otherwise there's
+            // a race with the OS which results in OpenProcess/TerminateProcess failing.
+            var snapshotProcessId = GetSnapshotProcessId();
+            TerminateProcessById(snapshotProcessId);
+
+            ThrowIfFailed(PssFreeSnapshot(GetCurrentProcess().Handle, handle));
+            return true;
+        }
+
+        private static void TerminateProcessById(uint processId)
+        {
+            // Note: We cannot use GetProcessById(processId).Kill() here.
+            // GetProcessById will fail for snapshot processes in the sandbox.
+
+            var handle = OpenProcess(PROCESS_TERMINATE, false, processId);
+            if (handle == IntPtr.Zero)
+            {
+                throw new Win32Exception();
+            }
+
+            try
+            {
+                if (!TerminateProcess(handle, unchecked((uint)-1)))
+                {
+                    throw new Win32Exception();
+                }
+            }
+            finally
+            {
+                CloseHandle(handle);
+            }
+        }
+
+        /// <summary>
+        /// Get the PID of the snapshot process.
+        /// </summary>
+        /// <returns>The process ID of the snapshot process.</returns>
+        private uint GetSnapshotProcessId()
+        {
+            ThrowIfFailed(PssQuerySnapshot(handle, PSS_QUERY_INFORMATION_CLASS.PSS_QUERY_VA_CLONE_INFORMATION, out var vaCloneInformation, Marshal.SizeOf<PSS_VA_CLONE_INFORMATION>()));
+            return GetProcessId(vaCloneInformation.VaCloneHandle);
+        }
+
+        private static void ThrowIfFailed(int status)
+        {
+            if (status != ERROR_SUCCESS)
+            {
+                throw new Win32Exception(status);
+            }
+        }
+
+        private const int ERROR_SUCCESS = 0;
+    }
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -260,6 +260,8 @@
     <Compile Include="Infrastructure\IServerConfiguration.cs" />
     <Compile Include="Infrastructure\DockerContainerRestartTrigger.cs" />
     <Compile Include="Infrastructure\NaiveFileSystemWatcher.cs" />
+    <Compile Include="Infrastructure\PssSnapshotSafeHandle.cs" />
+    <Compile Include="Infrastructure\PssSnapshotNativeMethods.cs" />
     <Compile Include="Infrastructure\SecurityUtility.cs" />
     <Compile Include="Infrastructure\PathUtils\PathLinuxUtility.cs" />
     <Compile Include="Infrastructure\PathUtils\PathUtilityBase.cs" />

--- a/Kudu.Services/Diagnostics/ProcessController.cs
+++ b/Kudu.Services/Diagnostics/ProcessController.cs
@@ -176,7 +176,7 @@ namespace Kudu.Services.Performance
                 {
                     using (_tracer.Step(String.Format("MiniDump pid={0}, name={1}, file={2}", process.Id, process.ProcessName, dumpFile)))
                     {
-                        process.MiniDump(dumpFile, (MINIDUMP_TYPE)dumpType);
+                        process.SnapshotAndDump(dumpFile, (MINIDUMP_TYPE)dumpType);
                         _tracer.Trace("MiniDump size={0}", new FileInfo(dumpFile).Length);
                     }
                 }


### PR DESCRIPTION
Use PssCaptureSnapshot for the memory dump feature. This API is what the Snapshot Debugger and procdump use to capture fast snapshots without impacting the running process.