### PR TITLE
SyncTriggers for all Function App SKUs

### DIFF
--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -135,13 +135,6 @@ namespace Kudu.Core.Helpers
                 return;
             }
 
-            if (!string.Equals(Constants.DynamicSku, WebSiteSku, StringComparison.OrdinalIgnoreCase)
-                && !string.Equals(Constants.ElasticScaleEnabled, WebSiteElasticScaleEnabled, StringComparison.OrdinalIgnoreCase))
-            {
-                Trace(TraceEventType.Verbose, string.Format("Skip function trigger and logicapp sync because sku ({0}) is not dynamic (consumption plan).", WebSiteSku));
-                return;
-            }
-
             VerifyEnvironments();
 
             functionsPath = !string.IsNullOrEmpty(functionsPath)


### PR DESCRIPTION
Due to the expanded role SyncTriggers plays in the new Functions ARM work (https://github.com/Azure/azure-functions-host/issues/3949, https://github.com/Azure/azure-functions-host/issues/3950) we need to sync from Kudu regardless of SKU. Functions runtime SyncTriggers operations will be publishing an updated payload including additional function/secrets details for use in ARM APIs. The Functions runtime does sync regardless of SKU. We need to avoid cases where a sync was done with full info by the runtime populating the cache, but a subsequent sync performed by Kudu (e.g. as a result of a deployment) doesn't invalidate this cache. Otherwise ARM APIs would be returning stale data.

With these changes, we're ensured that Kudu sync will invalidate the cache, resulting in subsequent ARM API invocations to have a cache miss and go to runtime. The full cache will be rebuilt later either by background SyncTriggers performed by the runtime (https://github.com/Azure/azure-functions-host/pull/4070), or by direct runtime SyncTrigger invocation. With recent changes SyncTriggers ARM API will go to runtime for v2 functions, doing a full sync. In an upcoming runtime release we'll update Functions v1 to also support SyncTriggers, at which point the SyncTriggers ARM API will be updated to always target the runtime rather than Kudu. With those changes, only direct Kudu operations will do the partial sync.