### PR TITLE
Remove disabled function filter for settriggers

### DIFF
--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -365,29 +365,7 @@ namespace Kudu.Core.Helpers
                 var functionName = Path.GetFileName(Path.GetDirectoryName(functionJson));
                 var json = JObject.Parse(File.ReadAllText(functionJson));
 
-                JToken value;
-                // https://github.com/Azure/azure-webjobs-sdk-script/blob/a9bafba78a3a8092bfd61a8c7093200dae867efb/src/WebJobs.Script/Host/ScriptHost.cs#L1476-L1498
-                if (json.TryGetValue("disabled", out value))
-                {
-                    string stringValue = value.ToString();
-                    bool disabled;
-                    // if "disabled" is not a boolean, we try to expend it as an environment variable
-                    if (!Boolean.TryParse(stringValue, out disabled))
-                    {
-                        string expandValue = System.Environment.GetEnvironmentVariable(stringValue);
-                        // "1"/"true" -> true, else false
-                        disabled = string.Equals(expandValue, "1", StringComparison.OrdinalIgnoreCase) ||
-                                   string.Equals(expandValue, "true", StringComparison.OrdinalIgnoreCase);
-                    }
-
-                    if (disabled)
-                    {
-                        Trace(TraceEventType.Verbose, "Function {0} is disabled", functionName);
-                        return Enumerable.Empty<JObject>();
-                    }
-                }
-
-                var excluded = json.TryGetValue("excluded", out value) && (bool)value;
+                var excluded = json.TryGetValue("excluded", out JToken value) && (bool)value;
                 if (excluded)
                 {
                     Trace(TraceEventType.Verbose, "Function {0} is excluded", functionName);


### PR DESCRIPTION
Related to https://github.com/Azure/Azure-Functions/issues/1111 [kudu work-item]

We don't want to filter out disabled functions before making the /settriggers call.

I left out the filter for "excluded", because I don't think it's supported anymore and we probably want to leave it as is.