### PR TITLE
Site Extension SemVer2 Port

### DIFF
--- a/Build/Build.proj
+++ b/Build/Build.proj
@@ -19,7 +19,7 @@
     
     <PropertyGroup>
         <!-- When bumping up MajorVersion, make sure to update VersionStartYear to current year -->
-        <MajorVersion>83</MajorVersion>
+        <MajorVersion>84</MajorVersion>
         <VersionStartYear>2019</VersionStartYear>
         
         <!-- Build number is of the format (CurrentYear - VersionStartYear + 1)(2 digit month)(2 digit day) -->

--- a/Common/CommonAssemblyInfo.cs
+++ b/Common/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 
 // If you change this version, make sure to change Build\build.proj accordingly
-[assembly: AssemblyVersion("83.0.0.0")]
-[assembly: AssemblyFileVersion("83.0.0.0")]
+[assembly: AssemblyVersion("84.0.0.0")]
+[assembly: AssemblyFileVersion("84.0.0.0")]
 
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -87,6 +87,11 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Xml.Linq, Version=3.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.Linq.3.5.21022.801\lib\net20\System.Xml.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
@@ -160,6 +165,7 @@
     <Compile Include="Settings\SettingsKeys.cs" />
     <Compile Include="SiteExtensions\InvalidEndpointException.cs" />
     <Compile Include="SiteExtensions\ISiteExtensionManager.cs" />
+    <Compile Include="SiteExtensions\ISiteExtensionManagerV2.cs" />
     <Compile Include="SiteExtensions\SiteExtensionInfo.cs" />
     <Compile Include="SourceControl\IFileFinder.cs" />
     <Compile Include="SourceControl\IRepositoryFactory.cs" />

--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -252,6 +252,11 @@ namespace Kudu.Contracts.Settings
             return value == null || StringUtils.IsTrueLike(value);
         }
 
+        public static bool GetUseSiteExtensionV1(this IDeploymentSettingsManager settings)
+        {
+            return settings.GetValue(SettingsKeys.UseSiteExtensionV1) == "1";
+        }
+
         public static bool RunFromLocalZip(this IDeploymentSettingsManager settings)
         {
             return settings.GetFromFromZipAppSettingValue() == "1";

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -17,6 +17,7 @@
         public const string GitEmail = "SCM_GIT_EMAIL";
         public const string ScmType = "ScmType";
         public const string UseShallowClone = "SCM_USE_SHALLOW_CLONE";
+        public const string UseSiteExtensionV1 = "SCM_USE_SITEEXTENSION_V1";
         public const string Command = "COMMAND";
         public const string Project = "PROJECT";
         public const string WorkerCommand = "WORKER_COMMAND";

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -47,5 +47,6 @@
         public const string RunFromZip = "WEBSITE_RUN_FROM_PACKAGE";
         public const string MaxZipPackageCount = "SCM_MAX_ZIP_PACKAGE_COUNT";
         public const string ZipDeployDoNotPreserveFileTime = "SCM_ZIPDEPLOY_DONOT_PRESERVE_FILETIME";
+        public const string EnableLegacySiteExtension = "ENABLE_V1_SITE_EXTENSION";
     }
 }

--- a/Kudu.Contracts/SiteExtensions/ISiteExtensionManagerV2.cs
+++ b/Kudu.Contracts/SiteExtensions/ISiteExtensionManagerV2.cs
@@ -1,33 +1,30 @@
-﻿using Kudu.Contracts.Tracing;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Kudu.Contracts.Tracing;
 
 namespace Kudu.Contracts.SiteExtensions
 {
-        public interface ISiteExtensionManagerV2
-        {
-            IEnumerable<SiteExtensionInfo> GetRemoteExtensions(string filter, bool allowPrereleaseVersions, string feedUrl);
+    public interface ISiteExtensionManagerV2
+    {
+        IEnumerable<SiteExtensionInfo> GetRemoteExtensions(string filter, bool allowPrereleaseVersions, string feedUrl);
 
-            SiteExtensionInfo GetRemoteExtension(string id, string version, string feedUrl);
+        SiteExtensionInfo GetRemoteExtension(string id, string version, string feedUrl);
 
-            IEnumerable<SiteExtensionInfo> GetLocalExtensions(string filter, bool checkLatest);
+        IEnumerable<SiteExtensionInfo> GetLocalExtensions(string filter, bool checkLatest);
 
-            SiteExtensionInfo GetLocalExtension(string id, bool checkLatest);
+        SiteExtensionInfo GetLocalExtension(string id, bool checkLatest);
 
-            /// <summary>
-            /// Install or update a site extension.
-            /// </summary>
-            /// <param name="id"></param>
-            /// <param name="version"></param>
-            /// <param name="feedUrl"></param>
-            /// <param name="type"></param>
-            /// <param name="tracer"></param>
-            /// <param name="installationArgs">String argument to pass to the install.cmd script. If the string is "a b" then the batch script will parse as %1 = a, %2 = b</param>
-            Task<SiteExtensionInfo> InstallExtension(string id, string version, string feedUrl, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs);
+        /// <summary>
+        /// Install or update a site extension.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="version"></param>
+        /// <param name="feedUrl"></param>
+        /// <param name="type"></param>
+        /// <param name="tracer"></param>
+        /// <param name="installationArgs">String argument to pass to the install.cmd script. If the string is "a b" then the batch script will parse as %1 = a, %2 = b</param>
+        Task<SiteExtensionInfo> InstallExtension(string id, string version, string feedUrl, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs);
 
-            Task<bool> UninstallExtension(string id);
-        }
+        Task<bool> UninstallExtension(string id);
+    }
 }

--- a/Kudu.Contracts/SiteExtensions/ISiteExtensionManagerV2.cs
+++ b/Kudu.Contracts/SiteExtensions/ISiteExtensionManagerV2.cs
@@ -1,0 +1,33 @@
+﻿using Kudu.Contracts.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kudu.Contracts.SiteExtensions
+{
+        public interface ISiteExtensionManagerV2
+        {
+            IEnumerable<SiteExtensionInfo> GetRemoteExtensions(string filter, bool allowPrereleaseVersions, string feedUrl);
+
+            SiteExtensionInfo GetRemoteExtension(string id, string version, string feedUrl);
+
+            IEnumerable<SiteExtensionInfo> GetLocalExtensions(string filter, bool checkLatest);
+
+            SiteExtensionInfo GetLocalExtension(string id, bool checkLatest);
+
+            /// <summary>
+            /// Install or update a site extension.
+            /// </summary>
+            /// <param name="id"></param>
+            /// <param name="version"></param>
+            /// <param name="feedUrl"></param>
+            /// <param name="type"></param>
+            /// <param name="tracer"></param>
+            /// <param name="installationArgs">String argument to pass to the install.cmd script. If the string is "a b" then the batch script will parse as %1 = a, %2 = b</param>
+            Task<SiteExtensionInfo> InstallExtension(string id, string version, string feedUrl, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs);
+
+            Task<bool> UninstallExtension(string id);
+        }
+}

--- a/Kudu.Contracts/SiteExtensions/SiteExtensionInfo.cs
+++ b/Kudu.Contracts/SiteExtensions/SiteExtensionInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Kudu.Contracts.Infrastructure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -19,6 +20,65 @@ namespace Kudu.Contracts.SiteExtensions
 
         public SiteExtensionInfo()
         {
+        }
+
+        public SiteExtensionInfo(System.Xml.Linq.XElement xe)
+        {
+            Id = (xe.Elements().First(e => e.Name.LocalName.Equals("Id",StringComparison.OrdinalIgnoreCase))).Value;
+            Version = (xe.Elements().First(e => e.Name.LocalName.Equals("Version", StringComparison.OrdinalIgnoreCase))).Value;
+            Title = (xe.Elements().First(e => e.Name.LocalName.Equals("Title", StringComparison.OrdinalIgnoreCase))).Value;
+            Description = (xe.Elements().First(e => e.Name.LocalName.Equals("Description", StringComparison.OrdinalIgnoreCase))).Value;
+            Authors = new List<string>((xe.Elements().First(e => e.Name.LocalName.Equals("Authors", StringComparison.OrdinalIgnoreCase))).Value.Split(','));
+
+            try
+            {
+                IconUrl = (xe.Elements().First(e => e.Name.LocalName.Equals("IconUrl", StringComparison.OrdinalIgnoreCase))).Value;
+            }
+            catch (Exception)
+            {
+                // pass
+            }
+
+            try
+            {
+                LicenseUrl = (xe.Elements().First(e => e.Name.LocalName.Equals("LicenseUrl", StringComparison.OrdinalIgnoreCase))).Value;
+            }
+            catch (Exception)
+            {
+                // pass
+            }
+
+            try
+            {
+                DownloadCount = int.Parse((xe.Elements().First(e => e.Name.LocalName.Equals("DownloadCount", StringComparison.OrdinalIgnoreCase))).Value);
+            }
+            catch (Exception)
+            {
+                // pass
+            }
+
+            try
+            {
+                Summary = (xe.Elements().First(e => e.Name.LocalName.Equals("Summary", StringComparison.OrdinalIgnoreCase))).Value;
+            }
+            catch (Exception)
+            {
+                // pass
+            }
+
+            try
+            {
+                PublishedDateTime = DateTime.Parse((xe.Elements().First(e => e.Name.LocalName.Equals("Published", StringComparison.OrdinalIgnoreCase))).Value);
+            }
+            catch (Exception)
+            {
+                // pass
+            }
+
+            if (IconUrl == null)
+            {
+                IconUrl = "https://www.siteextensions.net/Content/Images/packageDefaultIcon-50x50.png";
+            }
         }
 
         public SiteExtensionInfo(SiteExtensionInfo info)

--- a/Kudu.Contracts/packages.config
+++ b/Kudu.Contracts/packages.config
@@ -11,4 +11,5 @@
   <package id="NuGet.Protocol.Types" version="3.0.0-pre-20150220053306" targetFramework="net45" />
   <package id="NuGet.Protocol.V2V3" version="3.0.0-pre-20150220053309" targetFramework="net45" />
   <package id="NuGet.Versioning" version="1.0.7" targetFramework="net45" />
+  <package id="System.Xml.Linq" version="3.5.21022.801" targetFramework="net452" />
 </packages>

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -194,9 +194,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq, Version=3.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.Linq.3.5.21022.801\lib\net20\System.Xml.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="XmlSettings, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -307,9 +311,11 @@
     <Compile Include="Settings\DiagnosticsSettingsManager.cs" />
     <Compile Include="SiteExtensions\DummyReference.cs" />
     <Compile Include="SiteExtensions\FeedExtensions.cs" />
+    <Compile Include="SiteExtensions\FeedExtensionsV2.cs" />
     <Compile Include="SiteExtensions\SiteExtensionBatchUpdateStatusLock.cs" />
     <Compile Include="SiteExtensions\SiteExtensionInstallationLock.cs" />
     <Compile Include="SiteExtensions\SemanticVersion.cs" />
+    <Compile Include="SiteExtensions\SiteExtensionManagerV2.cs" />
     <Compile Include="SiteExtensions\SiteExtensionStatus.cs" />
     <Compile Include="SiteExtensions\SiteExtensionManager.cs" />
     <Compile Include="SourceControl\Git\IGitRepository.cs" />

--- a/Kudu.Core/Resources.Designer.cs
+++ b/Kudu.Core/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Kudu.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -228,6 +228,15 @@ namespace Kudu.Core {
         internal static string Error_ProjectNotDeployable {
             get {
                 return ResourceManager.GetString("Error_ProjectNotDeployable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SiteExtension id: {0} not installed locally. Searched directory : {1}.
+        /// </summary>
+        internal static string Error_SiteExtensionNotFound {
+            get {
+                return ResourceManager.GetString("Error_SiteExtensionNotFound", resourceCulture);
             }
         }
         

--- a/Kudu.Core/Resources.resx
+++ b/Kudu.Core/Resources.resx
@@ -234,4 +234,7 @@
   <data name="ReceivingChanges" xml:space="preserve">
     <value>Receiving changes.</value>
   </data>
+  <data name="Error_SiteExtensionNotFound" xml:space="preserve">
+    <value>SiteExtension id: {0} not installed locally. Searched directory : {1}</value>
+  </data>
 </root>

--- a/Kudu.Core/SiteExtensions/FeedExtensionsV2.cs
+++ b/Kudu.Core/SiteExtensions/FeedExtensionsV2.cs
@@ -1,0 +1,428 @@
+﻿using Ionic.Zip;
+using Kudu.Contracts.SiteExtensions;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
+using NuGet.Client;
+using NuGet.PackagingCore;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Kudu.Core.SiteExtensions
+{
+    public static class FeedExtensionsV2
+    {
+        /// <summary>
+        /// Return the feed URL to directly query nuget v2 api by search term, 
+        /// always include pre-released
+        /// </summary>
+        internal static string GetFeedUrl(string filter)
+        {
+            String searchTerm = "tags:AzureSiteExtension";
+            if (String.IsNullOrWhiteSpace(filter))
+            {
+                // No user provided search string: just search by tag
+                searchTerm = "tags:AzureSiteExtension";
+            }
+            else if (filter.Contains(":"))
+            {
+                // User provided complex query with fields: add it as is to the tag field query
+                searchTerm = $"tags:AzureSiteExtension {filter}";
+            }
+            else
+            {
+                // User provided simple string: treat it as a title. This is not ideal behavior, but
+                // is the best we can do based on how nuget.org works
+                searchTerm = $"tags:AzureSiteExtension title:\"{filter}\"";
+            }
+            return $"https://www.nuget.org/api/v2/Search?searchTerm=%27{searchTerm}%27&includePrerelease=true&semVerLevel=2.0.0";
+        }
+
+        // <summary>
+        /// Query result by search term, always include pre-released
+        /// </summary>
+        public static IEnumerable<SiteExtensionInfo> SearchLocalRepo(string siteExtensionRootPath, string searchTerm, SearchFilter filterOptions = null, int skip = 0, int take = 1000)
+        {
+            List<SiteExtensionInfo> extensions = new List<SiteExtensionInfo>();
+            // always include pre-release package
+            if (filterOptions == null)
+            {
+                filterOptions = new SearchFilter();
+            }
+
+            filterOptions.IncludePrerelease = true; // keep the good old behavior
+
+            List<string> installedPackages = new List<string>(Directory.EnumerateDirectories(siteExtensionRootPath));
+            int countEntries = 0;
+            foreach (string extDir in installedPackages)
+            {
+                string packageId = extDir.Substring(extDir.LastIndexOf("\\")+1);
+                if(countEntries++ > take)
+                {
+                    break;
+                }
+
+                string nupkgFile = Directory.GetFiles(extDir, "*.nupkg", SearchOption.AllDirectories).First();
+                string nuspecFile = Directory.GetFiles(extDir, "*.nuspec", SearchOption.AllDirectories).First();
+
+                if(nupkgFile == null)
+                {
+                    // we ignore this site extension
+                    break;
+                }
+
+                DateTime installedTime = System.IO.File.GetLastWriteTime(nupkgFile);
+
+                if (nuspecFile == null)
+                {
+                    using (ZipFile nupkgZipFile = ZipFile.Read(nupkgFile))
+                    {
+                        ZipEntry entry = nupkgZipFile[string.Format("{0}.nuspec", packageId)];
+                        if (entry != null)
+                        {
+                            entry.Extract(extDir);
+                        }
+                    }
+                }
+
+                string data = FileSystemHelpers.ReadAllText(nuspecFile);
+                if ((searchTerm != null && data.Contains(searchTerm)) || searchTerm == null)
+                {
+                    using (XmlReader reader = XmlReader.Create(nuspecFile))
+                    {
+                        reader.ReadToDescendant("metadata");
+                        var extInfo = new SiteExtensionInfo((XElement)XNode.ReadFrom(reader));
+                        extensions.Add(extInfo);
+                    }
+                }
+            }
+            return extensions;
+        }
+
+        public static List<SiteExtensionInfo> GetPackagesFromNugetAPI(string filter = null, string feedUrl = null)
+        {
+            List<SiteExtensionInfo> extensions = new List<SiteExtensionInfo>();
+
+            if (feedUrl == null)
+            {
+                feedUrl = FeedExtensionsV2.GetFeedUrl(filter);
+            }
+
+            using (XmlReader reader = XmlReader.Create(feedUrl))
+            {
+                reader.ReadStartElement("feed");
+                while (reader.Read())
+                {
+                    if (reader.Name == "entry" && reader.IsStartElement())
+                    {
+                        reader.ReadToDescendant("m:properties");
+                        extensions.Add(new SiteExtensionInfo((XElement)XNode.ReadFrom(reader)));
+                    }
+                }
+            }
+            return extensions;
+        }
+
+        /// <summary>
+        /// Query source repository for latest package base given package id
+        /// </summary>
+        internal static SiteExtensionInfo GetLatestPackageByIdFromSrcRepo(string packageId)
+        {
+            return GetPackagesFromNugetAPI().First(a => a.Id != null && a.Id == packageId);
+        }
+        /// <summary>
+        /// <para>Query source repository for a package base on given package id and version</para>
+        /// <para>Will also query pre-release and unlisted packages</para>
+        /// </summary>
+        /// <param name="packageId">Package id, must not be null</param>
+        /// <param name="version">Package version, must not be null</param>
+        /// <returns>Package metadata</returns>
+        public static SiteExtensionInfo GetPackageByIdentity(string packageId, string version)
+        {
+            return GetPackagesFromNugetAPI().First(a => a.Id != null && a.Version != null && a.Id == packageId && a.Version == version);
+        }
+
+        /// <summary>
+        /// Helper function to download package from given url, and place package (only 'content' folder from package) to given folder
+        /// </summary>
+        /// <param name="identity">Package identity</param>
+        /// <param name="destinationFolder">Folder where we copy the package content (content folder only) to</param>
+        /// <param name="pathToLocalCopyOfNupkg">File path where we copy the nudpk to</param>
+        /// <returns></returns>
+        public static async Task DownloadPackageToFolder(string packageId, string packageVersion, string destinationFolder, string pathToLocalCopyOfNupkg)
+        {
+            using (var client = new HttpClient())
+            {
+                var uri = new Uri(String.Format("https://www.nuget.org/api/v2/package/{0}/{1}", packageId, packageVersion));
+
+                var response = await client.GetAsync(uri);
+
+                using (Stream packageStream = await response.Content.ReadAsStreamAsync())
+                {
+                    using (ZipFile zipFile = ZipFile.Read(packageStream))
+                    {
+                        // we only care about stuff under "content" folder
+                        int substringStartIndex = @"content/".Length;
+                        IEnumerable<ZipEntry> contentEntries = zipFile.Entries.Where(e => e.FileName.StartsWith(@"content/", StringComparison.InvariantCultureIgnoreCase));
+                        foreach (var entry in contentEntries)
+                        {
+                            string entryFileName = Uri.UnescapeDataString(entry.FileName);
+                            string fullPath = Path.Combine(destinationFolder, entryFileName.Substring(substringStartIndex));
+
+                            if (entry.IsDirectory)
+                            {
+                                FileSystemHelpers.EnsureDirectory(fullPath.Replace('/', '\\'));
+                                continue;
+                            }
+
+                            FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(fullPath));
+                            using (Stream writeStream = FileSystemHelpers.OpenWrite(fullPath))
+                            {
+                                // reset length of file stream
+                                writeStream.SetLength(0);
+
+                                // let the thread go with itself, so that once file finishes writing, doesn't need to request thread context from main thread
+                                await entry.OpenReader().CopyToAsync(writeStream).ConfigureAwait(false);
+                            }
+                        }
+                    }
+
+                    // set position back to the head of stream
+                    packageStream.Position = 0;
+
+                    // save a copy of the nupkg at last
+                    WriteStreamToFile(packageStream, pathToLocalCopyOfNupkg);
+                }
+            }
+        }
+
+        public static async Task UpdateLocalPackage(SourceRepository localRepo, string packageId, string packageVersion, string destinationFolder, string pathToLocalCopyOfNupkg, ITracer tracer)
+        {
+            tracer.Trace("Performing incremental package update for {0}", packageId);
+            using (var client = new HttpClient())
+            {
+                var uri = new Uri(String.Format("https://www.nuget.org/api/v2/package/{0}/{1}", packageId, packageVersion));
+                var response = await client.GetAsync(uri);
+                using (Stream newPackageStream = await response.Content.ReadAsStreamAsync())
+                {
+                    // update file
+                    var localPackage = await localRepo.GetLatestPackageByIdFromSrcRepo(packageId);
+                    if (localPackage == null)
+                    {
+                        throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Package {0} not found from local repo.", packageId));
+                    }
+                    using (Stream oldPackageStream = await localRepo.GetPackageStream(localPackage.Identity))
+                    using (ZipFile oldPackageZip = ZipFile.Read(oldPackageStream))
+                    using (ZipFile newPackageZip = ZipFile.Read(newPackageStream))
+                    {
+                        // we only care about stuff under "content" folder
+                        IEnumerable<ZipEntry> oldContentEntries = oldPackageZip.Entries.Where(e => e.FileName.StartsWith(@"content/", StringComparison.InvariantCultureIgnoreCase));
+                        IEnumerable<ZipEntry> newContentEntries = newPackageZip.Entries.Where(e => e.FileName.StartsWith(@"content/", StringComparison.InvariantCultureIgnoreCase));
+                        List<ZipEntry> filesNeedToUpdate = new List<ZipEntry>();
+                        Dictionary<string, ZipEntry> indexedOldFiles = new Dictionary<string, ZipEntry>();
+                        foreach (var item in oldContentEntries)
+                        {
+                            indexedOldFiles.Add(item.FileName.ToLowerInvariant(), item);
+                        }
+
+                        foreach (var newEntry in newContentEntries)
+                        {
+                            var fileName = newEntry.FileName.ToLowerInvariant();
+                            if (indexedOldFiles.ContainsKey(fileName))
+                            {
+                                // file name existed, only update if file has been touched
+                                ZipEntry oldEntry = indexedOldFiles[fileName];
+                                if (oldEntry.LastModified != newEntry.LastModified)
+                                {
+                                    filesNeedToUpdate.Add(newEntry);
+                                }
+
+                                // remove from old index files buffer, the rest will be files that need to be deleted
+                                indexedOldFiles.Remove(fileName);
+                            }
+                            else
+                            {
+                                // new files
+                                filesNeedToUpdate.Add(newEntry);
+                            }
+                        }
+
+                        int substringStartIndex = @"content/".Length;
+
+                        foreach (var entry in filesNeedToUpdate)
+                        {
+                            string entryFileName = Uri.UnescapeDataString(entry.FileName);
+                            string fullPath = Path.Combine(destinationFolder, entryFileName.Substring(substringStartIndex));
+
+                            if (entry.IsDirectory)
+                            {
+                                using (tracer.Step("Ensure directory: {0}", fullPath))
+                                {
+                                    FileSystemHelpers.EnsureDirectory(fullPath.Replace('/', '\\'));
+                                }
+
+                                continue;
+                            }
+
+                            using (tracer.Step("Adding/Updating file: {0}", fullPath))
+                            {
+                                FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(fullPath));
+                                using (Stream writeStream = FileSystemHelpers.OpenWrite(fullPath))
+                                {
+                                    // reset length of file stream
+                                    writeStream.SetLength(0);
+
+                                    // let the thread go with itself, so that once file finishes writing, doesn't need to request thread context from main thread
+                                    await entry.OpenReader().CopyToAsync(writeStream).ConfigureAwait(false);
+                                }
+                            }
+                        }
+
+                        foreach (var entry in indexedOldFiles.Values)
+                        {
+                            string entryFileName = Uri.UnescapeDataString(entry.FileName);
+                            string fullPath = Path.Combine(destinationFolder, entryFileName.Substring(substringStartIndex));
+
+                            if (entry.IsDirectory)
+                            {
+                                // in case the two zip file was created from different tool. some tool will include folder as seperate entry, some don`t.
+                                // to be sure that folder is meant to be deleted, double check there is no files under it
+                                var entryNameInLower = entryFileName.ToLower();
+                                if (!string.Equals(destinationFolder, fullPath, StringComparison.OrdinalIgnoreCase)
+                                    && newContentEntries.FirstOrDefault(e => e.FileName.ToLowerInvariant().StartsWith(entryNameInLower)) == null)
+                                {
+                                    using (tracer.Step("Deleting directory: {0}", fullPath))
+                                    {
+                                        FileSystemHelpers.DeleteDirectorySafe(fullPath);
+                                    }
+                                }
+                                continue;
+                            }
+
+                            using (tracer.Step("Deleting file: {0}", fullPath))
+                            {
+                                FileSystemHelpers.DeleteFileSafe(fullPath);
+                            }
+                        }
+                    }
+
+                    // update nupkg
+                    newPackageStream.Position = 0;
+                    using (tracer.Step("Updating nupkg file."))
+                    {
+                        WriteStreamToFile(newPackageStream, pathToLocalCopyOfNupkg);
+                        if (!packageVersion.Equals(localPackage.Identity.Version))
+                        {
+                            using (tracer.Step("New package has difference version {0} from old package {1}. Remove old nupkg file.", packageVersion, localPackage.Identity.Version))
+                            {
+                                // if version is difference, nupkg file name will be difference. will need to clean up the old one.
+                                var oldNupkg = pathToLocalCopyOfNupkg.Replace(
+                                    string.Format(CultureInfo.InvariantCulture, "{0}.{1}.nupkg", packageId, packageVersion),
+                                    string.Format(CultureInfo.InvariantCulture, "{0}.{1}.nupkg", localPackage.Identity.Id, localPackage.Identity.Version.ToNormalizedString()));
+
+                                FileSystemHelpers.DeleteFileSafe(oldNupkg);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static async Task<Stream> GetPackageStream(this SourceRepository srcRepo, PackageIdentity identity)
+        {
+            var downloadResource = await srcRepo.GetResourceAsync<DownloadResource>();
+            Stream sourceStream = null;
+            Stream packageStream = null;
+
+            try
+            {
+                sourceStream = await downloadResource.GetStream(identity, CancellationToken.None);
+                if (sourceStream == null)
+                {
+                    // package not exist from feed
+                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Package {0} - {1} not found when try to download.", identity.Id, identity.Version.ToNormalizedString()));
+                }
+
+                packageStream = sourceStream;
+                if (!sourceStream.CanSeek)
+                {
+                    // V3 DownloadResource.GetStream does not support seek operations.
+                    // https://github.com/NuGet/NuGet.Protocol/issues/15
+
+                    MemoryStream memStream = new MemoryStream();
+
+                    try
+                    {
+                        byte[] buffer = new byte[2048];
+
+                        int bytesRead = 0;
+                        do
+                        {
+                            bytesRead = sourceStream.Read(buffer, 0, buffer.Length);
+                            memStream.Write(buffer, 0, bytesRead);
+                        } while (bytesRead != 0);
+
+                        await memStream.FlushAsync();
+                        memStream.Position = 0;
+
+                        packageStream = memStream;
+                    }
+                    catch
+                    {
+                        memStream.Dispose();
+                        throw;
+                    }
+                }
+
+                return packageStream;
+            }
+            catch
+            {
+                if (packageStream != null && packageStream != sourceStream)
+                {
+                    packageStream.Dispose();
+                }
+
+                if (sourceStream != null)
+                {
+                    sourceStream.Dispose();
+                }
+
+                throw;
+            }
+            finally
+            {
+                if (packageStream != null && sourceStream != null && !sourceStream.CanSeek)
+                {
+                    // packageStream is a copy of sourceStream, dispose sourceStream
+                    sourceStream.Dispose();
+                }
+            }
+        }
+
+        private static void WriteStreamToFile(Stream stream, string filePath)
+        {
+            string packageFolderPath = Path.GetDirectoryName(filePath);
+            FileSystemHelpers.EnsureDirectory(packageFolderPath);
+            using (Stream writeStream = FileSystemHelpers.OpenWrite(filePath))
+            {
+                OperationManager.Attempt(() =>
+                {
+                    // reset length of file stream
+                    writeStream.SetLength(0);
+
+                    stream.CopyTo(writeStream);
+                });
+            }
+        }
+    }
+}

--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -22,7 +22,6 @@ using Kudu.Core.Helpers;
 using Kudu.Core.Infrastructure;
 using Kudu.Core.Settings;
 using Kudu.Core.Tracing;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Client;
 using NuGet.Client.VisualStudio;

--- a/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
@@ -247,7 +247,7 @@ namespace Kudu.Core.SiteExtensions
             try
             {
                 // Check if site extension already installed (id, version, feedUrl), if already install with correct installation arguments then return right away
-                if (IsSiteExtensionInstalled(id, version, feedUrl, installationArgs))
+                if (IsSiteExtensionInstalled(id, installationArgs))
                 {
                     // package already installed, return package from local repo.
                     tracer.Trace("Package {0} with version {1} from {2} with installation arguments '{3}' already installed.", id, version, feedUrl, installationArgs);
@@ -574,12 +574,11 @@ namespace Kudu.Core.SiteExtensions
         /// <para>              Try to use feed from local package, if feed from local package also null, fallback to default feed</para>
         /// <para>              Check if version from query is same as local package</para>
         /// </summary>
-        private bool IsSiteExtensionInstalled(string id, string version, string feedUrl, string installationArgs)
+        private bool IsSiteExtensionInstalled(string id, string installationArgs)
         {
             ITracer tracer = _traceFactory.GetTracer();
             JsonSettings siteExtensionSettings = GetSettingManager(id);
             string localPackageVersion = siteExtensionSettings.GetValue(_versionSetting);
-            string localPackageFeedUrl = siteExtensionSettings.GetValue(_feedUrlSetting);
             string localPackageInstallationArgs = siteExtensionSettings.GetValue(_installationArgs);
             SemanticVersion localPkgVer = null;
             SemanticVersion lastFoundVer = null;
@@ -598,6 +597,7 @@ namespace Kudu.Core.SiteExtensions
 
             if (lastFoundVer != null && localPkgVer != null && lastFoundVer <= localPkgVer)
             {
+                tracer.Trace(string.Format("Site Extension with id {0} is already installed", id));
                 isInstalled = true;
             }
 
@@ -851,7 +851,7 @@ namespace Kudu.Core.SiteExtensions
             return new SourceRepository(source, _providers.Value);
         }
 
-        private void TryCheckLocalPackageLatestVersionFromRemote(SiteExtensionInfo info, bool checkLatest = true, ITracer tracer = null)
+        private static void TryCheckLocalPackageLatestVersionFromRemote(SiteExtensionInfo info, bool checkLatest = true, ITracer tracer = null)
         {
             if (checkLatest)
             {

--- a/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
@@ -649,12 +649,13 @@ namespace Kudu.Core.SiteExtensions
 
             string installationDirectory = GetInstallationDirectory(id);
 
+
             SiteExtensionInfo info = GetLocalExtension(id, checkLatest: false);
 
             if (info == null || !FileSystemHelpers.DirectoryExists(info.LocalPath))
             {
                 tracer.TraceError("Site extension {0} not found.", id);
-                throw new DirectoryNotFoundException(installationDirectory);
+                throw new DirectoryNotFoundException(String.Format(CultureInfo.CurrentCulture, Resources.Error_SiteExtensionNotFound, id, installationDirectory));
             }
 
             if (IsInstalledToWebRoot(id))
@@ -730,7 +731,7 @@ namespace Kudu.Core.SiteExtensions
 
         private string GetInstallationDirectory(string id)
         {
-            return Path.Combine(_localRepository.PackageSource.Source, id);
+            return Path.Combine(_rootPath, id);
         }
 
         private JsonSettings GetSettingManager(string id)

--- a/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
@@ -425,7 +425,7 @@ namespace Kudu.Core.SiteExtensions
                     // Copy/update nupkg file for package list/lookup
                     if (packageExisted)
                     {
-                        await FeedExtensionsV2.UpdateLocalPackage(_localRepository, package.Id, package.Version, extractPath, packageLocalFilePath, tracer);
+                        await FeedExtensionsV2.UpdateLocalPackage(_rootPath, package.Id, package.Version, extractPath, packageLocalFilePath, tracer);
                     }
                     else
                     {
@@ -505,7 +505,7 @@ namespace Kudu.Core.SiteExtensions
                 throw;
             }
 
-            return FeedExtensionsV2.GetLatestPackageByIdFromSrcRepo(package.Id);
+            return FeedExtensionsV2.SearchLocalRepo(_rootPath, package.Id).FirstOrDefault();
         }
 
         /// <summary>

--- a/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
@@ -1,0 +1,964 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition.Hosting;
+using System.Configuration;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using System.Web;
+using System.Xml;
+using Kudu.Contracts.Infrastructure;
+using Kudu.Contracts.Jobs;
+using Kudu.Contracts.Settings;
+using Kudu.Contracts.SiteExtensions;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Deployment.Generator;
+using Kudu.Core.Helpers;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Settings;
+using Kudu.Core.Tracing;
+using Newtonsoft.Json.Linq;
+using NuGet.Client;
+using NuGet.Client.VisualStudio;
+using NuGet.Versioning;
+using NullLogger = Kudu.Core.Deployment.NullLogger;
+namespace Kudu.Core.SiteExtensions
+{
+    public class SiteExtensionManagerV2 : ISiteExtensionManagerV2
+    {
+        private static Lazy<IEnumerable<Lazy<INuGetResourceProvider, INuGetResourceProviderMetadata>>> _providers
+            = new Lazy<IEnumerable<Lazy<INuGetResourceProvider, INuGetResourceProviderMetadata>>>(GetNugetProviders);
+
+        private readonly SourceRepository _localRepository;
+        private readonly IEnvironment _environment;
+        private readonly IDeploymentSettingsManager _settings;
+        private readonly ITraceFactory _traceFactory;
+        private readonly IAnalytics _analytics;
+
+        private const string _settingsFileName = "SiteExtensionSettings.json";
+        private const string _feedUrlSetting = "feed_url";
+        private const string _installUtcTimestampSetting = "install_timestamp_utc";
+        private const string _packageType = "package_type";
+        private const string _versionSetting = "version";
+        private const string _installationArgs = "installer_command_line_params";
+
+        private readonly string _rootPath;
+        private readonly string _baseUrl;
+        private readonly IContinuousJobsManager _continuousJobManager;
+        private readonly ITriggeredJobsManager _triggeredJobManager;
+
+        private static readonly string _toBeDeletedDirectoryPath = System.Environment.ExpandEnvironmentVariables(@"%HOME%\data\Temp\SiteExtensions");
+
+
+        private const string _installScriptName = "install.cmd";
+        private const string _uninstallScriptName = "uninstall.cmd";
+
+        public SiteExtensionManagerV2(IContinuousJobsManager continuousJobManager, ITriggeredJobsManager triggeredJobManager, IEnvironment environment, IDeploymentSettingsManager settings, ITraceFactory traceFactory, HttpContextBase context, IAnalytics analytics)
+        {
+            _rootPath = Path.Combine(environment.RootPath, "SiteExtensions");
+            _baseUrl = context.Request.Url == null ? String.Empty : context.Request.Url.GetLeftPart(UriPartial.Authority).TrimEnd('/');
+
+            _localRepository = GetSourceRepository(_rootPath);
+            _continuousJobManager = continuousJobManager;
+            _triggeredJobManager = triggeredJobManager;
+            _environment = environment;
+            _settings = settings;
+            _traceFactory = traceFactory;
+            _analytics = analytics;
+        }
+
+        /// <summary>
+        /// Gets Remote extensions directly from NuGet V2 API 
+        /// </summary>
+        /// <param name="filter">query filter term inputted as a query param to the API to filter on tags/title</param>
+        /// <param name="allowPrereleaseVersions">boolean flag to determine if results should include preview versions</param>
+        /// <param name="feedUrl">NuGet feed URL</param>
+        /// <returns></returns>
+        public IEnumerable<SiteExtensionInfo> GetRemoteExtensions(string filter, bool allowPrereleaseVersions, string feedUrl)
+        {
+            ITracer tracer = _traceFactory.GetTracer();
+            var extensions = new List<SiteExtensionInfo>();
+
+            using (tracer.Step("Search site extensions directly from nuget api by filter: {0}", filter))
+            {
+                extensions = FeedExtensionsV2.GetPackagesFromNugetAPI(filter, feedUrl);
+            }
+
+
+            foreach (var ext in extensions)
+            {
+                SetLocalInfo(ext);
+            }
+
+            return extensions;
+        }
+
+        /// <summary>
+        /// Returns a remote site extension metadata for a particular id and version, null 
+        /// if this id and version doesn't exist in the report repo
+        /// </summary>
+        public SiteExtensionInfo GetRemoteExtension(string id, string version, string feedUrl)
+        {
+            ITracer tracer = _traceFactory.GetTracer();
+            SiteExtensionInfo package = null;
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                using (tracer.Step("Version is null, search latest package by id: {0}", id))
+                {
+                    package = FeedExtensionsV2.GetLatestPackageByIdFromSrcRepo(id);
+                }
+            }
+            else
+            {
+                using (tracer.Step("Search package by id: {0} and version: {1}", id, version))
+                {
+                    package = FeedExtensionsV2.GetPackageByIdentity(id, version);
+                }
+            }
+
+            if (package == null)
+            {
+                tracer.Trace("No package found with id: {0} and version: {1}", id, version);
+                return null;
+            }
+
+            if(package != null)
+            {
+                SetLocalInfo(package);
+            }
+
+            return package;
+        }
+
+
+        /// <summary>
+        /// Gets and returns metadata for the locally installed site extension
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <param name="checkLatest"></param>
+        /// <returns></returns>
+        public IEnumerable<SiteExtensionInfo> GetLocalExtensions(string filter, bool checkLatest = true)
+        {
+            ITracer tracer = _traceFactory.GetTracer();
+            IEnumerable<SiteExtensionInfo> siteExtensionInfos = new List<SiteExtensionInfo>();
+
+            using (tracer.Step("Search packages locally with filter: {0}", filter))
+            {
+                siteExtensionInfos = FeedExtensionsV2.SearchLocalRepo(_rootPath, "");
+            }
+
+            using (tracer.Step("Adding local metadata to site extensions"))
+            {
+                foreach (var ext in siteExtensionInfos)
+                {
+                    SetLocalInfo(ext);
+                }
+            }
+
+            return siteExtensionInfos;
+        }
+
+
+        // <inheritdoc />
+        public SiteExtensionInfo GetLocalExtension(string id, bool checkLatest = true)
+        {
+            
+            SiteExtensionInfo info;
+            ITracer tracer = _traceFactory.GetTracer();
+
+            using (tracer.Step("Now querying from local repo for package '{0}'.", id))
+            {
+               info =  GetLocalExtensions(id).First();
+            }
+
+            if (info == null)
+            {
+                tracer.Trace("No package found from local repo with id: {0}.", id);
+                return null;
+            }
+
+            SiteExtensionStatus armSettings = new SiteExtensionStatus(_environment.SiteExtensionSettingsPath, id, tracer);
+            armSettings.FillSiteExtensionInfo(info);
+            return info;
+        }
+
+        /// <summary>
+        /// Installs a SiteExtension a particular id and version to the site's mounted dir.
+        /// If the version is null, gets the latest version from the feed url
+        /// </summary>
+        /// <returns></returns>
+        public Task<SiteExtensionInfo> InstallExtension(string id, string version, string feedUrl, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs = null)
+        {
+            var installationTask = InstallExtensionCore(id, version, feedUrl, type, tracer, installationArgs);
+
+#pragma warning disable 4014
+            // Track pending task
+            PostDeploymentHelper.TrackPendingOperation(installationTask, TimeSpan.Zero);
+#pragma warning restore 4014
+
+            return installationTask;
+        }
+
+        private async Task<SiteExtensionInfo> InstallExtensionCore(string id, string version, string feedUrl, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs)
+        {
+            try
+            {
+                using (tracer.Step("Installing '{0}' version '{1}' from '{2}'", id, version, feedUrl))
+                {
+                    var installationLock = SiteExtensionInstallationLock.CreateLock(_environment.SiteExtensionSettingsPath, id, enableAsync: true);
+                    // hold on to lock till action complete (success or fail)
+                    return await installationLock.LockOperationAsync<SiteExtensionInfo>(async () =>
+                    {
+                        return await TryInstallExtension(id, version, feedUrl, type, tracer, installationArgs);
+                    }, "Installing SiteExtension", TimeSpan.Zero);
+                }
+            }
+            catch (Exception ex)
+            {
+                _analytics.UnexpectedException(
+                        ex,
+                        method: "PUT",
+                        path: string.Format(CultureInfo.InvariantCulture, "/api/siteextensions/{0}", id),
+                        result: Constants.SiteExtensionProvisioningStateFailed,
+                        message: string.Format(CultureInfo.InvariantCulture, "{{\"version\": {0}, \"feed_url\": {1}}}", version, feedUrl),
+                        trace: false);
+
+                // handle unexpected exception
+                tracer.TraceError(ex);
+
+                var info = new SiteExtensionInfo();
+                info.Id = id;
+
+                SiteExtensionStatus armStatus = new SiteExtensionStatus(_environment.SiteExtensionSettingsPath, id, tracer);
+                armStatus.Operation = Constants.SiteExtensionOperationInstall;
+                armStatus.ProvisioningState = Constants.SiteExtensionProvisioningStateFailed;
+                armStatus.Status = HttpStatusCode.BadRequest;
+                armStatus.FillSiteExtensionInfo(info);
+                tracer.Trace("Update arm settings for {0} installation. Status: {1}", id, armStatus.Status);
+                return info;
+            }
+        }
+
+        private async Task<SiteExtensionInfo> TryInstallExtension(string id, string version, string feedUrl, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs)
+        {
+            SiteExtensionInfo info = null;
+            HttpStatusCode status = HttpStatusCode.OK;  // final status when success
+            bool alreadyInstalled = false;
+
+            try
+            {
+                // Check if site extension already installed (id, version, feedUrl), if already install with correct installation arguments then return right away
+                if (await this.IsSiteExtensionInstalled(id, version, feedUrl, installationArgs))
+                {
+                    // package already installed, return package from local repo.
+                    tracer.Trace("Package {0} with version {1} from {2} with installation arguments '{3}' already installed.", id, version, feedUrl, installationArgs);
+                    info = GetLocalExtension(id);
+                    alreadyInstalled = true;
+                }
+                else
+                {
+                    JsonSettings siteExtensionSettings = GetSettingManager(id);
+                    feedUrl = (string.IsNullOrEmpty(feedUrl) ? siteExtensionSettings.GetValue(_feedUrlSetting) : feedUrl);
+                    IEnumerable<SourceRepository> remoteRepos = GetRemoteRepositories(feedUrl);
+
+                    if (this.IsInstalledToWebRoot(id))
+                    {
+                        // override WebRoot type from setting
+                        // WebRoot is a special type that install package to wwwroot, when perform update we need to update new content to wwwroot even if type is not specified
+                        type = SiteExtensionInfo.SiteExtensionType.WebRoot;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(version))
+                    {
+                        using (tracer.Step("Version is null, search latest package by id: {0}, will not search for unlisted package.", id))
+                        {
+                            info = FeedExtensionsV2.GetLatestPackageByIdFromSrcRepo(id);
+                        }
+                    }
+                    else
+                    {
+                        using (tracer.Step("Search package by id: {0} and version: {1}, will also search for unlisted package.", id, version))
+                        {
+                            info = FeedExtensionsV2.GetLatestPackageByIdFromSrcRepo(id);
+                        }
+                    }
+
+                    if (info != null)
+                    {
+                        using (tracer.Step("Install package: {0}.", id))
+                        {
+                            string installationDirectory = GetInstallationDirectory(id);
+                            info = await InstallExtension(info, installationDirectory, type, tracer, installationArgs);
+                            siteExtensionSettings.SetValues(new KeyValuePair<string, JToken>[] {
+                                new KeyValuePair<string, JToken>(_versionSetting, info.Version),
+                                new KeyValuePair<string, JToken>(_feedUrlSetting, feedUrl),
+                                new KeyValuePair<string, JToken>(_installUtcTimestampSetting, DateTime.UtcNow.ToString("u")),
+                                new KeyValuePair<string, JToken>(_packageType, Enum.GetName(typeof(SiteExtensionInfo.SiteExtensionType), type)),
+                                new KeyValuePair<string, JToken>(_installationArgs, installationArgs)
+                            });
+                        }
+                    }
+                }
+            }
+            catch (FileNotFoundException ex)
+            {
+                _analytics.UnexpectedException(
+                    ex,
+                    method: "PUT",
+                    path: string.Format(CultureInfo.InvariantCulture, "/api/siteextensions/{0}", id),
+                    result: Constants.SiteExtensionProvisioningStateFailed,
+                    message: string.Format(CultureInfo.InvariantCulture, "{{\"version\": {0}, \"feed_url\": {1}}}", version, feedUrl),
+                    trace: false);
+
+                tracer.TraceError(ex);
+                info = new SiteExtensionInfo();
+                info.Id = id;
+                info.ProvisioningState = Constants.SiteExtensionProvisioningStateFailed;
+                info.Comment = ex.ToString();
+                status = HttpStatusCode.NotFound;
+            }
+            catch (WebException ex)
+            {
+                _analytics.UnexpectedException(
+                    ex,
+                    method: "PUT",
+                    path: string.Format(CultureInfo.InvariantCulture, "/api/siteextensions/{0}", id),
+                    result: Constants.SiteExtensionProvisioningStateFailed,
+                    message: string.Format(CultureInfo.InvariantCulture, "{{\"version\": {0}, \"feed_url\": {1}}}", version, feedUrl),
+                    trace: false);
+
+                tracer.TraceError(ex);
+                info = new SiteExtensionInfo();
+                info.Id = id;
+                info.ProvisioningState = Constants.SiteExtensionProvisioningStateFailed;
+                info.Comment = ex.ToString();
+                status = HttpStatusCode.BadRequest;
+            }
+            catch (InvalidEndpointException ex)
+            {
+                _analytics.UnexpectedException(ex, trace: false);
+
+                tracer.TraceError(ex);
+                info = new SiteExtensionInfo();
+                info.Id = id;
+                info.ProvisioningState = Constants.SiteExtensionProvisioningStateFailed;
+                info.Comment = ex.ToString();
+                status = HttpStatusCode.BadRequest;
+            }
+            catch (Exception ex)
+            {
+                _analytics.UnexpectedException(
+                    ex,
+                    method: "PUT",
+                    path: string.Format(CultureInfo.InvariantCulture, "/api/siteextensions/{0}", id),
+                    result: Constants.SiteExtensionProvisioningStateFailed,
+                    message: string.Format(CultureInfo.InvariantCulture, "{{\"version\": {0}, \"feed_url\": {1}}}", version, feedUrl),
+                    trace: false);
+
+                tracer.TraceError(ex);
+                info = new SiteExtensionInfo();
+                info.Id = id;
+                info.ProvisioningState = Constants.SiteExtensionProvisioningStateFailed;
+                info.Comment = ex.ToString();
+                status = HttpStatusCode.BadRequest;
+            }
+
+            if (info == null)
+            {
+                // treat this as an error case since no result return from repo
+                _analytics.UnexpectedException(
+                        new FileNotFoundException(id),
+                        method: "PUT",
+                        path: string.Format(CultureInfo.InvariantCulture, "/api/siteextensions/{0}", id),
+                        result: Constants.SiteExtensionProvisioningStateFailed,
+                        message: string.Format(CultureInfo.InvariantCulture, "{{\"version\": {0}, \"feed_url\": {1}}}", version, feedUrl),
+                        trace: false);
+
+                info = new SiteExtensionInfo();
+                info.ProvisioningState = Constants.SiteExtensionProvisioningStateFailed;
+                info.Comment = string.Format(Constants.SiteExtensionProvisioningStateNotFoundMessageFormat, id);
+                status = HttpStatusCode.NotFound;
+            }
+            else if (!string.Equals(Constants.SiteExtensionProvisioningStateFailed, info.ProvisioningState, StringComparison.OrdinalIgnoreCase))
+            {
+                info.ProvisioningState = Constants.SiteExtensionProvisioningStateSucceeded;
+                info.Comment = null;
+            }
+
+            using (tracer.Step("Update arm settings for {0} installation. Status: {1}", id, status))
+            {
+                SiteExtensionStatus armSettings = new SiteExtensionStatus(_environment.SiteExtensionSettingsPath, id, tracer);
+                armSettings.ReadSiteExtensionInfo(info);
+                armSettings.Status = status;
+                armSettings.Operation = alreadyInstalled ? null : Constants.SiteExtensionOperationInstall;
+            }
+
+            return info;
+        }
+
+        /// <summary>
+        /// <para>1. Download package</para>
+        /// <para>2. Generate xdt file if not exist</para>
+        /// <para>3. Deploy site extension job</para>
+        /// <para>4. Execute install.cmd if exist</para>
+        /// </summary>
+        private async Task<SiteExtensionInfo> InstallExtension(SiteExtensionInfo package, string installationDirectory, SiteExtensionInfo.SiteExtensionType type, ITracer tracer, string installationArgs)
+        {
+            try
+            {
+                EnsureInstallationEnvironment(installationDirectory, tracer);
+
+                string packageLocalFilePath = GetNuGetPackageFile(package.Id, package.Version);
+                bool packageExisted = FileSystemHelpers.DirectoryExists(installationDirectory);
+
+                using (tracer.Step("Download site extension: {0}", package.Id))
+                {
+                    string extractPath = installationDirectory;
+                    if (SiteExtensionInfo.SiteExtensionType.WebRoot == type)
+                    {
+                        extractPath = _environment.WebRootPath;
+                        FileSystemHelpers.EnsureDirectory(extractPath);
+                    }
+
+                    // Copy/update content folder
+                    // Copy/update nupkg file for package list/lookup
+                    if (packageExisted)
+                    {
+                        await FeedExtensionsV2.UpdateLocalPackage(_localRepository, package.Id, package.Version, extractPath, packageLocalFilePath, tracer);
+                    }
+                    else
+                    {
+                        FileSystemHelpers.EnsureDirectory(installationDirectory);
+                        await FeedExtensionsV2.DownloadPackageToFolder(package.Id, package.Version, extractPath, packageLocalFilePath);
+                    }
+
+                    if (SiteExtensionInfo.SiteExtensionType.WebRoot == type)
+                    {
+                        // if install to WebRoot, check if there is any xdt or scmXdt file come with package
+                        // if there is, move it to site extension folder
+                        string xdtFile = Path.Combine(extractPath, Constants.ApplicationHostXdtFileName);
+                        string scmXdtFile = Path.Combine(extractPath, Constants.ScmApplicationHostXdtFileName);
+                        bool findXdts = false;
+
+                        if (FileSystemHelpers.FileExists(xdtFile))
+                        {
+                            tracer.Trace("Use xdt file from package.");
+                            string newXdtFile = Path.Combine(installationDirectory, Constants.ApplicationHostXdtFileName);
+
+                            tracer.Trace("Moving {0} to {1}", xdtFile, newXdtFile);
+                            FileSystemHelpers.MoveFile(xdtFile, newXdtFile);
+                            findXdts = true;
+                        }
+                        // if the siteextension applies to both main site and the scm site
+                        if (FileSystemHelpers.FileExists(scmXdtFile))
+                        {
+                            tracer.Trace("Use scmXdt file from package.");
+                            string newScmXdtFile = Path.Combine(installationDirectory, Constants.ScmApplicationHostXdtFileName);
+
+                            tracer.Trace("Moving {0} to {1}", scmXdtFile, newScmXdtFile);
+                            FileSystemHelpers.MoveFile(scmXdtFile, newScmXdtFile);
+                            findXdts = true;
+                        }
+
+                        if (!findXdts)
+                        {
+                            tracer.Trace("No xdt file come with package.");
+                        }
+                    }
+                }
+
+                // ignore below action if we install package to wwwroot
+                if (SiteExtensionInfo.SiteExtensionType.WebRoot != type)
+                {
+                    using (tracer.Step("Check if applicationHost.xdt or scmApplicationHost.xdt file existed."))
+                    {
+                        GenerateDefaultScmApplicationHostXdt(installationDirectory, '/' + package.Id, tracer: tracer);
+                    }
+
+                    using (tracer.Step("Trigger site extension job"))
+                    {
+                        OperationManager.Attempt(() => DeploySiteExtensionJobs(package.Id));
+                    }
+
+                    var externalCommandFactory = new ExternalCommandFactory(_environment, _settings, installationDirectory);
+                    string installScript = Path.Combine(installationDirectory, _installScriptName);
+                    if (FileSystemHelpers.FileExists(installScript))
+                    {
+                        using (tracer.Step("Execute install.cmd"))
+                        {
+                            OperationManager.Attempt(() =>
+                            {
+                                Executable exe = externalCommandFactory.BuildCommandExecutable(installScript,
+                                    installationDirectory,
+                                    _settings.GetCommandIdleTimeout(), NullLogger.Instance);
+                                exe.ExecuteWithProgressWriter(NullLogger.Instance, _traceFactory.GetTracer(), installationArgs ?? String.Empty);
+                            });
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                tracer.TraceError(ex);
+                FileSystemHelpers.DeleteDirectorySafe(installationDirectory);
+                throw;
+            }
+
+            return FeedExtensionsV2.GetLatestPackageByIdFromSrcRepo(package.Id);
+        }
+
+        /// <summary>
+        /// <para>Check if there is damaged leftover data</para>
+        /// <para>If there is leftover data, will try to cleanup.</para>
+        /// <para>If fail to cleanup, will move leftover data to Temp folder</para>
+        /// </summary>
+        private static void EnsureInstallationEnvironment(string installationDir, ITracer tracer)
+        {
+            // folder is there but nupkg is gone, means previous uninstallation must encounter some error
+            bool isInstalledPackageBroken = FileSystemHelpers.DirectoryExists(installationDir) && FileSystemHelpers.GetFiles(installationDir, "*.nupkg").Length == 0;
+            if (!isInstalledPackageBroken)
+            {
+                return;
+            }
+
+            using (tracer.Step("There was leftover data from previous uninstallation. Trying to cleanup now."))
+            {
+                try
+                {
+                    OperationManager.Attempt(() => FileSystemHelpers.DeleteDirectorySafe(installationDir, ignoreErrors: false));
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    tracer.TraceError(ex);
+                }
+
+                FileSystemHelpers.EnsureDirectory(_toBeDeletedDirectoryPath);
+                DirectoryInfo dirInfo = new DirectoryInfo(installationDir);
+                string tmpFolder = Path.Combine(
+                    _toBeDeletedDirectoryPath,
+                    string.Format(CultureInfo.InvariantCulture, "{0}-{1}", dirInfo.Name, Guid.NewGuid().ToString("N").Substring(0, 8)));
+
+                using (tracer.Step("Failed to cleanup. Moving leftover data to {0}", tmpFolder))
+                {
+                    // if failed, let exception bubble up to trigger bad request
+                    OperationManager.Attempt(() => FileSystemHelpers.MoveDirectory(installationDir, tmpFolder));
+                }
+            }
+
+            FileSystemHelpers.DeleteDirectoryContentsSafe(_toBeDeletedDirectoryPath);
+        }
+
+        /// <summary>
+        /// <para> Return false if the installation arguments are different. Otherwise,</para>
+        /// <para> Return true if any of below cases is satisfied:</para>
+        /// <para>      1) Package with same version and from same feed already exist in local repo</para>
+        /// <para>      2) If given feedUrl is null</para>
+        /// <para>              Try to use feed from local package, if feed from local package also null, fallback to default feed</para>
+        /// <para>              Check if version from query is same as local package</para>
+        /// <para>      3) If given version and feedUrl are null</para>
+        /// <para>              Try to use feed from local package, if feed from local package also null, fallback to default feed</para>
+        /// <para>              Check if version from query is same as local package</para>
+        /// </summary>
+        private async Task<bool> IsSiteExtensionInstalled(string id, string version, string feedUrl, string installationArgs)
+        {
+            ITracer tracer = _traceFactory.GetTracer();
+            JsonSettings siteExtensionSettings = GetSettingManager(id);
+            string localPackageVersion = siteExtensionSettings.GetValue(_versionSetting);
+            string localPackageFeedUrl = siteExtensionSettings.GetValue(_feedUrlSetting);
+            string localPackageInstallationArgs = siteExtensionSettings.GetValue(_installationArgs);
+            NuGetVersion localPkgVer = null;
+            NuGetVersion lastFoundVer = null;
+            bool isInstalled = false;
+
+            // Shortcircuit check: if the installation arguments do not match, then we should return false here to avoid other checks which are now unnecessary.
+            if (!string.Equals(localPackageInstallationArgs, installationArgs))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(localPackageVersion))
+            {
+                localPkgVer = NuGetVersion.Parse(localPackageVersion);
+            }
+
+            // Try to use given feed
+            // If given feed is null, try with feed that from local package
+            // And GetRemoteRepositories will fallback to use default feed if pass in feed param is null
+            IEnumerable<SourceRepository> remoteRepos = GetRemoteRepositories(feedUrl ?? localPackageFeedUrl);
+
+            foreach (SourceRepository rr in remoteRepos)
+            {
+                // case 1 and 2
+                if (!string.IsNullOrWhiteSpace(version)
+                    && version.Equals(localPackageVersion, StringComparison.OrdinalIgnoreCase)
+                    && rr.PackageSource.Source.Equals(localPackageFeedUrl, StringComparison.OrdinalIgnoreCase))
+                {
+                    isInstalled = true;
+                }
+                else if (string.IsNullOrWhiteSpace(version)
+                         && string.IsNullOrWhiteSpace(feedUrl)
+                         && string.Equals(localPackageInstallationArgs, installationArgs))
+                {
+                    // case 3
+                    UIPackageMetadata remotePackage = await rr.GetLatestPackageByIdFromSrcRepo(id);
+                    if (remotePackage != null)
+                    {
+                        tracer.Trace("Found version: {0} on feed: {1}",
+                                     remotePackage.Identity.Version.ToNormalizedString(),
+                                     rr.PackageSource.Source);
+                        if (lastFoundVer == null || lastFoundVer < remotePackage.Identity.Version)
+                        {
+                            lastFoundVer = remotePackage.Identity.Version;
+                        }
+                    }
+                }
+            }
+
+            if (lastFoundVer != null && localPkgVer != null && lastFoundVer <= localPkgVer)
+            {
+                isInstalled = true;
+            }
+
+            return isInstalled;
+        }
+
+        private static void GenerateDefaultScmApplicationHostXdt(string installationDirectory, string relativeUrl, ITracer tracer = null)
+        {
+            // If there is no xdt and scmXdt file, generate default scmXdt file.
+            FileSystemHelpers.CreateDirectory(installationDirectory);
+            string xdtPath = Path.Combine(installationDirectory, Constants.ApplicationHostXdtFileName);
+            string scmXdtPath = Path.Combine(installationDirectory, Constants.ScmApplicationHostXdtFileName);
+
+            if (!FileSystemHelpers.FileExists(xdtPath) && !FileSystemHelpers.FileExists(scmXdtPath))
+            {
+                if (tracer != null)
+                {
+                    tracer.Trace("Missing xdt file, creating one.");
+                }
+
+                string xdtContent = CreateDefaultScmXdtFile(relativeUrl, "%XDT_EXTENSIONPATH%");
+                OperationManager.Attempt(() => FileSystemHelpers.WriteAllText(scmXdtPath, xdtContent));
+            }
+        }
+
+        public async Task<bool> UninstallExtension(string id)
+        {
+            ITracer tracer = _traceFactory.GetTracer();
+
+            string installationDirectory = GetInstallationDirectory(id);
+
+            SiteExtensionInfo info = GetLocalExtension(id, checkLatest: false);
+
+            if (info == null || !FileSystemHelpers.DirectoryExists(info.LocalPath))
+            {
+                tracer.TraceError("Site extension {0} not found.", id);
+                throw new DirectoryNotFoundException(installationDirectory);
+            }
+
+            if (IsInstalledToWebRoot(id))
+            {
+                // special handling for package that install in wwwroot instead of under site extension folder
+                tracer.Trace("Clear all content in wwwroot");
+                OperationManager.Attempt(() => FileSystemHelpers.DeleteDirectoryContentsSafe(_environment.WebRootPath));
+            }
+            else
+            {
+                // default action for site extension uninstall
+
+                // only site extension has below infomation
+                var externalCommandFactory = new ExternalCommandFactory(_environment, _settings, installationDirectory);
+
+                string uninstallScript = Path.Combine(installationDirectory, _uninstallScriptName);
+
+                if (FileSystemHelpers.FileExists(uninstallScript))
+                {
+                    using (tracer.Step("Execute uninstall.cmd"))
+                    {
+                        OperationManager.Attempt(() =>
+                        {
+                            Executable exe = externalCommandFactory.BuildCommandExecutable(uninstallScript,
+                                installationDirectory,
+                                _settings.GetCommandIdleTimeout(), NullLogger.Instance);
+                            exe.ExecuteWithProgressWriter(NullLogger.Instance, _traceFactory.GetTracer(), String.Empty);
+                        });
+                    }
+                }
+
+                using (tracer.Step("Remove site extension job"))
+                {
+                    OperationManager.Attempt(() => CleanupSiteExtensionJobs(id));
+                }
+            }
+
+            using (tracer.Step("Delete site extension package, directory and arm settings"))
+            {
+                OperationManager.Attempt(() => FileSystemHelpers.DeleteFileSafe(GetNuGetPackageFile(info.Id, info.Version)));
+                OperationManager.Attempt(() => FileSystemHelpers.DeleteDirectorySafe(installationDirectory));
+                SiteExtensionStatus armSettings = new SiteExtensionStatus(_environment.SiteExtensionSettingsPath, id, tracer);
+                await armSettings.RemoveStatus();
+            }
+
+            return GetLocalExtension(id, checkLatest: false) == null;
+        }
+
+        private IEnumerable<SourceRepository> GetRemoteRepositories(string feedUrl)
+        {
+            List<SourceRepository> repos = new List<SourceRepository>();
+
+            if (!string.IsNullOrWhiteSpace(feedUrl))
+            {
+                repos.Add(GetSourceRepository(feedUrl));
+            }
+            else
+            {
+                // The remote feed URL can either be the default siteextensions.net, or some user override via
+                // SCM_SITEEXTENSIONS_FEED_URL. We only want to add nuget.org to the list if the user
+                // is *not* overriding the feed URL
+                // UPDATE 8/2018: we no longer use siteextension.net, per https://github.com/Azure/app-service-announcements/issues/87
+                // GetSiteExtensionRemoteUrl() now returns the NuGet feed by default
+                string remoteUrl = _settings.GetSiteExtensionRemoteUrl(out bool isDefault);
+                if (isDefault)
+                {
+                    //repos.Add(GetSourceRepository(DeploymentSettingsExtension.NuGetSiteExtensionFeedUrl));
+                }
+                repos.Add(GetSourceRepository(remoteUrl));
+            }
+            return repos;
+        }
+
+        private string GetInstallationDirectory(string id)
+        {
+            return Path.Combine(_localRepository.PackageSource.Source, id);
+        }
+
+        private JsonSettings GetSettingManager(string id)
+        {
+            string filePath = Path.Combine(_rootPath, id, _settingsFileName);
+            return new JsonSettings(filePath);
+        }
+
+        private string GetNuGetPackageFile(string id, string version)
+        {
+            return Path.Combine(GetInstallationDirectory(id), String.Format(CultureInfo.InvariantCulture, "{0}.{1}.nupkg", id, version));
+        }
+
+        private static string CreateDefaultScmXdtFile(string relativeUrl, string physicalPath)
+        {
+            string template = null;
+            // the template has "%XDT_SCMSITENAME%" by default
+            Stream stream = typeof(SiteExtensionManager).Assembly.GetManifestResourceStream("Kudu.Core.SiteExtensions." + Constants.ScmApplicationHostXdtFileName + ".xml");
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                template = reader.ReadToEnd();
+            }
+
+            return String.Format(template, relativeUrl, physicalPath);
+        }
+
+        private void SetLocalInfo(SiteExtensionInfo info)
+        {
+            string localPath = GetInstallationDirectory(info.Id);
+            if (FileSystemHelpers.DirectoryExists(localPath))
+            {
+                info.LocalPath = localPath;
+                info.InstalledDateTime = FileSystemHelpers.GetLastWriteTimeUtc(info.LocalPath);
+            }
+
+            if (ExtensionRequiresApplicationHost(info))
+            {
+                info.ExtensionUrl = GetFullUrl(GetUrlFromApplicationHost(localPath));
+            }
+            else
+            {
+                info.ExtensionUrl = String.IsNullOrEmpty(info.LocalPath) ? null : GetFullUrl(info.ExtensionUrl);
+            }
+
+            foreach (var setting in GetSettingManager(info.Id).GetValues())
+            {
+                if (String.Equals(setting.Key, _feedUrlSetting, StringComparison.OrdinalIgnoreCase))
+                {
+                    info.FeedUrl = setting.Value.Value<string>();
+                }
+                else if (String.Equals(setting.Key, _installUtcTimestampSetting, StringComparison.OrdinalIgnoreCase))
+                {
+                    DateTime installedDateTime;
+                    if (DateTime.TryParse(setting.Value.Value<string>(), out installedDateTime))
+                    {
+                        info.InstalledDateTime = installedDateTime.ToUniversalTime();
+                    }
+                }
+                else if (String.Equals(setting.Key, _installationArgs, StringComparison.OrdinalIgnoreCase))
+                {
+                    info.InstallationArgs = setting.Value.Value<string>();
+                }
+            }
+        }
+
+        private static string GetUrlFromApplicationHost(string localPath)
+        {
+            string xdtFile = Path.Combine(localPath, Constants.ApplicationHostXdtFileName);
+            string scmXdtFile = Path.Combine(localPath, Constants.ScmApplicationHostXdtFileName);
+            string xdtFilePath = FileSystemHelpers.FileExists(scmXdtFile) ? scmXdtFile : FileSystemHelpers.FileExists(xdtFile) ? xdtFile : null;
+
+            if (xdtFilePath != null)
+            {
+                try
+                {
+                    var appHostDoc = new XmlDocument();
+
+                    appHostDoc.Load(xdtFilePath);
+                    // yet there's no siteextension with both applicationHost.xdt
+                    // Get the 'path' property of the first 'application' element, which is the relative url.
+                    XmlNode pathPropertyNode = appHostDoc.SelectSingleNode("//application[@path]/@path");
+
+                    return pathPropertyNode.Value;
+
+                }
+                catch (SystemException)
+                {
+                    // return null
+                }
+            }
+            return null;
+
+        }
+
+        private void DeploySiteExtensionJobs(string siteExtensionName)
+        {
+            string siteExtensionPath = Path.Combine(_rootPath, siteExtensionName);
+            _continuousJobManager.SyncExternalJobs(siteExtensionPath, siteExtensionName);
+            _triggeredJobManager.SyncExternalJobs(siteExtensionPath, siteExtensionName);
+        }
+
+        private void CleanupSiteExtensionJobs(string siteExtensionName)
+        {
+            _continuousJobManager.CleanupExternalJobs(siteExtensionName);
+            _triggeredJobManager.CleanupExternalJobs(siteExtensionName);
+        }
+
+        private async Task<SiteExtensionInfo> ConvertRemotePackageToSiteExtensionInfo(UIPackageMetadata package, string feedUrl, UIMetadataResource metadataResource)
+        {
+            // convert uipackagemetadata structure to siteextensioninfo structure
+            var siteExtensionInfo = new SiteExtensionInfo(package);
+            siteExtensionInfo.FeedUrl = feedUrl;
+            // check existing local site extension version and update the field "LocalIsLatestVersion" in siteextensioninfo
+            return await CheckRemotePackageLatestVersion(siteExtensionInfo, metadataResource);
+        }
+
+        private async Task<SiteExtensionInfo> CheckRemotePackageLatestVersion(SiteExtensionInfo info, UIMetadataResource metadataResource)
+        {
+            bool isNuGetPackage = false;
+
+            if (!string.IsNullOrEmpty(info.FeedUrl))
+            {
+                isNuGetPackage = FeedExtensions.IsNuGetRepo(info.FeedUrl);
+            }
+
+            UIPackageMetadata localPackage = await metadataResource.GetLatestPackageByIdFromMetaRes(info.Id,
+                explicitTag: isNuGetPackage);
+
+            if (localPackage != null)
+            {
+                SetLocalInfo(info);
+                // Assume input package (from remote) is always the latest version.
+                info.LocalIsLatestVersion = NuGetVersion.Parse(info.Version).Equals(localPackage.Identity.Version);
+            }
+
+            return info;
+        }
+
+        private async Task<SiteExtensionInfo> ConvertLocalPackageToSiteExtensionInfo(UIPackageMetadata package, bool checkLatest, ITracer tracer = null)
+        {
+            if (package == null)
+            {
+                return null;
+            }
+
+            var info = new SiteExtensionInfo(package);
+            if (IsInstalledToWebRoot(info.Id))
+            {
+                info.Type = SiteExtensionInfo.SiteExtensionType.WebRoot;
+            }
+
+            SetLocalInfo(info);
+            await TryCheckLocalPackageLatestVersionFromRemote(info, checkLatest, tracer);
+            return info;
+        }
+
+        private async Task TryCheckLocalPackageLatestVersionFromRemote(SiteExtensionInfo info, bool checkLatest, ITracer tracer = null)
+        {
+            if (checkLatest)
+            {
+                try
+                {
+                    // FindPackage gets back the latest version.
+                    IEnumerable<SourceRepository> remoteRepos = GetRemoteRepositories(info.FeedUrl);
+                    foreach (SourceRepository remoteRepo in remoteRepos)
+                    {
+                        UIPackageMetadata latestPackage = await remoteRepo.GetLatestPackageByIdFromSrcRepo(info.Id);
+                        if (latestPackage != null)
+                        {
+                            NuGetVersion currentVersion = NuGetVersion.Parse(info.Version);
+                            info.LocalIsLatestVersion = NuGetVersion.Parse(info.Version).Equals(latestPackage.Identity.Version);
+                            info.DownloadCount = latestPackage.DownloadCount;
+                            info.PublishedDateTime = latestPackage.Published;
+                            break;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (tracer != null)
+                    {
+                        tracer.TraceError(ex);
+                    }
+                }
+            }
+        }
+
+        private static bool ExtensionRequiresApplicationHost(SiteExtensionInfo info)
+        {
+            string appSettingName = info.Id.ToUpper(CultureInfo.CurrentCulture) + "_EXTENSION_VERSION";
+            return ConfigurationManager.AppSettings[appSettingName] != "beta";
+        }
+
+        private string GetFullUrl(string url)
+        {
+            return url == null ? null : new Uri(new Uri(_baseUrl), url).ToString().Trim('/') + "/";
+        }
+
+        private bool IsInstalledToWebRoot(string packageId)
+        {
+            JsonSettings siteExtensionSettings = GetSettingManager(packageId);
+            string packageTypeStr = siteExtensionSettings.GetValue(_packageType);
+            SiteExtensionInfo.SiteExtensionType packageType;
+
+            return (Enum.TryParse<SiteExtensionInfo.SiteExtensionType>(packageTypeStr, true, out packageType)
+                && SiteExtensionInfo.SiteExtensionType.WebRoot == packageType);
+        }
+
+        /// <summary>
+        /// Create SourceRepository from given feed endpoint
+        /// </summary>
+        /// <param name="feedEndpoint">V2 or V3 feed endpoint</param>
+        /// <returns>SourceRepository object</returns>
+        private static SourceRepository GetSourceRepository(string feedEndpoint)
+        {
+            NuGet.Configuration.PackageSource source = new NuGet.Configuration.PackageSource(feedEndpoint);
+            return new SourceRepository(source, _providers.Value);
+        }
+
+        private static IEnumerable<Lazy<INuGetResourceProvider, INuGetResourceProviderMetadata>> GetNugetProviders()
+        {
+            var aggregateCatalog = new AggregateCatalog();
+            var directoryCatalog = new DirectoryCatalog(HttpRuntime.BinDirectory, "NuGet.Client*.dll");
+            aggregateCatalog.Catalogs.Add(directoryCatalog);
+            var container = new CompositionContainer(aggregateCatalog);
+            return container.GetExports<INuGetResourceProvider, INuGetResourceProviderMetadata>();
+        }
+    }
+}

--- a/Kudu.Core/packages.config
+++ b/Kudu.Core/packages.config
@@ -53,5 +53,6 @@
   <package id="System.Text.Encodings.Web" version="4.0.0" targetFramework="net46" />
   <package id="System.Threading" version="4.0.11" targetFramework="net46" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net46" />
+  <package id="System.Xml.Linq" version="3.5.21022.801" targetFramework="net46" />
   <package id="XmlSettings" version="0.1.3" targetFramework="net45" />
 </packages>

--- a/Kudu.FunctionalTests/SiteExtensions/SiteExtensionApiFacts.cs
+++ b/Kudu.FunctionalTests/SiteExtensions/SiteExtensionApiFacts.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Kudu.Client;
 using Kudu.Client.SiteExtensions;
 using Kudu.Contracts.Jobs;
+using Kudu.Contracts.Settings;
 using Kudu.Contracts.SiteExtensions;
 using Kudu.Core.Infrastructure;
 using Kudu.FunctionalTests.Infrastructure;
@@ -31,15 +32,22 @@ namespace Kudu.FunctionalTests.SiteExtensions
         };
 
         [Theory]
-        [InlineData(null, "sitereplicator", "site replicator")]    // default site extension endpoint (v2)
-        [InlineData("https://api.nuget.org/v3/index.json", "filecounter", "file counter")]    // v3 endpoint
-        public async Task SiteExtensionV2AndV3FeedTests(string feedEndpoint, string testPackageId, string searchString)
+        [InlineData(null, "sitereplicator", "site replicator", false)]    // default site extension endpoint (v2)
+        [InlineData("https://api.nuget.org/v3/index.json", "filecounter", "file counter", false)]    // v3 endpoint
+        [InlineData(null, "sitereplicator", "site replicator", true)]    // default site extension endpoint (v2)
+        [InlineData("https://api.nuget.org/v3/index.json", "filecounter", "file counter", true)]    // v3 endpoint
+        public async Task SiteExtensionV2AndV3FeedTests(string feedEndpoint, string testPackageId, string searchString, bool useSiteExtensionV1)
         {
             TestTracer.Trace("Testing against feed: '{0}'", feedEndpoint);
 
             const string appName = "SiteExtensionV2AndV3FeedTests";
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -76,14 +84,21 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionBasicTests()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionBasicTests(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionBasicTests";
             const string installationArgument = "arg0";
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -177,13 +192,20 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionShouldDeployWebJobs()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionShouldDeployWebJobs(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionShouldDeployWebJobs";
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -225,9 +247,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
         }
 
         [Theory]
-        [InlineData(null, "sitereplicator")]    // default site extension endpoint (v2)
-        [InlineData("https://api.nuget.org/v3/index.json", "filecounter")]    // v3 endpoint
-        public async Task SiteExtensionInstallUninstallAsyncTest(string feedEndpoint, string testPackageId)
+        [InlineData(null, "sitereplicator", false)]    // default site extension endpoint (v2)
+        [InlineData("https://api.nuget.org/v3/index.json", "filecounter", false)]    // v3 endpoint
+        [InlineData(null, "sitereplicator", true)]    // default site extension endpoint (v2)
+        [InlineData("https://api.nuget.org/v3/index.json", "filecounter", true)]    // v3 endpoint
+        public async Task SiteExtensionInstallUninstallAsyncTest(string feedEndpoint, string testPackageId, bool useSiteExtensionV1)
         {
             TestTracer.Trace("Testing against feed: '{0}'", feedEndpoint);
 
@@ -235,6 +259,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -304,8 +333,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionGetArmTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionGetArmTest(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionGetAsyncTest";
             const string searchString = "file counter";
@@ -315,6 +346,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -375,14 +411,20 @@ namespace Kudu.FunctionalTests.SiteExtensions
         }
 
         [Theory]
-        [InlineData(null, "sitereplicator", "filecounter", "letsencrypt")]    // default site extension endpoint (v2)
+        [InlineData(null, "sitereplicator", "filecounter", "letsencrypt", false)]    // default site extension endpoint (v2)
+        [InlineData(null, "sitereplicator", "filecounter", "letsencrypt", true)]    // default site extension endpoint (v2)
         // [InlineData("https://api.nuget.org/v3/index.json", "bootstrap", "knockoutjs", "angularjs")]    // v3 endpoint
-        public async Task SiteExtensionParallelInstallationTest(string feedEndpoint, string testPackageId1, string testPackageId2, string testPackageId3)
+        public async Task SiteExtensionParallelInstallationTest(string feedEndpoint, string testPackageId1, string testPackageId2, string testPackageId3, bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionParallelInstallationTest";
             string[] packageIds = { testPackageId1, testPackageId2, testPackageId3 };
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -433,8 +475,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionShouldNotSeeButAbleToInstallUnlistedPackage()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionShouldNotSeeButAbleToInstallUnlistedPackage(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionShouldNotSeeUnlistPackage";
             const string externalPackageId = "SimpleSite";
@@ -444,6 +488,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -509,8 +558,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionNormalizedVersionTests()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionNormalizedVersionTests(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionNormalizedVersionTests";
             const string externalPackageId = "SimpleSite";
@@ -521,6 +572,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -537,8 +593,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionInstallPackageToWebRootTests()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionInstallPackageToWebRootTests(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionInstallPackageToWebRootTests";
             const string externalPackageId = "SimpleSvc";
@@ -550,6 +608,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -609,8 +672,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionInstallPackageToWebRootAsyncTests()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionInstallPackageToWebRootAsyncTests(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionInstallPackageToWebRootAsyncTests";
             const string externalPackageId = "SimpleSvc";
@@ -622,6 +687,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 
@@ -704,8 +774,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task SiteExtensionNugetOrgTest()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SiteExtensionNugetOrgTest(bool useSiteExtensionV1)
         {
             const string appName = "SiteExtensionNugetOrgTest";
             const string nonSiteExtensionPackage = "NewRelic.Azure.WebSites";
@@ -714,6 +786,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await CleanSiteExtensions(manager);
 

--- a/Kudu.FunctionalTests/SiteExtensions/SiteExtensionsIncrementalDeploymentTests.cs
+++ b/Kudu.FunctionalTests/SiteExtensions/SiteExtensionsIncrementalDeploymentTests.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
+using Kudu.Contracts.Settings;
 using Kudu.Contracts.SiteExtensions;
 using Kudu.TestHarness;
 using Kudu.TestHarness.Xunit;
@@ -16,8 +13,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
     [KuduXunitTestClass]
     public class SiteExtensionsIncrementalDeploymentTests
     {
-        [Fact]
-        public async Task CanInstallAndUpdate()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CanInstallAndUpdate(bool useSiteExtensionV1)
         {
             const string appName = "IncrementalDeploymentTests";
             const string packageId = "IncrementalDeployment";
@@ -27,6 +26,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await SiteExtensionApiFacts.CleanSiteExtensions(manager);
 
@@ -65,8 +69,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
             });
         }
 
-        [Fact]
-        public async Task CanInstallAndUpdateWithoutType()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CanInstallAndUpdateWithoutType(bool useSiteExtensionV1)
         {
             const string appName = "IncrementalDeploymentTests";
             const string packageId = "IncrementalDeployment";
@@ -76,6 +82,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await SiteExtensionApiFacts.CleanSiteExtensions(manager);
 
@@ -118,8 +129,10 @@ namespace Kudu.FunctionalTests.SiteExtensions
         /// <para>Test package that are not zip by nuget tool</para>
         /// <para>Differences are, package zip by nuget tool will not include 'folder', others might</para>
         /// </summary>
-        [Fact]
-        public async Task CanInstallAndUpdateWithAbnormalPackage()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CanInstallAndUpdateWithAbnormalPackage(bool useSiteExtensionV1)
         {
             const string appName = "IncrementalDeploymentWithComplexPackageTests";
             const string packageId = "microsoft.com.azuremediaservicesconnector";
@@ -130,6 +143,11 @@ namespace Kudu.FunctionalTests.SiteExtensions
 
             await ApplicationManager.RunAsync(appName, async appManager =>
             {
+                if (useSiteExtensionV1)
+                {
+                    await appManager.SettingsManager.SetValue(SettingsKeys.UseSiteExtensionV1, "1");
+                }
+
                 var manager = appManager.SiteExtensionManager;
                 await SiteExtensionApiFacts.CleanSiteExtensions(manager);
 

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -329,6 +329,7 @@ namespace Kudu.Services.Web.App_Start
 
             // SiteExtensions
             kernel.Bind<ISiteExtensionManager>().To<SiteExtensionManager>().InRequestScope();
+            kernel.Bind<ISiteExtensionManagerV2>().To<SiteExtensionManagerV2>().InRequestScope();
 
             // Functions
             kernel.Bind<IFunctionManager>().To<FunctionManager>().InRequestScope();

--- a/Kudu.Services.Web/App_Start/PathResolver.cs
+++ b/Kudu.Services.Web/App_Start/PathResolver.cs
@@ -9,7 +9,7 @@ namespace Kudu.Services.Web
         public static string ResolveRootPath()
         {
             // The HOME path should always be set correctly
-            string path = "E:\\kudu-debug2";
+            string path = Environment.ExpandEnvironmentVariables(@"%HOME%");
             if (Directory.Exists(path))
             {
                 // For users running Windows Azure Pack 2 (WAP2), %HOME% actually points to the site folder,

--- a/Kudu.Services.Web/App_Start/PathResolver.cs
+++ b/Kudu.Services.Web/App_Start/PathResolver.cs
@@ -9,7 +9,7 @@ namespace Kudu.Services.Web
         public static string ResolveRootPath()
         {
             // The HOME path should always be set correctly
-            string path = Environment.ExpandEnvironmentVariables(@"%HOME%");
+            string path = "E:\\kudu-debug2";
             if (Directory.Exists(path))
             {
                 // For users running Windows Azure Pack 2 (WAP2), %HOME% actually points to the site folder,

--- a/Kudu.Services/SiteExtensions/SiteExtensionController.cs
+++ b/Kudu.Services/SiteExtensions/SiteExtensionController.cs
@@ -64,7 +64,7 @@ namespace Kudu.Services.SiteExtensions
         [HttpGet]
         public async Task<HttpResponseMessage> GetRemoteExtensions(string filter = null, bool allowPrereleaseVersions = false, string feedUrl = null)
         {
-            if (_useSiteExtensionV1)
+            if (_useSiteExtensionV1 || !string.IsNullOrEmpty(feedUrl))
             {
                 return Request.CreateResponse(
                     HttpStatusCode.OK,
@@ -82,7 +82,7 @@ namespace Kudu.Services.SiteExtensions
         public async Task<HttpResponseMessage> GetRemoteExtension(string id, string version = null, string feedUrl = null)
         {
             SiteExtensionInfo extension = null;
-            if (_useSiteExtensionV1)
+            if (_useSiteExtensionV1 || !string.IsNullOrEmpty(feedUrl))
             {
                 extension = await _v1Manager.GetRemoteExtension(id, version, feedUrl);
             }
@@ -324,7 +324,7 @@ namespace Kudu.Services.SiteExtensions
                         {
                             using (backgroundTracer.Step("Background thread started for {0} installation", id))
                             {
-                                if (_useSiteExtensionV1)
+                                if (_useSiteExtensionV1 || !string.IsNullOrEmpty(requestInfo.FeedUrl))
                                 {
                                     _v1Manager.InstallExtension(id, requestInfo.Version, requestInfo.FeedUrl, requestInfo.Type, backgroundTracer, requestInfo.InstallationArgs).Wait();
                                 }
@@ -362,7 +362,7 @@ namespace Kudu.Services.SiteExtensions
             else
             {
 
-                if (_useSiteExtensionV1)
+                if (_useSiteExtensionV1 || !string.IsNullOrEmpty(requestInfo.FeedUrl))
                 {
                     result = await _v1Manager.InstallExtension(id, requestInfo.Version, requestInfo.FeedUrl, requestInfo.Type, tracer, requestInfo.InstallationArgs);
                 }


### PR DESCRIPTION
Added a new SiteExtensionManager which directly queries the NuGet repositories from v2 NuGet API(supporting SemVer2 versioning) to serve/install Kudu Site Extensions.