### PR TITLE
Allow Deep linking for detectors, Analysis and Diagnostic Tools in Diagnose and Solve

### DIFF
--- a/Kudu.Services.Web/Detectors/Default.cshtml
+++ b/Kudu.Services.Web/Detectors/Default.cshtml
@@ -5,6 +5,12 @@
     var siteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? "";
     var hostName = Environment.GetEnvironmentVariable("HTTP_HOST") ?? "";
     var slotName = "";
+    var path = "";
+
+    if (Request.QueryString["type"] != null && Request.QueryString["name"] != null)
+    {
+        path = string.Format("{0}%2F{1}", Request.QueryString["type"].ToString(), Request.QueryString["name"].ToString());
+    }
 
     var index = ownerName.IndexOf('+');
     if (index >= 0)
@@ -13,13 +19,20 @@
     }
 
     string detectorPath;
-    if (Kudu.Core.Helpers.OSDetector.IsOnWindows())
+    if (!string.IsNullOrWhiteSpace(path))
     {
-        detectorPath = "diagnostics%2Favailability%2Fanalysis";
+        detectorPath = path;
     }
     else
     {
-        detectorPath = "detectors%2FLinuxAppDown";
+        if (Kudu.Core.Helpers.OSDetector.IsOnWindows())
+        {
+            detectorPath = "analysis%2FappDownAnalysis";
+        }
+        else
+        {
+            detectorPath = "detectors%2FLinuxAppDown";
+        }
     }
 
     var hostNameIndex = hostName.IndexOf('.');


### PR DESCRIPTION
With this change, we can now deeplink to different tools and detectors in Diagnostics blade

Url| Destination
-- | --
_sitename_.scm.azurewebsites.net/detectors | New Web App Down for Windows Web Apps
_sitename_.scm.azurewebsites.net/detectors?type=detectors&name=httpservererrors | Goes to HttpServerErrors detector
_sitename_.scm.azurewebsites.net/detectors?type=analysis&name=perfAnalysis | Goes to Web App Slow Analysis
_sitename_.scm.azurewebsites.net/detectors?type=tools&name=profiler | Goes to Profiler tool

