### PR TITLE
Add Web Console support for Windows Containers on Azure App Service

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
+++ b/Kudu.Services.Web/Content/Scripts/KuduExecV2.js
@@ -7,7 +7,14 @@ function SwitchConsole() {
         LoadConsole();
     } else {
         window.$KuduExecConsole.replaceWith("<div id=\"KuduExecConsoleV2\" class=\"left-aligned\"></div>");
-        $('#SwitchConsoleLink').text("Use old console");
+        
+        if ($.isolation === "hyperv") {
+            $('#SwitchConsoleLink').text("");
+        }
+        else {
+            $('#SwitchConsoleLink').text("Use old console");
+        }
+
         LoadConsoleV2();
     }
 }

--- a/Kudu.Services.Web/DebugConsole/WindowsConsole.cshtml
+++ b/Kudu.Services.Web/DebugConsole/WindowsConsole.cshtml
@@ -127,7 +127,7 @@
                 <span class="up" title="Slide up"><i class="glyphicon glyphicon-chevron-up"></i></span>
             </h4>
         </div>
-        <a id="SwitchConsoleLink" href="javascript:SwitchConsole();" class="right">Use old console</a>
+        <a id="SwitchConsoleLink" href="javascript:SwitchConsole();" class="right"></a>
         <div id="KuduExecConsoleV2" class="left-aligned"></div>
 
         <!-- File upload progress modal -->

--- a/Kudu.Services.Web/_Layout.cshtml
+++ b/Kudu.Services.Web/_Layout.cshtml
@@ -41,12 +41,21 @@
     {
         <script>
             $.serverOS = "windows";
+            $.isolation = "pico";
+        </script>
+    }
+    else if (Kudu.Core.Helpers.EnvironmentHelper.IsWindowsContainers())
+    {
+        <script>
+            $.serverOS = "windows";
+            $.isolation = "hyperv";
         </script>
     }
     else
     {
         <script>
             $.serverOS = "linux";
+            $.isolation = "none";
         </script>
     }
 </head>
@@ -91,12 +100,9 @@
                     }
                     else if (Kudu.Core.Helpers.OSDetector.IsOnWindows() && Kudu.Core.Helpers.EnvironmentHelper.IsWindowsContainers())
                     {
-                        <li class="dropdown">
-                            <a href="#" data-toggle="dropdown" class="dropdown-toggle">Debug console <b class="caret"></b></a>
-                            <ul class="dropdown-menu">
-                                <li><a href="~/webssh/host">SSH</a></li>
-                            </ul>
-                        </li>
+                        <li><a href="~/DebugConsole">Console</a></li>
+                        <li><a href="~/webssh/host">SSH</a></li>
+                        <li><a href="~/api/logstream">Log stream</a></li>
                     }
                     else
                     {

--- a/Kudu.Services/Commands/PersistentCommandController.cs
+++ b/Kudu.Services/Commands/PersistentCommandController.cs
@@ -106,7 +106,11 @@ namespace Kudu.Services
                 WorkingDirectory = _environment.RootPath
             };
 
-            if (shell.Equals("powershell", StringComparison.OrdinalIgnoreCase))
+            if (Kudu.Core.Helpers.EnvironmentHelper.IsWindowsContainers())
+            {
+                startInfo.FileName = System.Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\IIS\Microsoft Web Hosting Framework\Containers\Diagnostics\Microsoft.Windows.Containers.Console.exe");
+            }
+            else if (shell.Equals("powershell", StringComparison.OrdinalIgnoreCase))
             {
                 startInfo.FileName = System.Environment.ExpandEnvironmentVariables(@"%windir%\System32\WindowsPowerShell\v1.0\powershell.exe");
                 startInfo.Arguments = "-ExecutionPolicy RemoteSigned -File -";


### PR DESCRIPTION
Additionally, I disabled the option "Use old console" for Windows Container sites.