### PR TITLE
SyncTriggers on Docker WebHook

### DIFF
--- a/Kudu.Core/Helpers/EnvironmentHelper.cs
+++ b/Kudu.Core/Helpers/EnvironmentHelper.cs
@@ -27,18 +27,6 @@ namespace Kudu.Core.Helpers
         // Is this a Windows Containers site?
         public static bool IsWindowsContainers()
         {
-            // OLD WAY: This can be removed after ANT84
-            string xenonVarString = System.Environment.GetEnvironmentVariable("XENON");
-            int xenonVarValue;
-            if (xenonVarString != null && int.TryParse(xenonVarString, out xenonVarValue))
-            {
-                if (xenonVarValue == 1)
-                {
-                    return true;
-                }
-            }
-
-            // NEW WAY
             string isolation = System.Environment.GetEnvironmentVariable("WEBSITE_ISOLATION");
             return isolation == "hyperv" || isolation == "process";
         }

--- a/Kudu.Core/Helpers/FunctionsHelper.cs
+++ b/Kudu.Core/Helpers/FunctionsHelper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kudu.Contracts.Tracing;
+using Kudu.Core.Tracing;
+
+namespace Kudu.Core.Helpers
+{
+    public static class FunctionsHelper
+    {
+        private static HttpClient _httpClient;
+
+        internal static HttpClient HttpClient
+        {
+            get
+            {
+                if (_httpClient == null)
+                {
+                    _httpClient = new HttpClient();
+                }
+                return _httpClient;
+            }
+            set
+            {
+                _httpClient = value;
+            }
+        }
+
+        public static async Task SyncTriggersAsync(ITracer tracer)
+        {
+            string uri = GetRuntimeUri("admin/host/synctriggers");
+
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            await SendRuntimeRequestAsync(request, tracer);
+        }
+
+        private static async Task<HttpResponseMessage> SendRuntimeRequestAsync(HttpRequestMessage request, ITracer tracer)
+        {
+            try
+            {
+                var requestId = Guid.NewGuid().ToString();
+                tracer.Trace($"Issuing request to runtime (Method: {request.Method}, Uri: {request.RequestUri}, RequestId: {requestId})");
+
+                request.Headers.UserAgent.Add(PostDeploymentHelper.UserAgent.Value);
+                request.Headers.Add(Constants.SiteRestrictedToken, SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5)));
+                request.Headers.Add(Constants.RequestIdHeader, requestId);
+
+                var response = await HttpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+
+                tracer.Trace($"Request succeeded (Status: {response.StatusCode})");
+
+                return response;
+            }
+            catch (HttpRequestException ex)
+            {
+                tracer.TraceError(ex, "Request failed");
+                throw;
+            }
+        }
+
+        private static string GetRuntimeUri(string path)
+        {
+            // form the runtime host name from our own SCM host
+            // by removing the scm segement
+            var host = PostDeploymentHelper.HttpHost;
+            host = host.Replace(".scm.", ".");
+
+            return $"https://{host}/{path}";
+        }
+    }
+}

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -25,7 +25,7 @@ namespace Kudu.Core.Helpers
     {
         public const string AutoSwapLockFile = "autoswap.lock";
 
-        private static Lazy<ProductInfoHeaderValue> _userAgent = new Lazy<ProductInfoHeaderValue>(() =>
+        internal static Lazy<ProductInfoHeaderValue> UserAgent = new Lazy<ProductInfoHeaderValue>(() =>
         {
             var assembly = Assembly.GetExecutingAssembly();
             var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
@@ -48,7 +48,7 @@ namespace Kudu.Core.Helpers
         }
 
         // HTTP_HOST = site.scm.azurewebsites.net
-        private static string HttpHost
+        internal static string HttpHost
         {
             get { return System.Environment.GetEnvironmentVariable(Constants.HttpHost); }
         }
@@ -237,7 +237,7 @@ namespace Kudu.Core.Helpers
 
                 using (var client = HttpClientFactory())
                 {
-                    client.DefaultRequestHeaders.UserAgent.Add(_userAgent.Value);
+                    client.DefaultRequestHeaders.UserAgent.Add(UserAgent.Value);
                     client.DefaultRequestHeaders.Add(Constants.ClientRequestIdHeader, requestId);
 
                     var payload = new StringContent(content ?? string.Empty, Encoding.UTF8, "application/json");
@@ -435,7 +435,7 @@ namespace Kudu.Core.Helpers
                         client.DefaultRequestHeaders.Host = host;
                     }
 
-                    client.DefaultRequestHeaders.UserAgent.Add(_userAgent.Value);
+                    client.DefaultRequestHeaders.UserAgent.Add(UserAgent.Value);
                     client.DefaultRequestHeaders.Add(Constants.SiteRestrictedToken, SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5)));
                     client.DefaultRequestHeaders.Add(Constants.RequestIdHeader, requestId);
 

--- a/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
+++ b/Kudu.Core/Infrastructure/DockerContainerRestartTrigger.cs
@@ -20,6 +20,11 @@ namespace Kudu.Core.Infrastructure
             "The last modification Kudu made to this file was at {0}, for the following reason: {1}.",
             System.Environment.NewLine);
 
+        public static string GetRestartFilePath(IEnvironment environment)
+        {
+            return Path.Combine(environment.SiteRootPath, CONFIG_DIR_NAME, TRIGGER_FILENAME);
+        }
+
         public static void RequestContainerRestart(IEnvironment environment, string reason)
         {
             if (OSDetector.IsOnWindows() && !EnvironmentHelper.IsWindowsContainers())
@@ -27,7 +32,7 @@ namespace Kudu.Core.Infrastructure
                 throw new NotSupportedException("RequestContainerRestart is only supported on Linux and Windows Containers");
             }
 
-            var restartTriggerPath = Path.Combine(environment.SiteRootPath, CONFIG_DIR_NAME, TRIGGER_FILENAME);
+            var restartTriggerPath = GetRestartFilePath(environment);
 
             FileSystemHelpers.CreateDirectory(Path.GetDirectoryName(restartTriggerPath));
 

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Deployment\ZipDeploymentInfo.cs" />
     <Compile Include="Functions\FunctionManager.cs" />
     <Compile Include="Helpers\EnvironmentHelper.cs" />
+    <Compile Include="Helpers\FunctionsHelper.cs" />
     <Compile Include="Helpers\OSDetector.cs" />
     <Compile Include="Helpers\PermissionHelper.cs" />
     <Compile Include="Helpers\PostDeploymentHelper.cs" />

--- a/Kudu.Core/Properties/AssemblyInfo.cs
+++ b/Kudu.Core/Properties/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Core APIs for Kudu.")]
 [assembly: InternalsVisibleTo("Kudu.Core.Test")]
 [assembly: InternalsVisibleTo("Kudu.TestHarness")]
+[assembly: InternalsVisibleTo("Kudu.Services.Test")]

--- a/Kudu.Services.Test/DockerControllerFacts.cs
+++ b/Kudu.Services.Test/DockerControllerFacts.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Kudu.Contracts.Settings;
+using Kudu.Core;
+using Kudu.Core.Helpers;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
+using Kudu.Services.Docker;
+using Moq;
+using Xunit;
+
+namespace Kudu.Services.Test
+{
+    public class DockerControllerFacts
+    {
+        private readonly Mock<IDeploymentSettingsManager> _settingsManagerMock;
+        private readonly Mock<ITraceFactory> _traceFactoryMock;
+        private readonly Mock<IEnvironment> _environmentMock;
+        private readonly DockerController _controller;
+        private readonly MockHttpHandler _httpHandler;
+        private string _dockerCIEnabled;
+
+        public DockerControllerFacts()
+        {
+            _settingsManagerMock = new Mock<IDeploymentSettingsManager>(MockBehavior.Strict);
+            _settingsManagerMock.Setup(p => p.GetValue(SettingsKeys.DockerCiEnabled, false)).Returns(() => _dockerCIEnabled);
+            _traceFactoryMock = new Mock<ITraceFactory>(MockBehavior.Strict);
+            _traceFactoryMock.Setup(p => p.GetTracer()).Returns(NullTracer.Instance);
+            _environmentMock = new Mock<IEnvironment>(MockBehavior.Strict);
+            _environmentMock.SetupGet(p => p.SiteRootPath).Returns(Path.Combine(Path.GetTempPath(), nameof(DockerControllerFacts)));
+
+            _controller = new DockerController(_traceFactoryMock.Object, _settingsManagerMock.Object, _environmentMock.Object)
+            {
+                Request = new HttpRequestMessage()
+            };
+
+            _httpHandler = new MockHttpHandler();
+            FunctionsHelper.HttpClient = new HttpClient(_httpHandler);
+        }
+
+        [Fact]
+        public async Task ReceiveHook_InvokesSyncTriggers()
+        {
+            var prevIsolationValue = System.Environment.GetEnvironmentVariable("WEBSITE_ISOLATION");
+            var prevHostValue = System.Environment.GetEnvironmentVariable(Constants.HttpHost);
+            var prevEncryptionKey = System.Environment.GetEnvironmentVariable(Constants.SiteAuthEncryptionKey);
+
+            _dockerCIEnabled = "1";
+
+            var restartTriggerPath = DockerContainerRestartTrigger.GetRestartFilePath(_environmentMock.Object);
+            if (File.Exists(restartTriggerPath))
+            {
+                File.Delete(restartTriggerPath);
+            }
+            
+            try
+            {
+                System.Environment.SetEnvironmentVariable(Constants.SiteAuthEncryptionKey, GenerateKey());
+                System.Environment.SetEnvironmentVariable("WEBSITE_ISOLATION", "hyperv");
+                System.Environment.SetEnvironmentVariable(Constants.HttpHost, "test.scm.azurewebsites.net");
+
+                var response = await _controller.ReceiveHook();
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                Assert.True(File.Exists(restartTriggerPath));
+
+                var syncRequest = _httpHandler.Request;
+                Assert.NotNull(syncRequest);
+                Assert.Equal("https://test.azurewebsites.net/admin/host/synctriggers", syncRequest.RequestUri.ToString());
+                Assert.Equal(PostDeploymentHelper.UserAgent.Value.ToString(), syncRequest.Headers.UserAgent.ToString());
+                Assert.True(syncRequest.Headers.Contains(Constants.SiteRestrictedToken));
+                Assert.True(syncRequest.Headers.Contains(Constants.RequestIdHeader));
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable("WEBSITE_ISOLATION", prevIsolationValue);
+                System.Environment.SetEnvironmentVariable(Constants.HttpHost, prevHostValue);
+                System.Environment.SetEnvironmentVariable(Constants.SiteAuthEncryptionKey, prevEncryptionKey);
+            }
+        }
+
+        private class MockHttpHandler : HttpClientHandler
+        {
+            public MockHttpHandler()
+            {
+            }
+
+            public HttpRequestMessage Request { get; set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Request = request;
+                var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+                return Task.FromResult(response);
+            }
+        }
+
+        private static string GenerateKey()
+        {
+            using (var aes = new AesManaged())
+            {
+                aes.GenerateKey();
+                return BitConverter.ToString(aes.Key).Replace("-", string.Empty);
+            }
+        }
+    }
+}

--- a/Kudu.Services.Test/Kudu.Services.Test.csproj
+++ b/Kudu.Services.Test/Kudu.Services.Test.csproj
@@ -78,6 +78,7 @@
     <Compile Include="CustomGitRepositoryHandlerFacts.cs" />
     <Compile Include="DeploymentControllerFacts.cs" />
     <Compile Include="Diagnostics\ProcessControllerFacts.cs" />
+    <Compile Include="DockerControllerFacts.cs" />
     <Compile Include="DropboxHelperFacts.cs" />
     <Compile Include="FileInfoBase.cs" />
     <Compile Include="GenericHandlerFacts.cs" />

--- a/Kudu.Services/Docker/DockerController.cs
+++ b/Kudu.Services/Docker/DockerController.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web.Http;
-using Kudu.Core.Helpers;
-using Kudu.Core.Tracing;
 using Kudu.Contracts.Settings;
-using Kudu.Core.Infrastructure;
 using Kudu.Core;
+using Kudu.Core.Helpers;
+using Kudu.Core.Infrastructure;
+using Kudu.Core.Tracing;
 
 namespace Kudu.Services.Docker
 {
@@ -25,7 +26,7 @@ namespace Kudu.Services.Docker
         }
 
         [HttpPost]
-        public HttpResponseMessage ReceiveHook()
+        public async Task<HttpResponseMessage> ReceiveHook()
         {
             if (OSDetector.IsOnWindows() && !EnvironmentHelper.IsWindowsContainers())
             {
@@ -40,6 +41,15 @@ namespace Kudu.Services.Docker
                     if (_settings.IsDockerCiEnabled())
                     {
                         DockerContainerRestartTrigger.RequestContainerRestart(_environment, RESTART_REASON);
+
+
+                        // When a docker image is updated, we need to ensure that a SyncTriggers operation is performed.
+                        // There are 2 cases:
+                        // 1) No containers are currently running - in this case the sync will start a container with the new image,
+                        //    and the sync will be up to date.
+                        // 2) One or more containers are currently running - in this case the container restart will cause them to
+                        //    restart, and the background sync triggers performed by the runtime will do the sync.
+                        await FunctionsHelper.SyncTriggersAsync(tracer);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
Issue runtime SyncTriggers when a Docker image update webhook is received.

I'll need to make the same change to KuduLite as well. Working on testing E2E now by hot swapping Kudu binaries in my private stamp and verifying runtime sync is invoked.