### PR TITLE
Fix the IsLoopback check

### DIFF
--- a/Kudu.Services/Error404Controller.cs
+++ b/Kudu.Services/Error404Controller.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 
@@ -10,7 +11,7 @@ namespace Kudu.Services
         public HttpResponseMessage Handle()
         {
             // Mock few paths. For development purposes only.
-            if (this.Request.RequestUri.IsLoopback)
+            if (this.Request.RequestUri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
             {
                 if (this.Request.RequestUri.AbsolutePath.Equals(Constants.RestartApiPath, System.StringComparison.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
- IsLoopback() is an incorrect check. It will be true if a local proxy (on the same machine as the Kudu server) forwards requests to Kudu as it would be a local connection.
- Instead, checking for the Host header is a better check for mocking APIs