### PR TITLE
Append WebJobType with /SDK to analytics

### DIFF
--- a/Kudu.Core.Test/Jobs/ContinuousJobRunnerFacts.cs
+++ b/Kudu.Core.Test/Jobs/ContinuousJobRunnerFacts.cs
@@ -94,6 +94,12 @@ namespace Kudu.Core.Test.Jobs
         }
 
         [Fact]
+        public void CheckJobType_Continuous_JobTypeIsNonSdk_ByDefault()
+        {
+            Assert.Equal("continuous", _runner.GetJobType());
+        }
+
+        [Fact]
         public void CheckAlwaysOn_OnlyLogsOncePerLogFile()
         {
             System.Environment.SetEnvironmentVariable(ContinuousJobRunner.WebsiteSCMAlwaysOnEnabledKey, "0");

--- a/Kudu.Core.Test/Jobs/JobsManagerBaseFacts.cs
+++ b/Kudu.Core.Test/Jobs/JobsManagerBaseFacts.cs
@@ -1,0 +1,43 @@
+﻿using Kudu.Core.Jobs;
+using System;
+using System.IO;
+using Xunit;
+
+namespace Kudu.Core.Test.Jobs
+{
+    public class JobsManagerBaseFacts : IDisposable
+    {
+        private const string testJobDataDir = @"c:\test\data\continuous";
+        private string _jobName;
+        private string _jobDataDir;
+
+        public JobsManagerBaseFacts()
+        {
+            _jobName = Path.GetRandomFileName();
+            _jobDataDir = Path.Combine(testJobDataDir, _jobName);
+            Directory.CreateDirectory(_jobDataDir);
+        }
+
+        [Fact]
+        public void JobsManagerBase_IsUsingSdk_WhenMarkerPresents()
+        {
+            string markerPath = Path.Combine(_jobDataDir, "webjobssdk.marker");
+            File.Create(markerPath).Close();
+            Assert.True(JobsManagerBase.IsUsingSdk(_jobDataDir));
+        }
+
+        [Fact]
+        public void JobsManagerBase_IsNotUsingSdk_WhenMarkerAbsents()
+        {
+            Assert.False(JobsManagerBase.IsUsingSdk(_jobDataDir));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_jobDataDir))
+            {
+                Directory.Delete(_jobDataDir, recursive: true);
+            }
+        }
+    }
+}

--- a/Kudu.Core.Test/Kudu.Core.Test.csproj
+++ b/Kudu.Core.Test/Kudu.Core.Test.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Jobs\BaseJobRunnerFacts.cs" />
     <Compile Include="Jobs\ContinuousJobRunnerFacts.cs" />
     <Compile Include="Jobs\ContinuousJobsManagerFacts.cs" />
+    <Compile Include="Jobs\JobsManagerBaseFacts.cs" />
     <Compile Include="Jobs\ScheduleFacts.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Kudu.Core/Jobs/BaseJobRunner.cs
+++ b/Kudu.Core/Jobs/BaseJobRunner.cs
@@ -552,6 +552,7 @@ namespace Kudu.Core.Jobs
                         jobType += "/SDK";
                     }
 
+                    // jobType can be triggered, continuous, triggered/SDK or continuous/SDK
                     _analytics.JobStarted(_job.Name, scriptFileExtension, jobType, _siteMode, Error, _trigger);
                 }
             }

--- a/Kudu.Core/Jobs/JobsManagerBase.cs
+++ b/Kudu.Core/Jobs/JobsManagerBase.cs
@@ -107,13 +107,19 @@ namespace Kudu.Core.Jobs
             _jobsTypePath = jobsTypePath;
             JobsBinariesPath = Path.Combine(basePath, jobsTypePath);
             JobsDataPath = Path.Combine(Environment.JobsDataPath, jobsTypePath);
-            JobsWatcher = new JobsFileWatcher(JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, jobsTypePath);
+            JobsWatcher = new JobsFileWatcher(JobsBinariesPath, OnJobChanged, null, ListJobNames, traceFactory, analytics, GetJobType());
             HostingEnvironment.RegisterObject(this);
         }
 
         protected virtual IEnumerable<string> ListJobNames(bool forceRefreshCache)
         {
             return ListJobs(forceRefreshCache).Select(job => job.Name);
+        }
+
+        protected string GetJobType()
+        {
+            // jobType can be triggered, continuous, triggered/SDK or continuous/SDK
+            return IsUsingSdk(JobsDataPath) ? $"{_jobsTypePath}/SDK" : _jobsTypePath;
         }
 
         public void RegisterExtraEventHandlerForFileChange(Action<string> action)


### PR DESCRIPTION
### Background
When a webjob is developed by Azure.WebJobs.SDK, we will mark the webjob data directory with **webjobssdk.marker**.

However, when analytics tools writing jobType to Kusto during webjob initialization, creation and deletion, the reported jobType is missing the expected **/SDK** flag.

This change can be used by the webjobs detector to raise warning when visual studio deploys webjobs in an unexpected mode.
(e.g. timer trigger is deployed in triggered mode, but it should use continuous mode instead).

### Fix
This PR is intended to fix JobType developed with SDK in Kudu table. 
Changing **continuous** to **continuous/SDK**
Changing **triggered** to **triggered/SDK**