### PR TITLE
Fix misleading message about the termination of the log streaming ses…

### DIFF
--- a/Kudu.Services/Resources.resx
+++ b/Kudu.Services/Resources.resx
@@ -193,7 +193,7 @@
     <value>Repository could not be found.</value>
   </data>
   <data name="LogStream_AppShutdown" xml:space="preserve">
-    <value>{0}{1}  The application was terminated.{0}</value>
+    <value>{0}{1}  The log-streaming session has ended. Please reconnect to continue streaming logs.{0}</value>
   </data>
   <data name="LogStream_Error" xml:space="preserve">
     <value>{0}{1}  Error has occurred and stream is terminated. {2}{0}</value>
@@ -202,7 +202,7 @@
     <value>{0}  No new trace in the past {1} min(s).{2}</value>
   </data>
   <data name="LogStream_Timeout" xml:space="preserve">
-    <value>{0}  Stream terminated due to timeout {1} min(s).{2}</value>
+    <value>{0}  The log-streaming session has ended due to timeout {1} min(s).{2}</value>
   </data>
   <data name="LogStream_Welcome" xml:space="preserve">
     <value>{0}  Welcome, you are now connected to log-streaming service. The default timeout is 2 hours. Change the timeout with the App Setting SCM_LOGSTREAM_TIMEOUT (in seconds). {1}</value>


### PR DESCRIPTION
In case we need to recycle the process that host kudu, the current message for the termination is accurate in the context of just kudu but if kudu is a companion of the real app, the message can be misleading into which app actually was terminated.

This change is just to make the message more precise about what is happening in the context of a log streaming session.