### PR TITLE
Change the default value of WEBSITE_RECYCLE_PREVIEW_ENABLED from false to true

### DIFF
--- a/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
+++ b/Kudu.Contracts/Settings/DeploymentSettingsExtension.cs
@@ -280,8 +280,8 @@ namespace Kudu.Contracts.Settings
         {
             string value = settings.GetValue(SettingsKeys.RecyclePreviewEnabled);
 
-            // Default value, if setting is not explicitly defined, is false
-            return StringUtils.IsTrueLike(value);
+            // Default value, if setting is not explicitly defined, is True
+            return value == null || StringUtils.IsTrueLike(value);
         }
 
         public static bool DoBuildDuringDeployment(this IDeploymentSettingsManager settings)

--- a/Kudu.Contracts/Settings/SettingsKeys.cs
+++ b/Kudu.Contracts/Settings/SettingsKeys.cs
@@ -45,7 +45,7 @@
         public const string DockerCiEnabled = "DOCKER_ENABLE_CI";
 
         // This app-setting works for all kinds of apps, including classic Windows apps (not just container-based apps).
-        // To make it work for Windows apps, the app-setting WEBSITE_RECYCLE_PREVIEW_ENABLED=1 needs to be defined.
+        // To disable its effect on classic Windows apps, set WEBSITE_RECYCLE_PREVIEW_ENABLED=0.
         public const string RestartAppAfterDeployment = "SCM_RESTART_APP_CONTAINER_AFTER_DEPLOYMENT"; 
 
         public const string DoBuildDuringDeployment = "SCM_DO_BUILD_DURING_DEPLOYMENT";


### PR DESCRIPTION
- Background: WEBSITE_RECYCLE_PREVIEW_ENABLED=true triggers a restart using the /api/app/restart API, whereas WEBSITE_RECYCLE_PREVIEW_ENABLED=false triggers a restart using the file-system (i.e. by touching restartTrigger.txt)
- Prior to this commit, WEBSITE_RECYCLE_PREVIEW_ENABLED defaulted to False. This commit changes the default to True. Subsequently, the app setting WEBSITE_RECYCLE_PREVIEW_ENABLED will go away completely.