### PR TITLE
Update deep link to LinuxAppDown

### DIFF
--- a/Kudu.Services.Web/Detectors/Default.cshtml
+++ b/Kudu.Services.Web/Detectors/Default.cshtml
@@ -31,7 +31,7 @@
         }
         else
         {
-            detectorPath = "detectors%2FLinuxAppDown";
+            detectorPath = "analysis%2FLinuxAppDown";
         }
     }
 


### PR DESCRIPTION
This PR updates the deeplink from the 503 page for the Linux apps, pointing to the Web App Down analysis page instead of the detector itself. It has been confirmed that the update link works.