### PR TITLE
OneDeploy API - /api/publish

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -8,8 +8,8 @@ namespace Kudu
         public const string WebRoot = "wwwroot";
         public const string MappedSite = "/_app";
         public const string RepositoryPath = "repository";
-        public const string ZipTempPath = "zipdeploy";
-        public const string ZipExtractPath = "extracted";
+        public const string ZipTempDirectoryName = "zipdeploy";
+        public const string ArtifactStagingDirectoryName = "extracted";
 
         public const string LockPath = "locks";
         public const string DeploymentLockFile = "deployments.lock";
@@ -101,7 +101,7 @@ namespace Kudu
         public const string FreeSKU = "Free";
         public const string BasicSKU = "Basic";
 
-        //Setting for VC++ for node builds
+        // Setting for VC++ for node builds
         public const string VCVersion = "2015";
 
         public const string RoleBasedContributorHeader = "X-MS-CLIENT-ROLEBASED-CONTRIBUTOR";
@@ -136,5 +136,14 @@ namespace Kudu
         public const string PackageNameTxt = "packagename.txt";
         public const string AppOfflineFileName = "app_offline.htm";
         public const string AppOfflineKuduContent = "Created by kudu";
+
+        public const string OneDeploy = "OneDeploy";
+        public const string StackEnvVarName = "WEBSITE_STACK";
+
+        // Stacks supported by OneDeploy 
+        public const string Tomcat = "TOMCAT";
+        public const string JavaSE = "JAVA";
+        public const string JBossEap = "JBOSSEAP";
+
     }
 }

--- a/Kudu.Contracts/Deployment/ArtifactType.cs
+++ b/Kudu.Contracts/Deployment/ArtifactType.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kudu.Contracts.Deployment
+{
+    public enum ArtifactType
+    {
+        Invalid,
+        War,
+        Jar,
+        Ear,
+        Lib,
+        Static,
+        Startup,
+        Zip,
+    }
+}

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -14,6 +14,8 @@ namespace Kudu.Core.Deployment
             IsReusable = true;
             AllowDeferredDeployment = true;
             DoFullBuildByDefault = true;
+            WatchedFileEnabled = true;
+            RestartAllowed = true;
         }
 
         public RepositoryType RepositoryType { get; set; }
@@ -25,13 +27,20 @@ namespace Kudu.Core.Deployment
         public bool AllowDeferredDeployment { get; set; }
         // indicating that this is a CI triggered by SCM provider 
         public bool IsContinuous { get; set; }
+
+        // NOTE: Do not access the request stream in the Fetch handler as it may have been closed during asynchronous scenarios
         public FetchDelegate Fetch { get; set; }
         public bool AllowDeploymentWhileScmDisabled { get; set; }
 
         // Optional.
         // Path of the directory to be deployed to. The path should be relative to the wwwroot directory.
         // Example: "webapps/ROOT"
-        public string TargetPath { get; set; }
+        public string TargetDirectoryPath { get; set; }
+
+        // Optional.
+        // Specifies the name of the deployed artifact.
+        // Example: When deploying startup files, OneDeploy will set this to startup.bat (or startup.sh)
+        public string TargetFileName { get; set; }
 
         // Optional.
         // Path of the file that is watched for changes by the web server.
@@ -68,5 +77,12 @@ namespace Kudu.Core.Deployment
         // won't update until after a process restart. Therefore, we copy the needed
         // files into a separate folders and run sync triggers from there.
         public string SyncFunctionsTriggersPath { get; set; } = null;
+
+        // Specifies whether to touch the watched file (example web.config, web.xml, etc) after the deployment
+        public bool WatchedFileEnabled { get; set;}
+
+        // Used to allow / disallow 'restart' on a per deployment basis, if needed.
+        // For example: OneDeploy allows clients to enable / disable 'restart'.
+        public bool RestartAllowed { get; set; }
     }
 }

--- a/Kudu.Contracts/Kudu.Contracts.csproj
+++ b/Kudu.Contracts/Kudu.Contracts.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Commands\CommandEventType.cs" />
     <Compile Include="Commands\CommandResult.cs" />
     <Compile Include="Commands\ICommandExecutor.cs" />
+    <Compile Include="Deployment\ArtifactType.cs" />
     <Compile Include="Deployment\DeploymentFailedException.cs" />
     <Compile Include="Deployment\DeploymentInfoBase.cs" />
     <Compile Include="Deployment\DeployResult.cs" />

--- a/Kudu.Core.Test/Deployment/Generator/SiteBuilderFactoryFacts.cs
+++ b/Kudu.Core.Test/Deployment/Generator/SiteBuilderFactoryFacts.cs
@@ -26,7 +26,7 @@ namespace Kudu.Core.Test.Deployment.Generator
 
             var factory = new SiteBuilderFactory(pProvider, environment);
 
-            var result = factory.CreateBuilder(tracer, logger, settings, repository);
+            var result = factory.CreateBuilder(tracer, logger, settings, repository, deploymentInfo: null);
 
             Assert.IsType(expectedBuilderType, result);
         }

--- a/Kudu.Core.Test/Deployment/PushDeploymentControllerFacts.cs
+++ b/Kudu.Core.Test/Deployment/PushDeploymentControllerFacts.cs
@@ -57,7 +57,7 @@ namespace Kudu.Core.Test.Deployment
             FileSystemHelpers.Instance = fileSystem.Object;
 
             deploymentManager
-                .Setup(m => m.FetchDeploy(It.IsAny<ZipDeploymentInfo>(), It.IsAny<bool>(), It.IsAny<Uri>(), It.IsAny<string>()))
+                .Setup(m => m.FetchDeploy(It.IsAny<ArtifactDeploymentInfo>(), It.IsAny<bool>(), It.IsAny<Uri>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(FetchDeploymentRequestResult.RanSynchronously));
 
             var controller = new PushDeploymentController(
@@ -78,8 +78,8 @@ namespace Kudu.Core.Test.Deployment
 
             // Assert
             deploymentManager
-                .Verify(m => m.FetchDeploy(It.Is<ZipDeploymentInfo>(di =>
-                    !string.IsNullOrEmpty(di.ZipName) && !string.IsNullOrEmpty(di.SyncFunctionsTriggersPath)),
+                .Verify(m => m.FetchDeploy(It.Is<ArtifactDeploymentInfo>(di =>
+                    !string.IsNullOrEmpty(di.ArtifactFileName) && !string.IsNullOrEmpty(di.SyncFunctionsTriggersPath)),
                     It.IsAny<bool>(),
                     It.IsAny<Uri>(),
                     It.IsAny<string>()

--- a/Kudu.Core/Deployment/ArtifactDeploymentInfo.cs
+++ b/Kudu.Core/Deployment/ArtifactDeploymentInfo.cs
@@ -5,12 +5,12 @@ using Kudu.Core.Tracing;
 
 namespace Kudu.Core.Deployment
 {
-    public class ZipDeploymentInfo : DeploymentInfoBase
+    public class ArtifactDeploymentInfo : DeploymentInfoBase
     {
         private readonly IEnvironment _environment;
         private readonly ITraceFactory _traceFactory;
 
-        public ZipDeploymentInfo(IEnvironment environment, ITraceFactory traceFactory)
+        public ArtifactDeploymentInfo(IEnvironment environment, ITraceFactory traceFactory)
         {
             _environment = environment;
             _traceFactory = traceFactory;
@@ -18,9 +18,9 @@ namespace Kudu.Core.Deployment
 
         public override IRepository GetRepository()
         {
-            // Zip "repository" does not conflict with other types, including NoRepository,
+            // Artifact "repository" does not conflict with other types, including NoRepository,
             // so there's no call to EnsureRepository
-            var path = Path.Combine(_environment.ZipTempPath, Constants.ZipExtractPath);
+            var path = Path.Combine(_environment.ZipTempPath, Constants.ArtifactStagingDirectoryName);
             return new NullRepository(path, _traceFactory);
         }
 
@@ -30,10 +30,10 @@ namespace Kudu.Core.Deployment
 
         public string Message { get; set; }
 
-        // This is used if the deployment is Run-From-Zip
-        public string ZipName { get; set; }
+        // Optional file name. Used by certain features like run-from-zip.
+        public string ArtifactFileName { get; set; }
 
-        // This is used when getting the zipfile from the zipURL
-        public string ZipURL { get; set; }
+        // This is used when getting the artifact file from the remote URL
+        public string RemoteURL { get; set; }
     }
 }

--- a/Kudu.Core/Deployment/DeploymentHelper.cs
+++ b/Kudu.Core/Deployment/DeploymentHelper.cs
@@ -79,12 +79,12 @@ namespace Kudu.Core.Deployment
             }
         }
 
-        public static async Task<HttpContent> GetZipContentFromURL(ZipDeploymentInfo zipDeploymentInfo, ITracer tracer)
+        public static async Task<HttpContent> GetArtifactContentFromURL(ArtifactDeploymentInfo artifactDeploymentInfo, ITracer tracer)
         {
             using (var client = new HttpClient(new HttpClientHandler()))
             {
-                Uri uri = new Uri(zipDeploymentInfo.ZipURL);
-                using (tracer.Step($"Trying to make a GET request to {StringUtils.ObfuscatePath(zipDeploymentInfo.ZipURL)}"))
+                Uri uri = new Uri(artifactDeploymentInfo.RemoteURL);
+                using (tracer.Step($"Trying to make a GET request to {StringUtils.ObfuscatePath(artifactDeploymentInfo.RemoteURL)}"))
                 {
                     try
                     {

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Security;
 using System.Text;
 using System.Threading.Tasks;
 using Kudu.Contracts.Infrastructure;
@@ -275,7 +277,7 @@ namespace Kudu.Core.Deployment
 
                 if (statusFile != null && statusFile.Status == DeployStatus.Success && _settings.RunFromLocalZip())
                 {
-                    var zipDeploymentInfo = deploymentInfo as ZipDeploymentInfo;
+                    var zipDeploymentInfo = deploymentInfo as ArtifactDeploymentInfo;
                     if (zipDeploymentInfo != null)
                     {
                         await PostDeploymentHelper.UpdateSiteVersion(zipDeploymentInfo, _environment, tracer);
@@ -284,11 +286,23 @@ namespace Kudu.Core.Deployment
             }
         }
 
-        public async Task RestartMainSiteIfNeeded(ITracer tracer, ILogger logger)
+        public async Task RestartMainSiteIfNeeded(ITracer tracer, ILogger logger, DeploymentInfoBase deploymentInfo)
         {
             // If post-deployment restart is disabled, do nothing.
             if (!_settings.RestartAppOnGitDeploy())
             {
+                return;
+            }
+
+            // Proceed only if 'restart' is allowed for this deployment
+            if (deploymentInfo != null && !deploymentInfo.RestartAllowed)
+            {
+                return;
+            }
+
+            if (deploymentInfo != null && deploymentInfo.Deployer == Constants.OneDeploy)
+            {
+                await PostDeploymentHelper.RestartMainSiteAsync(_environment.RequestId, new PostDeploymentTraceListener(tracer, logger));
                 return;
             }
 
@@ -622,7 +636,7 @@ namespace Kudu.Core.Deployment
                 {
                     using (tracer.Step("Determining deployment builder"))
                     {
-                        builder = _builderFactory.CreateBuilder(tracer, innerLogger, perDeploymentSettings, repository);
+                        builder = _builderFactory.CreateBuilder(tracer, innerLogger, perDeploymentSettings, repository, deploymentInfo);
                         deploymentAnalytics.ProjectType = builder.ProjectType;
                         tracer.Trace("Builder is {0}", builder.GetType().Name);
                     }
@@ -693,15 +707,11 @@ namespace Kudu.Core.Deployment
                     {
                         await builder.Build(context);
                         builder.PostBuild(context);
-
-                        await RestartMainSiteIfNeeded(tracer, logger);
-
+                        await RestartMainSiteIfNeeded(tracer, logger, deploymentInfo);
+            
                         await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, new PostDeploymentTraceListener(tracer, logger), deploymentInfo?.SyncFunctionsTriggersPath);
 
-                        if (!_settings.RunFromZip() && _settings.TouchWatchedFileAfterDeployment())
-                        {
-                            TryTouchWatchedFile(context, deploymentInfo);
-                        }
+                        TouchWatchedFileIfNeeded(_settings, deploymentInfo, context);
 
                         FinishDeployment(id, deployStep);
 
@@ -726,6 +736,19 @@ namespace Kudu.Core.Deployment
             {
                 // Clean the temp folder up
                 CleanBuild(tracer, buildTempPath);
+            }
+        }
+
+        private static void TouchWatchedFileIfNeeded(IDeploymentSettingsManager settings, DeploymentInfoBase deploymentInfo, DeploymentContext context)
+        {
+            if (deploymentInfo != null && !deploymentInfo.WatchedFileEnabled)
+            {
+                return;
+            }
+
+            if (!settings.RunFromZip() && settings.TouchWatchedFileAfterDeployment())
+            {
+                TryTouchWatchedFile(context, deploymentInfo);
             }
         }
 
@@ -781,17 +804,17 @@ namespace Kudu.Core.Deployment
 
         private static string GetOutputPath(DeploymentInfoBase deploymentInfo, IEnvironment environment, IDeploymentSettingsManager perDeploymentSettings)
         {
-            string targetPath = perDeploymentSettings.GetTargetPath();
+            string targetDirectoryPath = perDeploymentSettings.GetTargetPath();
 
-            if (String.IsNullOrWhiteSpace(targetPath))
+            if (String.IsNullOrWhiteSpace(targetDirectoryPath))
             {
-                targetPath = deploymentInfo?.TargetPath;
+                targetDirectoryPath = deploymentInfo?.TargetDirectoryPath;
             }
 
-            if (!String.IsNullOrWhiteSpace(targetPath))
+            if (!String.IsNullOrWhiteSpace(targetDirectoryPath))
             {
-                targetPath = targetPath.Trim('\\', '/');
-                return Path.GetFullPath(Path.Combine(environment.WebRootPath, targetPath));
+                targetDirectoryPath = targetDirectoryPath.Trim('\\', '/');
+                return Path.GetFullPath(Path.Combine(environment.WebRootPath, targetDirectoryPath));
             }
 
             return environment.WebRootPath;

--- a/Kudu.Core/Deployment/Generator/OneDeployBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/OneDeployBuilder.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Kudu.Contracts.Settings;
+using Kudu.Core.Infrastructure;
+
+namespace Kudu.Core.Deployment.Generator
+{
+    // This is the site builder used for OneDeploy scenarios
+    public class OneDeployBuilder : BasicBuilder
+    {
+        private DeploymentInfoBase _deploymentInfo;
+        private string _repositoryPath;
+
+        public OneDeployBuilder(IEnvironment environment, IDeploymentSettingsManager settings, IBuildPropertyProvider propertyProvider, string repositoryPath, string projectPath, DeploymentInfoBase deploymentInfo)
+            : base(environment, settings, propertyProvider, repositoryPath, projectPath)
+        {
+            _deploymentInfo = deploymentInfo;
+            _repositoryPath = repositoryPath;
+        }
+
+        public override string ProjectType
+        {
+            get { return Constants.OneDeploy; }
+        }
+
+        public override Task Build(DeploymentContext context)
+        {
+            context.Logger.Log($"Running build. Project type: {ProjectType}");
+
+            // Start by copying the manifest as-is so that 
+            // manifest based deployments (Example: ZipDeploy) are unaffected
+            context.Logger.Log($"Copying the manifest");
+            FileSystemHelpers.CopyFile(context.PreviousManifestFilePath, context.NextManifestFilePath);
+
+            // If we want to clean up the target directory before copying
+            // the new files, use kudusync so that only unnecessary files are 
+            // deleted. This has two benefits:
+            // 1. This is faster than deleting the target directory before copying the source dir.
+            // 2. Minimizes chances of failure in deleting a directory due to open handles.
+            //    This is especially useful when a target directory is present in the source and
+            //    need not be deleted.
+            if (_deploymentInfo.CleanupTargetDirectory)
+            {
+                context.Logger.Log($"Clean deploying to {context.OutputPath}");
+
+                // We do not want to use the manifest for OneDeploy. Set manifest paths to null.
+                // This way we don't interfere with manifest based deployments.
+                context.PreviousManifestFilePath = context.NextManifestFilePath = string.Empty;
+                base.Build(context);
+            }
+            else
+            {
+                context.Logger.Log($"Incrementally deploying to {context.OutputPath}");
+                FileSystemHelpers.CopyDirectoryRecursive(_repositoryPath, context.OutputPath);
+            }
+
+            context.Logger.Log($"Build completed succesfully.");
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/Generator/SiteBuilderFactory.cs
@@ -22,7 +22,7 @@ namespace Kudu.Core.Deployment.Generator
             _environment = environment;
         }
 
-        public ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository repository)
+        public ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository repository, DeploymentInfoBase deploymentInfo)
         {
             string repositoryRoot = repository.RepositoryPath;
 
@@ -52,6 +52,12 @@ namespace Kudu.Core.Deployment.Generator
                 targetProjectPath = Path.GetFullPath(Path.Combine(repositoryRoot, targetProjectPath.TrimStart('/', '\\')));
             }
 
+            if (deploymentInfo != null && deploymentInfo.Deployer == Constants.OneDeploy)
+            {
+                var projectPath = !String.IsNullOrEmpty(targetProjectPath) ? targetProjectPath : repositoryRoot;
+                return new OneDeployBuilder(_environment, settings, _propertyProvider, repositoryRoot, projectPath, deploymentInfo);
+            }
+
             if (settings.RunFromLocalZip())
             {
                 return new RunFromZipSiteBuilder();
@@ -62,6 +68,7 @@ namespace Kudu.Core.Deployment.Generator
                 var projectPath = !String.IsNullOrEmpty(targetProjectPath) ? targetProjectPath : repositoryRoot;
                 return new BasicBuilder(_environment, settings, _propertyProvider, repositoryRoot, projectPath);
             }
+
             string msbuild16Log = String.Format("UseMSBuild16: {0}", VsHelper.UseMSBuild16().ToString());
             tracer.Trace(msbuild16Log);
             KuduEventSource.Log.GenericEvent(

--- a/Kudu.Core/Deployment/ISiteBuilderFactory.cs
+++ b/Kudu.Core/Deployment/ISiteBuilderFactory.cs
@@ -6,6 +6,6 @@ namespace Kudu.Core.Deployment
 {
     public interface ISiteBuilderFactory
     {
-        ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository fileFinder);
+        ISiteBuilder CreateBuilder(ITracer tracer, ILogger logger, IDeploymentSettingsManager settings, IRepository fileFinder, DeploymentInfoBase deploymentInfo);
     }
 }

--- a/Kudu.Core/Environment.cs
+++ b/Kudu.Core/Environment.cs
@@ -22,7 +22,7 @@ namespace Kudu.Core
         private readonly string _locksPath;
         private readonly string _sshKeyPath;
         private readonly string _tempPath;
-        private readonly string _zipTempPath;
+        private readonly string _zipTempDirectoryPath;
         private readonly string _scriptPath;
         private readonly string _nodeModulesPath;
         private string _repositoryPath;
@@ -42,7 +42,7 @@ namespace Kudu.Core
                 string rootPath,
                 string siteRootPath,
                 string tempPath,
-                string zipTempPath,
+                string zipTempDirectoryPath,
                 string repositoryPath,
                 string webRootPath,
                 string deploymentsPath,
@@ -65,7 +65,7 @@ namespace Kudu.Core
             SiteRootPath = siteRootPath;
             _tempPath = tempPath;
             _repositoryPath = repositoryPath;
-            _zipTempPath = zipTempPath;
+            _zipTempDirectoryPath = zipTempDirectoryPath;
             _webRootPath = webRootPath;
             _deploymentsPath = deploymentsPath;
             _deploymentToolsPath = Path.Combine(_deploymentsPath, Constants.DeploymentToolsPath);
@@ -104,7 +104,7 @@ namespace Kudu.Core
 
             _tempPath = Path.GetTempPath();
             _repositoryPath = repositoryPath;
-            _zipTempPath = Path.Combine(_tempPath, Constants.ZipTempPath);
+            _zipTempDirectoryPath = Path.Combine(_tempPath, Constants.ZipTempDirectoryName);
             _webRootPath = Path.Combine(SiteRootPath, Constants.WebRoot);
             _deploymentsPath = Path.Combine(SiteRootPath, Constants.DeploymentCachePath);
             _deploymentToolsPath = Path.Combine(_deploymentsPath, Constants.DeploymentToolsPath);
@@ -232,7 +232,7 @@ namespace Kudu.Core
         {
             get
             {
-                return FileSystemHelpers.EnsureDirectory(_zipTempPath);
+                return FileSystemHelpers.EnsureDirectory(_zipTempDirectoryPath);
             }
         }
 

--- a/Kudu.Core/Helpers/PostDeploymentHelper.cs
+++ b/Kudu.Core/Helpers/PostDeploymentHelper.cs
@@ -803,12 +803,12 @@ namespace Kudu.Core.Helpers
             }
         }
 
-        public static async Task UpdateSiteVersion(ZipDeploymentInfo deploymentInfo, IEnvironment environment, ITracer tracer)
+        public static async Task UpdateSiteVersion(ArtifactDeploymentInfo deploymentInfo, IEnvironment environment, ITracer tracer)
         {
             var siteVersionPath = Path.Combine(environment.SitePackagesPath, Constants.PackageNameTxt);
-            using (tracer.Step($"Updating {siteVersionPath} with deployment {deploymentInfo.ZipName}"))
+            using (tracer.Step($"Updating {siteVersionPath} with deployment {deploymentInfo.ArtifactFileName}"))
             {
-                await OperationManager.AttemptAsync(() => FileSystemHelpers.WriteAllTextToFileAsync(siteVersionPath, deploymentInfo.ZipName));
+                await OperationManager.AttemptAsync(() => FileSystemHelpers.WriteAllTextToFileAsync(siteVersionPath, deploymentInfo.ArtifactFileName));
             }
         }
 

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Deployment\DeploymentStatusManager.cs" />
     <Compile Include="Deployment\FetchDeploymentManager.cs" />
     <Compile Include="Deployment\Generator\AspNetCoreMSBuild1607Builder.cs" />
+    <Compile Include="Deployment\Generator\OneDeployBuilder.cs" />
     <Compile Include="Deployment\Generator\DotNetConsoleMSBuild1607Builder.cs" />
     <Compile Include="Deployment\Generator\FunctionMSBuild1607Builder.cs" />
     <Compile Include="Deployment\Generator\FunctionMsbuildBuilder.cs" />
@@ -248,7 +249,7 @@
     <Compile Include="Deployment\StructuredTextDocument.cs" />
     <Compile Include="Deployment\StructuredTextDocumentEntry.cs" />
     <Compile Include="Deployment\StructuredTextLogger.cs" />
-    <Compile Include="Deployment\ZipDeploymentInfo.cs" />
+    <Compile Include="Deployment\ArtifactDeploymentInfo.cs" />
     <Compile Include="Functions\FunctionManager.cs" />
     <Compile Include="Helpers\EnvironmentHelper.cs" />
     <Compile Include="Helpers\DeploymentCompletedInfo.cs" />

--- a/Kudu.FunctionalTests/DeploymentTestHelper.cs
+++ b/Kudu.FunctionalTests/DeploymentTestHelper.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.SessionState;
+using System.Web.UI.WebControls;
+using Kudu.Client.Deployment;
+using Kudu.Contracts.Settings;
+using Kudu.Core.Deployment;
+using Kudu.TestHarness;
+using Kudu.TestHarness.Xunit;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Kudu.FunctionalTests
+{
+    class DeploymentTestHelper
+    {
+        public static TestFile CreateRandomTestFile()
+        {
+            var fileValues = Guid.NewGuid().ToString("N");
+            return new TestFile { Content = fileValues, Filename = fileValues };
+        }
+
+        public static TestFile[] CreateRandomFilesForZip(int numFiles)
+        {
+            return Enumerable.Range(0, numFiles)
+                .Select(i => Guid.NewGuid().ToString("N"))
+                .Select(s => new TestFile { Content = s, Filename = s })
+                .ToArray();
+        }
+
+        public static async Task WaitForDeploymentCompletionAsync(ApplicationManager appManager, string deployer)
+        {
+            DeployResult result;
+            do
+            {
+                result = await appManager.DeploymentManager.GetResultAsync("latest");
+                Assert.Equal(deployer, result.Deployer);
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
+        }
+
+        public static Stream CreateZipStream(TestFile[] files)
+        {
+            var s = new MemoryStream();
+            using (var archive = new ZipArchive(s, ZipArchiveMode.Update, true))
+            {
+                foreach (var file in files)
+                {
+                    var entry = archive.CreateEntry(file.Filename);
+
+                    using (var w = new StreamWriter(entry.Open()))
+                    {
+                        w.Write(file.Content);
+                    }
+
+                    if (file.ModifiedTime.HasValue)
+                    {
+                        entry.LastWriteTime = file.ModifiedTime.Value;
+                    }
+                }
+            }
+
+            s.Position = 0;
+            return s;
+        }
+
+        public static Stream CreateFileStream(TestFile file)
+        {
+            var s = new MemoryStream();
+            using (var sw = new StreamWriter(s, Encoding.Default, file.Content.Length, true))
+            {
+                sw.Write(file.Content);
+            }
+            s.Position = 0;
+            return s;
+        }
+
+        public static async Task AssertSuccessfulDeploymentByFilenames(ApplicationManager appManager, IEnumerable<string> filenames, string path = null)
+        {
+            TestTracer.Trace("Verifying files are deployed and deployment record created.");
+
+            var deployment = await appManager.DeploymentManager.GetResultAsync("latest");
+
+            Assert.Equal(DeployStatus.Success, deployment.Status);
+
+            var entries = await appManager.VfsManager.ListAsync(path);
+            var deployedFilenames = entries.Select(e => e.Name);
+
+            var filenameSet = new HashSet<string>(filenames);
+            Assert.True(filenameSet.SetEquals(entries.Select(e => e.Name)), string.Join(",", filenameSet) + " != " + string.Join(",", entries.Select(e => e.Name)));
+        }
+    }
+}

--- a/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
+++ b/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
@@ -68,9 +68,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestFile.cs" />
+    <Compile Include="DeploymentTestHelper.cs" />
     <Compile Include="CommandExecutorTests.cs" />
     <Compile Include="Jobs\WebJobsTests.cs" />
     <Compile Include="DeploymentActionsTests.cs" />
+    <Compile Include="OneDeployTests.cs" />
     <Compile Include="ZipDeploymentTests.cs" />
     <Compile Include="SiteExtensions\SiteExtensionApiFacts.cs" />
     <Compile Include="SiteExtensions\SiteExtensionsIncrementalDeploymentTests.cs" />

--- a/Kudu.FunctionalTests/OneDeployTests.cs
+++ b/Kudu.FunctionalTests/OneDeployTests.cs
@@ -1,0 +1,379 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Kudu.Client.Deployment;
+using Kudu.Core.Deployment;
+using Kudu.TestHarness;
+using Kudu.TestHarness.Xunit;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Kudu.FunctionalTests
+{
+    [KuduXunitTestClass]
+    public class OneDeployTests
+    {
+        public const string deployer = "OneDeploy";
+
+        #region Test entry point artifacts: app.war, app.jar, app.ear
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestAppDotWarDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestAppDotWarDeployment", async appManager =>
+            {
+                ConfigureSiteAsTomcatSite(appManager);
+
+                await DeployNonZippedArtifact(appManager, "war", null, isAsync);
+
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "hostingstart.html", "app.war" }, "site/wwwroot");
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestAppDotJarDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestAppDotJarDeployment", async appManager =>
+            {
+                ConfigureSiteAsJavaSESite(appManager);
+
+                await DeployNonZippedArtifact(appManager, "jar", null, isAsync);
+
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "hostingstart.html", "app.jar" }, "site/wwwroot");
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestAppDotEarDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestAppDotEarDeployment", async appManager =>
+            {
+                ConfigureSiteAsJbossEapSite(appManager);
+
+                await DeployNonZippedArtifact(appManager, "ear", null, isAsync);
+
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "hostingstart.html", "app.ear" }, "site/wwwroot");
+            });
+        }
+
+        #endregion
+
+        #region Test non-entry point artifacts: type = lib, static, startup, zip
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestLibDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestLibDeployment", async appManager =>
+            {
+                ConfigureSiteAsJavaSESite(appManager);
+
+                await DeployNonZippedArtifact(appManager, "lib", "site/wwwroot/dir1/dir2/library.jar", isAsync);
+
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library.jar" }, "site/wwwroot/dir1/dir2");
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestStaticFileDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestStaticFileDeployment", async appManager =>
+            {
+                await DeployNonZippedArtifact(appManager, "static", "site/wwwroot/statictestdir/statictestfile.txt", isAsync);
+
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "statictestfile.txt" }, "site/wwwroot/statictestdir");
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestStartupFileDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestStartupFileDeployment", async appManager =>
+            {
+                var originalStartupFileContent = await DeployNonZippedArtifact(appManager, "startup", path: "invalid/path/to/be/sure/it/is/ignored/by/OneDeploy", isAsync: isAsync);
+
+                TestTracer.Trace("Verifying startup file is deployed and deployment record created.");
+
+                var deployment = await appManager.DeploymentManager.GetResultAsync("latest");
+
+                Assert.Equal(DeployStatus.Success, deployment.Status);
+
+                var observedStartupFileContent = appManager.VfsManager.ReadAllText("startup.bat");
+
+                Assert.Equal(originalStartupFileContent, observedStartupFileContent);
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestZipDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestZipDeployment", async appManager =>
+            {
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
+                await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "zip", null, isAsync);
+
+                var expectedFiles = files.Select(f => f.Filename).ToList();
+                expectedFiles.Add("hostingstart.html");
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, expectedFiles.ToArray(), "site/wwwroot");
+            });
+        }
+
+        #endregion
+
+        #region Advanced scenarios
+
+        // Tests deployments to /home/site/wwwroot/webapps/<dir>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestLegacyWarDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestLegacyWarDeployment", async appManager =>
+            {
+                ConfigureSiteAsTomcatSite(appManager);
+
+                // STEP 1A: First legacy war deployment
+                var files1 = DeploymentTestHelper.CreateRandomFilesForZip(10);
+                await DeployZippedArtifact(appManager, appManager.OneDeployManager, files1, "war", "site/wwwroot/webapps/ROOT", isAsync);
+
+                // STEP 1B: Validate the result of the first legacy war deployment
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files1.Select(f => f.Filename).ToArray(), "site/wwwroot/webapps/ROOT");
+
+
+                // STEP 2A: Second legacy war deployment
+                var files2 = DeploymentTestHelper.CreateRandomFilesForZip(10);
+                await DeployZippedArtifact(appManager, appManager.OneDeployManager, files2, "war", "site/wwwroot/webapps/ROOT", isAsync);
+
+                // STEP 2B: Validate that the second legacy war deployment cleans up the files deployes by the first deployment
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files2.Select(f => f.Filename).ToArray(), "site/wwwroot/webapps/ROOT");
+            });
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public Task TestURLBasedDeployment(bool isAsync, bool isArmRequest)
+        {
+            return ApplicationManager.RunAsync("TestURLDeployment", async appManager =>
+            {
+                ConfigureSiteAsTomcatSite(appManager);
+
+                var client = appManager.OneDeployManager.Client;
+                var requestUri = isArmRequest ? $"{client.BaseAddress}" : $"{client.BaseAddress}?type=static&restart=false&path=site/wwwroot/NOTICE.txt&async={isAsync}";
+                using (var request = new HttpRequestMessage(HttpMethod.Put, requestUri))
+                {
+                    var packageUri = "https://github.com/projectkudu/kudu/blob/master/NOTICE.txt?raw=true";
+
+                    if (isArmRequest)
+                    {
+                        var payload = new
+                        {
+                            properties = new
+                            {
+                                packageUri = packageUri,
+                                type = "static",
+                                restart = false,
+                                path = "site/wwwroot/NOTICE.txt",
+                                async = isAsync,
+                            }
+                        };
+
+                        request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+                        request.Headers.Referrer = new Uri("https://management.azure.com/subscriptions/sub-id/resourcegroups/rg-name/providers/Microsoft.Web/sites/site-name/extensions/publish?api-version=2016-03-01");
+                        request.Headers.Add("x-ms-geo-location", "westus");
+                    }
+                    else
+                    {
+                        var payload = new { packageUri = packageUri };
+                        request.Content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+                    }
+
+                    var response = await client.SendAsync(request);
+                    response.EnsureSuccessStatusCode();
+
+                    if (isAsync || isArmRequest)
+                    {
+                        await DeploymentTestHelper.WaitForDeploymentCompletionAsync(appManager, deployer);
+                    }
+
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "hostingstart.html", "NOTICE.txt" }, "site/wwwroot");
+                }
+            });
+        }
+
+        //
+        // Creates a war and static file to deploy one after the other and checks for both files in /wwwroot
+        //
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestIncrementalDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestIterativeDeployment", async appManager =>
+            {
+                await DeployNonZippedArtifact(appManager, "static", "site/wwwroot/staticfiletest1.txt", isAsync);
+                await DeployNonZippedArtifact(appManager, "static", "site/wwwroot/staticfiletest2.txt", isAsync);
+
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "hostingstart.html", "staticfiletest1.txt", "staticfiletest2.txt" }, "site/wwwroot");
+            });
+        }
+
+        // Tests that OneDeploy propagates the ZipDeploy manifest correct
+        // to ensure that manifest-based deployments (eg: zipdeploy) are not affected by
+        // OneDeploy based deployments
+        [Fact]
+        public Task TestManifestPropagatedCorrectly()
+        {
+            return ApplicationManager.RunAsync("TestManifestPropagatedCorrectly", async appManager =>
+            {
+                // We run this test in 3 steps: Zipdeploy, then OneDeploy, and then ZipDeploy again
+                // And then we check if the second ZipDeploy works as expected
+
+                // STEP 1a: Upload a zip using ZipDeploy
+                var files1 = DeploymentTestHelper.CreateRandomFilesForZip(10);
+                await DeployZippedArtifact(appManager, appManager.ZipDeploymentManager, files1, type: "", path: "", isAsync: false);
+
+                // STEP 1b: Validate the ZipDeploy result
+                var expectedFiles1 = files1.Select(f => f.Filename).ToList();
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, expectedFiles1.ToArray(), "site/wwwroot");
+
+                // STEP 2a: Upload a text file using OneDeploy
+                await DeployNonZippedArtifact(appManager, "static", "site/wwwroot/staticfiletest.txt", isAsync: false);
+
+                // STEP 2b: Validate the OneDeploy result
+                expectedFiles1.Add("staticfiletest.txt");
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, expectedFiles1.ToArray(), "site/wwwroot");
+
+                // STEP 3a: Upload a zip using ZipDeploy
+                var files2 = DeploymentTestHelper.CreateRandomFilesForZip(10);
+                await DeployZippedArtifact(appManager, appManager.ZipDeploymentManager, files2, type: "", path: "", isAsync: false);
+
+                // STEP 3b: Validate the ZipDeploy result
+                // Specifically, we want to make sure that the files deployed by the first 
+                // ZipDeploy are wiped out but the file deployed by OneDeploy is left untouched
+                // If this happens, we can assume that OneDeploy does not interfere with ZipDeploy
+                var expectedFiles2 = files2.Select(f => f.Filename).ToList();
+                expectedFiles2.Add("staticfiletest.txt");
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, expectedFiles2.ToArray(), "site/wwwroot");
+            });
+        }
+
+        #endregion
+
+        #region Helper methods
+
+        private static async Task<string> DeployNonZippedArtifact(
+            ApplicationManager appManager,
+            string type,
+            string path,
+            bool isAsync)
+        {
+            TestTracer.Trace("Deploying file");
+
+            var testFile = DeploymentTestHelper.CreateRandomTestFile();
+            using (var fileStream = DeploymentTestHelper.CreateFileStream(testFile))
+            {
+                IList<KeyValuePair<string, string>> queryParams = GetOneDeployQueryParams(type, path, isAsync);
+
+                var response = await appManager.OneDeployManager.PushDeployFromStream(fileStream, new ZipDeployMetadata(), queryParams);
+                response.EnsureSuccessStatusCode();
+
+                if (isAsync)
+                {
+                    await DeploymentTestHelper.WaitForDeploymentCompletionAsync(appManager, deployer);
+                }
+            }
+
+            return testFile.Content;
+        }
+
+        private static async Task DeployZippedArtifact(ApplicationManager applicationManager,
+                                                                            RemotePushDeploymentManager deploymentManager,
+                                                                            TestFile[] files,
+                                                                            string type,
+                                                                            string path,
+                                                                            bool isAsync)
+        {
+            TestTracer.Trace("Deploying zip");
+            using (var zipStream = DeploymentTestHelper.CreateZipStream(files))
+            {
+                IList<KeyValuePair<string, string>> queryParams = GetOneDeployQueryParams(type, path, isAsync);
+
+                var response = await deploymentManager.PushDeployFromStream(zipStream, new ZipDeployMetadata(), queryParams);
+                response.EnsureSuccessStatusCode();
+
+                if (isAsync)
+                {
+                    await DeploymentTestHelper.WaitForDeploymentCompletionAsync(applicationManager, deployer);
+                }
+            }
+        }
+
+        private static IList<KeyValuePair<string, string>> GetOneDeployQueryParams(string type, string path, bool isAsync)
+        {
+            IList<KeyValuePair<string, string>> queryParams = new List<KeyValuePair<string, string>>();
+
+            if (!string.IsNullOrWhiteSpace(type))
+            {
+                queryParams.Add(new KeyValuePair<string, string>("type", type));
+            }
+
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                queryParams.Add(new KeyValuePair<string, string>("path", path));
+            }
+
+            if (isAsync != false)
+            {
+                queryParams.Add(new KeyValuePair<string, string>("async", $"{isAsync}"));
+            }
+
+            //
+            // Restarting using /api/restart fails because of cert check failure
+            // unless running in Azure.
+            // OneDeploy uses /api/restart, so we disable restart in the tests.
+            //
+            queryParams.Add(new KeyValuePair<string, string>("restart", "false"));
+
+            return queryParams;
+        }
+
+        private void ConfigureSiteAsTomcatSite(ApplicationManager appManager)
+        {
+            // Obfuscate case to check for case-insensitivity
+            appManager.SettingsManager.SetValue("WEBSITE_STACK", "TOMcat").Wait();
+        }
+
+        private void ConfigureSiteAsJavaSESite(ApplicationManager appManager)
+        {
+            // Obfuscate case to check for case-insensitivity
+            appManager.SettingsManager.SetValue("WEBSITE_STACK", "JAva").Wait();
+        }
+
+        private void ConfigureSiteAsJbossEapSite(ApplicationManager appManager)
+        {
+            // Obfuscate case to check for case-insensitivity
+            appManager.SettingsManager.SetValue("WEBSITE_STACK", "JBOSSeap").Wait();
+        }
+
+        #endregion
+    }
+}

--- a/Kudu.FunctionalTests/TestFile.cs
+++ b/Kudu.FunctionalTests/TestFile.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kudu.FunctionalTests
+{
+    class TestFile
+    {
+        public string Filename;
+        public string Content;
+        public DateTime? ModifiedTime;
+    }
+}

--- a/Kudu.FunctionalTests/ZipDeploymentTests.cs
+++ b/Kudu.FunctionalTests/ZipDeploymentTests.cs
@@ -27,10 +27,10 @@ namespace Kudu.FunctionalTests
         {
             return ApplicationManager.RunAsync("TestSimpleZipDeployment", async appManager =>
             {
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata());
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
             });
         }
 
@@ -79,8 +79,8 @@ namespace Kudu.FunctionalTests
                             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         }
 
-                        await AssertSuccessfulDeploymentByFilenames(appManager, new[] { "host.json", "images", "index.htm" });
-                        await AssertSuccessfulDeploymentByFilenames(appManager, new[] { "picture1.jpg", "picture2.jpg" }, path: "images");
+                        await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new[] { "host.json", "images", "index.htm" }, "site/wwwroot");
+                        await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new[] { "picture1.jpg", "picture2.jpg" }, path: "site/wwwroot/images");
                     }
                 }
             });
@@ -96,7 +96,7 @@ namespace Kudu.FunctionalTests
 
             return ApplicationManager.RunAsync("TestSimpleZipDeployment", async appManager =>
             {
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata
                 {
                     Author = author,
@@ -105,7 +105,7 @@ namespace Kudu.FunctionalTests
                     Message = message
                 });
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
                 var result = await appManager.DeploymentManager.GetResultAsync("latest");
 
                 Assert.Equal(author, result.Author);
@@ -121,7 +121,7 @@ namespace Kudu.FunctionalTests
             return ApplicationManager.RunAsync("TestAsyncZipDeployment", async appManager =>
             {
                 // Big enough to require at least a couple polls for status until success
-                var files = CreateRandomFilesForZip(1000);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(1000);
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata { IsAsync = true });
                 response.EnsureSuccessStatusCode();
 
@@ -135,7 +135,7 @@ namespace Kudu.FunctionalTests
                     await Task.Delay(TimeSpan.FromSeconds(2));
                 } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
 
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
             });
         }
 
@@ -144,14 +144,14 @@ namespace Kudu.FunctionalTests
         {
             return ApplicationManager.RunAsync("TestEmptyZipClearsWwwroot", async appManager =>
             {
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata());
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
 
-                var empty = new FileForZip[0];
+                var empty = new TestFile[0];
                 var response2 = await DeployZip(appManager, empty, new ZipDeployMetadata());
-                await AssertSuccessfulDeploymentByFilenames(appManager, new string[0]);
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[0], "site/wwwroot");
             });
         }
 
@@ -161,12 +161,12 @@ namespace Kudu.FunctionalTests
             return ApplicationManager.RunAsync("EnsureConflictResultOnSimultaneousAsyncRequest", async appManager =>
             {
                 // Big enough to run for a few seconds
-                var files = CreateRandomFilesForZip(1000);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(1000);
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata { IsAsync = true });
                 response.EnsureSuccessStatusCode();
 
                 // Immediately try another deployment
-                var response2 = await DeployZip(appManager, new FileForZip[0], new ZipDeployMetadata { IsAsync = true });
+                var response2 = await DeployZip(appManager, new TestFile[0], new ZipDeployMetadata { IsAsync = true });
 
                 Assert.Equal(HttpStatusCode.Conflict, response2.StatusCode);
 
@@ -178,7 +178,7 @@ namespace Kudu.FunctionalTests
                     await Task.Delay(TimeSpan.FromSeconds(2));
                 } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
 
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
             });
         }
 
@@ -188,12 +188,12 @@ namespace Kudu.FunctionalTests
             return ApplicationManager.RunAsync("EnsureConflictResultOnSimultaneousSyncRequest", async appManager =>
             {
                 // Big enough to run for a few seconds
-                var files = CreateRandomFilesForZip(1000);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(1000);
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata { IsAsync = true });
                 response.EnsureSuccessStatusCode();
 
                 // Immediately try another deployment
-                var response2 = await DeployZip(appManager, new FileForZip[0], new ZipDeployMetadata());
+                var response2 = await DeployZip(appManager, new TestFile[0], new ZipDeployMetadata());
 
                 Assert.Equal(HttpStatusCode.Conflict, response2.StatusCode);
 
@@ -205,7 +205,7 @@ namespace Kudu.FunctionalTests
                     await Task.Delay(TimeSpan.FromSeconds(2));
                 } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
 
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
             });
         }
 
@@ -215,7 +215,7 @@ namespace Kudu.FunctionalTests
             return ApplicationManager.RunAsync("EnsureExpectedKudusyncBehavior", async appManager =>
             {
                 var origTime = DateTime.Now;
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 foreach (var file in files)
                 {
                     file.ModifiedTime = origTime;
@@ -226,9 +226,9 @@ namespace Kudu.FunctionalTests
                 await AssertSuccessfulDeploymentByContent(appManager, files);
 
                 // Deploy a new zip with some new files, some modified files, and some old files
-                var newFiles = CreateRandomFilesForZip(3);
+                var newFiles = DeploymentTestHelper.CreateRandomFilesForZip(3);
                 var oldfile = files[0];
-                var modifiedFile = new FileForZip { Filename = files[1].Filename, Content = "UPDATED", ModifiedTime = DateTime.Now };
+                var modifiedFile = new TestFile { Filename = files[1].Filename, Content = "UPDATED", ModifiedTime = DateTime.Now };
                 var files2 = newFiles.Concat(new[] { oldfile, modifiedFile }).ToArray();
 
                 var response2 = await DeployZip(appManager, files2, new ZipDeployMetadata());
@@ -246,13 +246,13 @@ namespace Kudu.FunctionalTests
             {
                 await appManager.SettingsManager.SetValue("PROJECT", "subdir");
 
-                var rootFile = new FileForZip { Filename = "should-not-be-deployed", Content = "" };
-                var subdirFile = new FileForZip { Filename = "subdir/should-be-deployed", Content = "" };
+                var rootFile = new TestFile { Filename = "should-not-be-deployed", Content = "" };
+                var subdirFile = new TestFile { Filename = "subdir/should-be-deployed", Content = "" };
 
                 var files = new[] { rootFile, subdirFile };
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata());
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, new[] { "should-be-deployed" });
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new[] { "should-be-deployed" }, "site/wwwroot");
             });
         }
 
@@ -263,17 +263,17 @@ namespace Kudu.FunctionalTests
             {
                 var files = new[]
                 {
-                    new FileForZip { Filename = "package.json", Content = simplePackageJsonWithDependencyContent}
+                    new TestFile { Filename = "package.json", Content = simplePackageJsonWithDependencyContent}
                 };
 
                 // Should do KuduSync copy only, no build (zip deployments are assumed to be complete by default)
                 var response = await DeployZip(appManager, files, new ZipDeployMetadata());
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
 
                 var files2 = files.Concat(new[]
                 {
-                    new FileForZip { Filename = ".deployment", Content = "[config]\r\nSCM_DO_BUILD_DURING_DEPLOYMENT = true"}
+                    new TestFile { Filename = ".deployment", Content = "[config]\r\nSCM_DO_BUILD_DURING_DEPLOYMENT = true"}
                 }).ToArray();
 
                 await appManager.SettingsManager.SetValue("SCM_DO_BUILD_DURING_DEPLOYMENT", "false");
@@ -282,7 +282,7 @@ namespace Kudu.FunctionalTests
                 // expect .deployment to be copied to the site root.
                 var response2 = await DeployZip(appManager, files2, new ZipDeployMetadata());
                 response2.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
 
                 await appManager.SettingsManager.Delete("SCM_DO_BUILD_DURING_DEPLOYMENT");
 
@@ -290,8 +290,8 @@ namespace Kudu.FunctionalTests
                 var response3 = await DeployZip(appManager, files2, new ZipDeployMetadata());
                 response3.EnsureSuccessStatusCode();
 
-                var expected = files.Concat(new[] { new FileForZip { Filename = "node_modules" } }).ToArray();
-                await AssertSuccessfulDeploymentByFilenames(appManager, expected.Select(f => f.Filename).ToArray());
+                var expected = files.Concat(new[] { new TestFile { Filename = "node_modules" } }).ToArray();
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, expected.Select(f => f.Filename).ToArray(), "site/wwwroot");
             });
         }
 
@@ -303,10 +303,10 @@ namespace Kudu.FunctionalTests
                 using (var repo = Git.Init(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())))
                 {
                     // First deploy zip
-                    var files = CreateRandomFilesForZip(10);
+                    var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                     var response = await DeployZip(appManager, files, new ZipDeployMetadata());
                     response.EnsureSuccessStatusCode();
-                    await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray());
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot");
 
                     await appManager.SettingsManager.SetValue(SettingsKeys.ScmType, "LocalGit");
 
@@ -315,19 +315,19 @@ namespace Kudu.FunctionalTests
                     File.WriteAllText(gitFilePath, Guid.NewGuid().ToString("N"));
                     Git.Commit(repo.PhysicalPath, "Initial commit");
                     var gitResult = appManager.GitDeploy(repo.PhysicalPath);
-                    await AssertSuccessfulDeploymentByFilenames(appManager, Directory.GetFiles(repo.PhysicalPath).Select(f => Path.GetFileName(f)).ToArray());
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, Directory.GetFiles(repo.PhysicalPath).Select(f => Path.GetFileName(f)).ToArray(), "site/wwwroot");
 
                     // Deploy new zip
-                    var files2 = CreateRandomFilesForZip(10);
+                    var files2 = DeploymentTestHelper.CreateRandomFilesForZip(10);
                     var response2 = await DeployZip(appManager, files2, new ZipDeployMetadata());
                     response2.EnsureSuccessStatusCode();
-                    await AssertSuccessfulDeploymentByFilenames(appManager, files2.Select(f => f.Filename).ToArray());
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files2.Select(f => f.Filename).ToArray(), "site/wwwroot");
 
                     // Redeploy git deployment
                     var id = Git.Id(repo.PhysicalPath);
                     var response3 = await appManager.DeploymentManager.DeployAsync(id);
                     response3.EnsureSuccessStatusCode();
-                    await AssertSuccessfulDeploymentByFilenames(appManager, Directory.GetFiles(repo.PhysicalPath).Select(f => Path.GetFileName(f)).ToArray());
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, Directory.GetFiles(repo.PhysicalPath).Select(f => Path.GetFileName(f)).ToArray(), "site/wwwroot");
                 }
             });
         }
@@ -337,10 +337,10 @@ namespace Kudu.FunctionalTests
         {
             return ApplicationManager.RunAsync("TestSimpleWarDeployment", async appManager =>
             {
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 var response = await DeployWar(appManager, files, new ZipDeployMetadata());
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "webapps/ROOT");
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot/webapps/ROOT");
             });
         }
 
@@ -349,7 +349,7 @@ namespace Kudu.FunctionalTests
         {
             return ApplicationManager.RunAsync("TestWarDeploymentUpdatesWebXmlTimestamp", async appManager =>
             {
-                var files = new[] { new FileForZip { Filename = "WEB-INF/web.xml" } };
+                var files = new[] { new TestFile { Filename = "WEB-INF/web.xml" } };
 
                 // STEP 1: Deploy WAR and get web.xml timestamp
 
@@ -413,10 +413,10 @@ namespace Kudu.FunctionalTests
 
                 // STEP 2: Perform wardeploy and check files deployed by wardeploy are the only ones that exist now
                 // (in other words, check that the file created in step 1 is removed by wardeploy)
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 var response = await DeployWar(appManager, files, new ZipDeployMetadata());
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "webapps/ROOT");
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot/webapps/ROOT");
             });
         }
 
@@ -425,14 +425,14 @@ namespace Kudu.FunctionalTests
         {
             return ApplicationManager.RunAsync("TestSimpleWarDeploymentPerformsCleanDeployment", async appManager =>
             {
-                var files = CreateRandomFilesForZip(10);
+                var files = DeploymentTestHelper.CreateRandomFilesForZip(10);
                 var response = await DeployWar(appManager, files, new ZipDeployMetadata(), "testappname");
                 response.EnsureSuccessStatusCode();
-                await AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "webapps/testappname");
+                await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, files.Select(f => f.Filename).ToArray(), "site/wwwroot/webapps/testappname");
             });
         }
 
-        private static async Task AssertSuccessfulDeploymentByContent(ApplicationManager appManager, FileForZip[] files)
+        private static async Task AssertSuccessfulDeploymentByContent(ApplicationManager appManager, TestFile[] files)
         {
             TestTracer.Trace("Verifying files are deployed and deployment record created.");
 
@@ -454,21 +454,6 @@ namespace Kudu.FunctionalTests
             }
         }
 
-        private static async Task AssertSuccessfulDeploymentByFilenames(ApplicationManager appManager, string[] filenames, string path = null)
-        {
-            TestTracer.Trace("Verifying files are deployed and deployment record created.");
-
-            var deployment = await appManager.DeploymentManager.GetResultAsync("latest");
-
-            Assert.Equal(DeployStatus.Success, deployment.Status);
-
-            var entries = await appManager.VfsWebRootManager.ListAsync(path);
-            var deployedFilenames = entries.Select(e => e.Name);
-
-            var filenameSet = new HashSet<string>(filenames);
-            Assert.True(filenameSet.SetEquals(entries.Select(e => e.Name)), string.Join(",", filenameSet) + " != " + string.Join(",", entries.Select(e => e.Name)));
-        }
-
         private static async Task AssertSuccessfulDeployment(ApplicationManager appManager, int timeoutSecs = 30)
         {
             DeployResult deployment = null;
@@ -488,11 +473,11 @@ namespace Kudu.FunctionalTests
 
         private static async Task<HttpResponseMessage> DeployZip(
             ApplicationManager appManager,
-            FileForZip[] files,
+            TestFile[] files,
             ZipDeployMetadata metadata)
         {
             TestTracer.Trace("Push-deploying zip");
-            using (var zipStream = CreateZipStream(files))
+            using (var zipStream = DeploymentTestHelper.CreateZipStream(files))
             {
                 return await appManager.ZipDeploymentManager.PushDeployFromStream(
                     zipStream,
@@ -502,12 +487,12 @@ namespace Kudu.FunctionalTests
 
         private static async Task<HttpResponseMessage> DeployWar(
             ApplicationManager appManager,
-            FileForZip[] files,
+            TestFile[] files,
             ZipDeployMetadata metadata,
             string appName = null)
         {
             TestTracer.Trace("Push-deploying war");
-            using (var zipStream = CreateZipStream(files))
+            using (var zipStream = DeploymentTestHelper.CreateZipStream(files))
             {
                 IList<KeyValuePair<string, string>> queryParams = null;
                 if (!string.IsNullOrWhiteSpace(appName))
@@ -522,60 +507,14 @@ namespace Kudu.FunctionalTests
             }
         }
 
-        private static FileForZip[] CreateRandomFilesForZip(int numFiles)
-        {
-            return Enumerable.Range(0, numFiles)
-                .Select(i => Guid.NewGuid().ToString("N"))
-                .Select(s => new FileForZip { Content = s, Filename = s })
-                .ToArray();
-        }
-        private static Stream CreateZipStream(int numFiles, out HashSet<string> fileNames)
-        {
-            var files = CreateRandomFilesForZip(numFiles);
-            var stream = CreateZipStream(files);
-            fileNames = new HashSet<string>(files.Select(f => f.Filename));
-            return stream;
-        }
-
-        private static Stream CreateZipStream(FileForZip[] files)
-        {
-            var s = new MemoryStream();
-            using (var archive = new ZipArchive(s, ZipArchiveMode.Update, true))
-            {
-                foreach (var file in files)
-                {
-                    var entry = archive.CreateEntry(file.Filename);
-
-                    using (var w = new StreamWriter(entry.Open()))
-                    {
-                        w.Write(file.Content);
-                    }
-
-                    if (file.ModifiedTime.HasValue)
-                    {
-                        entry.LastWriteTime = file.ModifiedTime.Value;
-                    }
-                }
-            }
-
-            s.Position = 0;
-            return s;
-        }
-
         private static string simplePackageJsonWithDependencyContent = @"{
-  ""name"": ""test"",
-  ""version"": ""1.0.0"",
-  ""dependencies"": {
-    ""express"": """"
-  }
-}
-";
-
-        private class FileForZip
-        {
-            public string Filename;
-            public string Content;
-            public DateTime? ModifiedTime;
+          ""name"": ""test"",
+          ""version"": ""1.0.0"",
+          ""dependencies"": {
+            ""express"": """"
+          }
         }
+        ";
+
     }
 }

--- a/Kudu.Services.Web/App_Start/NinjectServices.cs
+++ b/Kudu.Services.Web/App_Start/NinjectServices.cs
@@ -463,6 +463,9 @@ namespace Kudu.Services.Web.App_Start
             routes.MapHttpRouteDual("zip-push-deploy", "zipdeploy", new { controller = "PushDeployment", action = "ZipPushDeploy" }, new { verb = new HttpMethodConstraint("POST", "PUT") });
             routes.MapHttpRoute("zip-war-deploy", "api/wardeploy", new { controller = "PushDeployment", action = "WarPushDeploy" }, new { verb = new HttpMethodConstraint("POST") });
 
+            //OneDeploy
+            routes.MapHttpRouteDual("onedeploy", "publish", new { controller = "PushDeployment", action = "OneDeploy" }, new { verb = new HttpMethodConstraint("POST", "PUT") });
+            
             // Live Command Line
             routes.MapHttpRouteDual("execute-command", "command", new { controller = "Command", action = "ExecuteCommand" }, new { verb = new HttpMethodConstraint("POST") });
 
@@ -513,7 +516,7 @@ namespace Kudu.Services.Web.App_Start
                 routes.MapHttpRoute("current-docker-logs-zip", "api/logs/docker/zip", new { controller = "Diagnostics", action = "GetContainerLogsZip" }, new { verb = new HttpMethodConstraint("GET") });
                 routes.MapHttpRoute("current-docker-logs", "api/logs/docker", new { controller = "Diagnostics", action = "GetContainerLogs" }, new { verb = new HttpMethodConstraint("GET") });
             }
-
+            
             var processControllerName = OSDetector.IsOnWindows() ? "Process" : "LinuxProcess";
 
             // Processes

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -8,10 +8,12 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.ServiceModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Kudu.Contracts.Deployment;
 using Kudu.Contracts.Settings;
 using Kudu.Contracts.Tracing;
 using Kudu.Core;
@@ -64,7 +66,7 @@ namespace Kudu.Services.Deployment
         {
             using (_tracer.Step("ZipPushDeploy"))
             {
-                var deploymentInfo = new ZipDeploymentInfo(_environment, _traceFactory)
+                var deploymentInfo = new ArtifactDeploymentInfo(_environment, _traceFactory)
                 {
                     AllowDeploymentWhileScmDisabled = true,
                     Deployer = deployer,
@@ -86,7 +88,7 @@ namespace Kudu.Services.Deployment
                     // This is used if the deployment is Run-From-Zip
                     // the name of the deployed file in D:\home\data\SitePackages\{name}.zip is the 
                     // timestamp in the format yyyMMddHHmmss. 
-                    deploymentInfo.ZipName = $"{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}.zip";
+                    deploymentInfo.ArtifactFileName = $"{DateTime.UtcNow.ToString("yyyyMMddHHmmss")}.zip";
 
                     // This is also for Run-From-Zip where we need to extract the triggers
                     // for post deployment sync triggers.
@@ -114,11 +116,11 @@ namespace Kudu.Services.Deployment
                     appName = "ROOT";
                 }
 
-                var deploymentInfo = new ZipDeploymentInfo(_environment, _traceFactory)
+                var deploymentInfo = new ArtifactDeploymentInfo(_environment, _traceFactory)
                 {
                     AllowDeploymentWhileScmDisabled = true,
                     Deployer = deployer,
-                    TargetPath = Path.Combine("webapps", appName),
+                    TargetDirectoryPath = Path.Combine("webapps", appName),
                     WatchedFilePath = Path.Combine("WEB-INF", "web.xml"),
                     IsContinuous = false,
                     AllowDeferredDeployment = false,
@@ -138,9 +140,213 @@ namespace Kudu.Services.Deployment
             }
         }
 
-        private string GetZipURLFromARMJSON(JObject requestObject)
+        //
+        // Supports:
+        // 1. Deploy artifact in the request body:
+        //    - For this: Query parameters should contain configuration.
+        //                Example: /api/publish?type=war
+        //                Request body should contain the artifact being deployed
+        // 2. URL based deployment:
+        //    - For this: Query parameters should contain configuration. Example: /api/publish?type=war
+        //                Example: /api/publish?type=war
+        //                Request body should contain JSON with 'packageUri' property pointing to the artifact location
+        //                Example: { "packageUri": "http://foo/bar.war?accessToken=123" }
+        // 3. ARM template based deployment:
+        //    - For this: Query parameters are not supported.
+        //                Request body should contain JSON with configuration as well as the artifact location
+        //                Example: { "properties": { "type": "war", "packageUri": "http://foo/bar.war?accessToken=123" } }
+        //
+        [HttpPost]
+        [HttpPut]
+        public async Task<HttpResponseMessage> OneDeploy(
+            [FromUri] string type = null,
+            [FromUri] bool async = false,
+            [FromUri] string path = null,
+            [FromUri] bool restart = true,
+            [FromUri] string stack = null
+            )
         {
-            using (_tracer.Step("Reading the zip URL from the request JSON"))
+            using (_tracer.Step("OnePushDeploy"))
+            {
+                JObject requestObject = null;
+
+                try
+                {
+                    if (ArmUtils.IsArmRequest(Request))
+                    {
+                        requestObject = await Request.Content.ReadAsAsync<JObject>();
+                        var armProperties = requestObject.Value<JObject>("properties");
+                        type = armProperties.Value<string>("type");
+                        async = armProperties.Value<bool>("async");
+                        path = armProperties.Value<string>("path");
+                        restart = armProperties.Value<bool>("restart");
+                        stack = armProperties.Value<string>("stack");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    return ArmUtils.CreateErrorResponse(Request, HttpStatusCode.BadRequest, ex);
+                }
+
+                //
+                // 'async' is not a CSharp-ish variable name. And although it is a valid variable name, some
+                // IDEs confuse it to be the 'async' keyword in C#.
+                // On the other hand, isAsync is not a good name for the query-parameter.
+                // So we use 'async' as the query parameter, and then assign it to the C# variable 'isAsync' 
+                // at the earliest. Hereon, we use just 'isAsync'.
+                // 
+                bool isAsync = async;
+
+                var deploymentInfo = new ArtifactDeploymentInfo(_environment, _traceFactory)
+                {
+                    AllowDeploymentWhileScmDisabled = true,
+                    Deployer = Constants.OneDeploy,
+                    IsContinuous = false,
+                    AllowDeferredDeployment = false,
+                    IsReusable = false,
+                    TargetChangeset = DeploymentManager.CreateTemporaryChangeSet(message: "OneDeploy"),
+                    CommitId = null,
+                    RepositoryType = RepositoryType.None,
+                    Fetch = OneDeployFetch,
+                    DoFullBuildByDefault = false,
+                    Message = "OneDeploy",
+                    WatchedFileEnabled = false,
+                    RestartAllowed = restart,
+                };
+
+                string websiteStack = !string.IsNullOrWhiteSpace(stack) ? stack : _settings.GetValue(Constants.StackEnvVarName);
+
+                ArtifactType artifactType = ArtifactType.Invalid;
+                try
+                {
+                    artifactType = (ArtifactType)Enum.Parse(typeof(ArtifactType), type, ignoreCase: true);
+                }
+                catch
+                {
+                    return Request.CreateResponse(HttpStatusCode.BadRequest, $"type='{type}' not recognized");
+                }
+
+                switch (artifactType)
+                {
+                    case ArtifactType.War:
+                        if(!string.Equals(websiteStack, Constants.Tomcat, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return Request.CreateResponse(HttpStatusCode.BadRequest, $"WAR files cannot be deployed to stack='{websiteStack}'. Expected stack='TOMCAT'"); 
+                        }
+                        
+                        // Support for legacy war deployments
+                        // Sets TargetDirectoryPath then deploys the War file as a Zip so it can be extracted
+                        // then deployed
+                        if(!string.IsNullOrWhiteSpace(path))
+                        {
+                            //
+                            // For legacy war deployments, the only path allowed is site/wwwroot/webapps/<directory-name>
+                            //
+
+                            var segments = path.Split('/');
+                            if (segments.Length != 4 || !path.StartsWith("site/wwwroot/webapps/") || string.IsNullOrWhiteSpace(segments[3]))
+                            {
+                                return Request.CreateResponse(HttpStatusCode.BadRequest, $"path='{path}'. Only allowed path when type={artifactType} is site/wwwroot/webapps/<directory-name>. Example: path=site/wwwroot/webapps/ROOT");
+                            }
+
+                            deploymentInfo.TargetDirectoryPath = Path.Combine(_environment.RootPath, path);
+                            deploymentInfo.Fetch = LocalZipHandler;
+                            deploymentInfo.CleanupTargetDirectory = true;
+                            artifactType = ArtifactType.Zip;
+                        }
+                        else
+                        {
+                            // For type=war, the target file is app.war
+                            // As we want app.war to be deployed to wwwroot, no need to configure TargetDirectoryPath
+                            deploymentInfo.TargetFileName = "app.war";
+                        }
+
+                        break;
+
+                    case ArtifactType.Jar:
+                        if (!string.Equals(websiteStack, Constants.JavaSE, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return Request.CreateResponse(HttpStatusCode.BadRequest, $"JAR files cannot be deployed to stack='{websiteStack}'. Expected stack='JAVASE'");
+                        }
+
+                        deploymentInfo.TargetFileName = "app.jar";
+
+                        break;
+
+                    case ArtifactType.Ear:
+                        // Currently not supported on Windows but here for future use
+                        if (!string.Equals(websiteStack, Constants.JBossEap, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return Request.CreateResponse(HttpStatusCode.BadRequest, $"EAR files cannot be deployed to stack='{websiteStack}'. Expected stack='JBOSSEAP'");
+                        }
+
+                        deploymentInfo.TargetFileName = "app.ear";
+
+                        break;
+
+                    case ArtifactType.Lib:
+                        if (string.IsNullOrWhiteSpace(path))
+                        {
+                            return Request.CreateResponse(HttpStatusCode.BadRequest, $"Path must be defined for library deployments");
+                        }
+
+                        SetTargetFromPath(deploymentInfo, path);
+
+                        break;
+
+                    case ArtifactType.Startup:
+                        SetTargetFromPath(deploymentInfo, GetStartupFileName());
+
+                        break;
+
+                    case ArtifactType.Static:
+                        if (string.IsNullOrWhiteSpace(path))
+                        {
+                            return Request.CreateResponse(HttpStatusCode.BadRequest, $"Path must be defined for static file deployments");
+                        }
+
+                        SetTargetFromPath(deploymentInfo, path);
+
+                        break;
+
+                    case ArtifactType.Zip:
+                        deploymentInfo.Fetch = LocalZipHandler;
+
+                        break;
+
+                    default:
+                        return Request.CreateResponse(HttpStatusCode.BadRequest, $"Artifact type '{artifactType}' not supported");
+                }
+
+                return await PushDeployAsync(deploymentInfo, isAsync, requestObject, artifactType);
+            }
+        }
+
+        private void SetTargetFromPath(DeploymentInfoBase deploymentInfo, string path)
+        {
+            // Extract directory path and file name from 'path'
+            // Example: path=a/b/c.jar => TargetDirectoryName=a/b and TargetFileName=c.jar
+            deploymentInfo.TargetFileName = Path.GetFileName(path);
+
+            var relativeDirectoryPath = Path.GetDirectoryName(path);
+
+            // Translate /foo/bar to foo/bar
+            // Translate \foo\bar to foo\bar
+            // That way, we can combine it with %HOME% to get the absolute path
+            relativeDirectoryPath = relativeDirectoryPath.TrimStart('/', '\\');
+            var absoluteDirectoryPath = Path.Combine(_environment.RootPath, relativeDirectoryPath);
+
+            deploymentInfo.TargetDirectoryPath = absoluteDirectoryPath;
+        }
+
+        private static string GetStartupFileName()
+        {
+            return OSDetector.IsOnWindows() ? "startup.bat" : "startup.sh";
+        }
+
+        private string GetArticfactURLFromARMJSON(JObject requestObject)
+        {
+            using (_tracer.Step("Reading the artifact URL from the request JSON"))
             {
                 try
                 {
@@ -160,9 +366,9 @@ namespace Kudu.Services.Deployment
             }
         }
 
-        private string GetZipURLFromJSON(JObject requestObject)
+        private string GetArtifactURLFromJSON(JObject requestObject)
         {
-            using (_tracer.Step("Reading the zip URL from the request JSON"))
+            using (_tracer.Step("Reading the artifact URL from the request JSON"))
             {
                 try
                 {
@@ -181,7 +387,7 @@ namespace Kudu.Services.Deployment
             }
         }
 
-        private async Task<HttpResponseMessage> PushDeployAsync(ZipDeploymentInfo deploymentInfo, bool isAsync)
+        private async Task<HttpResponseMessage> PushDeployAsync(ArtifactDeploymentInfo deploymentInfo, bool isAsync, JObject requestObject = null, ArtifactType artifactType = ArtifactType.Zip)
         {
             var content = Request.Content;
             var isRequestJSON = content.Headers?.ContentType?.MediaType?.Equals("application/json", StringComparison.OrdinalIgnoreCase);
@@ -189,15 +395,21 @@ namespace Kudu.Services.Deployment
             {
                 try
                 {
-                    var requestObject = await Request.Content.ReadAsAsync<JObject>();
-                    deploymentInfo.ZipURL = ArmUtils.IsArmRequest(Request) ? GetZipURLFromARMJSON(requestObject) : GetZipURLFromJSON(requestObject);
+                    // Read the request body if it hasn't been read already
+                    if (requestObject == null)
+                    {
+                        requestObject = await Request.Content.ReadAsAsync<JObject>();
+                    }
+                    deploymentInfo.RemoteURL = ArmUtils.IsArmRequest(Request) ? GetArticfactURLFromARMJSON(requestObject) : GetArtifactURLFromJSON(requestObject);
                 }
                 catch (Exception ex)
                 {
                     return ArmUtils.CreateErrorResponse(Request, HttpStatusCode.BadRequest, ex);
                 }
             }
-            else
+            // For zip artifacts (zipdeploy, wardeploy, onedeploy with type=zip), copy the request body in a temp zip file.
+            // It will be extracted to the appropriate directory by the Fetch handler
+            else if (artifactType == ArtifactType.Zip)
             {
                 if (_settings.RunFromLocalZip())
                 {
@@ -215,6 +427,18 @@ namespace Kudu.Services.Deployment
 
                     deploymentInfo.RepositoryUrl = zipFilePath;
                 }
+            }
+            // Copy the request body to a temp file.
+            // It will be moved to the appropriate directory by the Fetch handler
+            else if (deploymentInfo.Deployer == Constants.OneDeploy)
+            {
+                var artifactTempPath = Path.Combine(_environment.ZipTempPath, deploymentInfo.TargetFileName);
+                using (_tracer.Step("Saving request content to {0}", artifactTempPath))
+                {
+                    await content.CopyToAsync(artifactTempPath, _tracer);
+                }
+
+                deploymentInfo.RepositoryUrl = artifactTempPath;
             }
 
             isAsync = ArmUtils.IsArmRequest(Request) ? true : isAsync;
@@ -303,13 +527,13 @@ namespace Kudu.Services.Deployment
 
         private async Task LocalZipHandler(IRepository repository, DeploymentInfoBase deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
         {
-            if (_settings.RunFromLocalZip() && deploymentInfo is ZipDeploymentInfo)
+            if (_settings.RunFromLocalZip() && deploymentInfo is ArtifactDeploymentInfo)
             {
-                ZipDeploymentInfo zipDeploymentInfo = (ZipDeploymentInfo) deploymentInfo;
+                ArtifactDeploymentInfo zipDeploymentInfo = (ArtifactDeploymentInfo)deploymentInfo;
                 // If this was a request with a Zip URL in the JSON, we first need to get the zip content and write it to the site.
-                if (!string.IsNullOrEmpty(zipDeploymentInfo.ZipURL))
+                if (!string.IsNullOrEmpty(zipDeploymentInfo.RemoteURL))
                 {
-                    await WriteSitePackageZip(zipDeploymentInfo, tracer, await DeploymentHelper.GetZipContentFromURL(zipDeploymentInfo, tracer));
+                    await WriteSitePackageZip(zipDeploymentInfo, tracer, await DeploymentHelper.GetArtifactContentFromURL(zipDeploymentInfo, tracer));
                 }
                 // If this is a Run-From-Zip deployment, then we need to extract function.json
                 // from the zip file into path zipDeploymentInfo.SyncFunctionsTriggersPath
@@ -321,13 +545,13 @@ namespace Kudu.Services.Deployment
             }
         }
 
-        private void ExtractTriggers(IRepository repository, ZipDeploymentInfo zipDeploymentInfo)
+        private void ExtractTriggers(IRepository repository, ArtifactDeploymentInfo deploymentInfo)
         {
-            FileSystemHelpers.EnsureDirectory(zipDeploymentInfo.SyncFunctionsTriggersPath);
+            FileSystemHelpers.EnsureDirectory(deploymentInfo.SyncFunctionsTriggersPath);
             // Loading the zip file depends on how fast the file system is.
             // Tested Azure Files share with a zip containing 120k files (160 MBs)
             // takes 20 seconds to load. On my machine it takes 900 msec.
-            using (var zip = ZipFile.OpenRead(Path.Combine(_environment.SitePackagesPath, zipDeploymentInfo.ZipName)))
+            using (var zip = ZipFile.OpenRead(Path.Combine(_environment.SitePackagesPath, deploymentInfo.ArtifactFileName)))
             {
                 var entries = zip.Entries
                     // Only select host.json, proxies.json, or function.json that are from top level directories only
@@ -339,13 +563,13 @@ namespace Kudu.Services.Deployment
 
                 foreach (var entry in entries)
                 {
-                    var path = Path.Combine(zipDeploymentInfo.SyncFunctionsTriggersPath, entry.FullName);
+                    var path = Path.Combine(deploymentInfo.SyncFunctionsTriggersPath, entry.FullName);
                     FileSystemHelpers.EnsureDirectory(Path.GetDirectoryName(path));
                     entry.ExtractToFile(path, overwrite: true);
                 }
             }
 
-            CommitRepo(repository, zipDeploymentInfo);
+            CommitRepo(repository, deploymentInfo);
 
             bool isFunctionJson(string fullName)
             {
@@ -354,13 +578,70 @@ namespace Kudu.Services.Deployment
             }
         }
 
-        private async Task<string> DeployZipLocally(ZipDeploymentInfo zipDeploymentInfo, ITracer tracer)
+        // OneDeploy Fetch handler for non-zip artifacts.
+        // For zip files, OneDeploy uses the LocalZipHandler Fetch handler
+        // NOTE: Do not access the request stream as it may have been closed during asynchronous scenarios
+        private async Task OneDeployFetch(IRepository repository, DeploymentInfoBase deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
         {
-            var content = await DeploymentHelper.GetZipContentFromURL(zipDeploymentInfo, tracer);
+            var artifactDeploymentInfo = (ArtifactDeploymentInfo) deploymentInfo;
+
+            // This is the path where the artifact being deployed is staged, before it is copied to the final target location
+            var artifactDirectoryStagingPath = repository.RepositoryPath;
+
+            var targetInfo = FileSystemHelpers.DirectoryInfoFromDirectoryName(artifactDirectoryStagingPath);
+            if (targetInfo.Exists)
+            {
+                // If tempDirPath already exists, rename it so we can delete it later 
+                var moveTarget = Path.Combine(targetInfo.Parent.FullName, Path.GetRandomFileName());
+                using (tracer.Step(string.Format("Renaming ({0}) to ({1})", targetInfo.FullName, moveTarget)))
+                {
+                    targetInfo.MoveTo(moveTarget);
+                }
+            }
+
+            // Create artifact staging directory before later use 
+            Directory.CreateDirectory(artifactDirectoryStagingPath);
+            var artifactFileStagingPath = Path.Combine(artifactDirectoryStagingPath, deploymentInfo.TargetFileName);
+
+            // If RemoteUrl is non-null, it means the content needs to be downloaded from the Url source to the staging location
+            // Else, it had been downloaded already so we just move the downloaded file to the staging location
+            if (!string.IsNullOrWhiteSpace(artifactDeploymentInfo.RemoteURL))
+            {
+                using (tracer.Step("Saving request content to {0}", artifactFileStagingPath))
+                {
+                    var content = await DeploymentHelper.GetArtifactContentFromURL(artifactDeploymentInfo, tracer);
+                    var copyTask = content.CopyToAsync(artifactFileStagingPath, tracer);
+
+                    // Deletes all files and directories except for artifactFileStagingPath and artifactDirectoryStagingPath
+                    var cleanTask = Task.Run(() => DeleteFilesAndDirsExcept(artifactFileStagingPath, artifactDirectoryStagingPath, tracer));
+
+                    // Lets the copy and cleanup tasks to run in parallel and wait for them to finish 
+                    await Task.WhenAll(copyTask, cleanTask);
+                }
+            }
+            else
+            {
+                var srcInfo = FileSystemHelpers.DirectoryInfoFromDirectoryName(deploymentInfo.RepositoryUrl);
+                using (tracer.Step(string.Format("Moving {0} to {1}", targetInfo.FullName, artifactFileStagingPath)))
+                {
+                    srcInfo.MoveTo(artifactFileStagingPath);
+                }
+
+                // Deletes all files and directories except for artifactFileStagingPath and artifactDirectoryStagingPath
+                DeleteFilesAndDirsExcept(artifactFileStagingPath, artifactDirectoryStagingPath, tracer);
+            }
+
+            // The deployment flow expects at least 1 commit in the IRepository commit, refer to CommitRepo() for more info
+            CommitRepo(repository, artifactDeploymentInfo);
+        }
+
+        private async Task<string> DeployZipLocally(ArtifactDeploymentInfo zipDeploymentInfo, ITracer tracer)
+        {
+            var content = await DeploymentHelper.GetArtifactContentFromURL(zipDeploymentInfo, tracer);
             var zipFileName = Path.ChangeExtension(Path.GetRandomFileName(), "zip");
             var zipFilePath = Path.Combine(_environment.ZipTempPath, zipFileName);
 
-            using (_tracer.Step("Downloading content from {0} to {1}", zipDeploymentInfo.ZipURL.Split('?')[0], zipFilePath))
+            using (_tracer.Step("Downloading content from {0} to {1}", zipDeploymentInfo.RemoteURL.Split('?')[0], zipFilePath))
             {
                 await content.CopyToAsync(zipFilePath, _tracer);
             }
@@ -371,15 +652,15 @@ namespace Kudu.Services.Deployment
 
         private async Task LocalZipFetch(IRepository repository, DeploymentInfoBase deploymentInfo, string targetBranch, ILogger logger, ITracer tracer)
         {
-            var zipDeploymentInfo = (ZipDeploymentInfo) deploymentInfo;
+            var zipDeploymentInfo = (ArtifactDeploymentInfo)deploymentInfo;
 
             // If this was a request with a Zip URL in the JSON, we need to deploy the zip locally and get the path
             // Otherwise, for this kind of deployment, RepositoryUrl is a local path.
-            var sourceZipFile = !string.IsNullOrEmpty(zipDeploymentInfo.ZipURL)
+            var sourceZipFile = !string.IsNullOrEmpty(zipDeploymentInfo.RemoteURL)
                 ? await DeployZipLocally(zipDeploymentInfo, tracer)
                 : zipDeploymentInfo.RepositoryUrl;
 
-            var extractTargetDirectory = repository.RepositoryPath;
+            var artifactFileStagingDirectory = repository.RepositoryPath;
 
             var info = FileSystemHelpers.FileInfoFromFileName(sourceZipFile);
             var sizeInMb = (info.Length / (1024f * 1024f)).ToString("0.00", CultureInfo.InvariantCulture);
@@ -389,7 +670,7 @@ namespace Kudu.Services.Deployment
                 "Cleaning up temp folders from previous zip deployments and extracting pushed zip file {0} ({1} MB) to {2}",
                 info.FullName,
                 sizeInMb,
-                extractTargetDirectory);
+                artifactFileStagingDirectory);
 
             logger.Log(message);
 
@@ -397,7 +678,7 @@ namespace Kudu.Services.Deployment
             {
                 // If extractTargetDirectory already exists, rename it so we can delete it concurrently with
                 // the unzip (along with any other junk in the folder)
-                var targetInfo = FileSystemHelpers.DirectoryInfoFromDirectoryName(extractTargetDirectory);
+                var targetInfo = FileSystemHelpers.DirectoryInfoFromDirectoryName(artifactFileStagingDirectory);
                 if (targetInfo.Exists)
                 {
                     var moveTarget = Path.Combine(targetInfo.Parent.FullName, Path.GetRandomFileName());
@@ -407,37 +688,36 @@ namespace Kudu.Services.Deployment
                     }
                 }
 
-                var cleanTask = Task.Run(() => DeleteFilesAndDirsExcept(sourceZipFile, extractTargetDirectory, tracer));
+                var cleanTask = Task.Run(() => DeleteFilesAndDirsExcept(sourceZipFile, artifactFileStagingDirectory, tracer));
                 var extractTask = Task.Run(() =>
                 {
-                    FileSystemHelpers.CreateDirectory(extractTargetDirectory);
+                    FileSystemHelpers.CreateDirectory(artifactFileStagingDirectory);
 
                     using (var file = info.OpenRead())
                     using (var zip = new ZipArchive(file, ZipArchiveMode.Read))
                     {
-                        zip.Extract(extractTargetDirectory, tracer, _settings.GetZipDeployDoNotPreserveFileTime());
+                        zip.Extract(artifactFileStagingDirectory, tracer, _settings.GetZipDeployDoNotPreserveFileTime());
                     }
                 });
 
                 await Task.WhenAll(cleanTask, extractTask);
             }
-
             CommitRepo(repository, zipDeploymentInfo);
         }
 
-        private static void CommitRepo(IRepository repository, ZipDeploymentInfo zipDeploymentInfo)
+        private static void CommitRepo(IRepository repository, ArtifactDeploymentInfo deploymentInfo)
         {
             // Needed in order for repository.GetChangeSet() to work.
             // Similar to what OneDriveHelper and DropBoxHelper do.
             // We need to make to call repository.Commit() since deployment flow expects at
             // least 1 commit in the IRepository. Even though there is no repo per se in this
             // scenario, deployment pipeline still generates a NullRepository
-            repository.Commit(zipDeploymentInfo.Message, zipDeploymentInfo.Author, zipDeploymentInfo.AuthorEmail);
+            repository.Commit(deploymentInfo.Message, deploymentInfo.Author, deploymentInfo.AuthorEmail);
         }
 
-        private async Task WriteSitePackageZip(ZipDeploymentInfo zipDeploymentInfo, ITracer tracer, HttpContent content)
+        private async Task WriteSitePackageZip(ArtifactDeploymentInfo zipDeploymentInfo, ITracer tracer, HttpContent content)
         {
-            var filePath = Path.Combine(_environment.SitePackagesPath, zipDeploymentInfo.ZipName);
+            var filePath = Path.Combine(_environment.SitePackagesPath, zipDeploymentInfo.ArtifactFileName);
 
             // Make sure D:\home\data\SitePackages exists
             FileSystemHelpers.EnsureDirectory(_environment.SitePackagesPath);

--- a/Kudu.TestHarness/ApplicationManager.cs
+++ b/Kudu.TestHarness/ApplicationManager.cs
@@ -57,6 +57,7 @@ namespace Kudu.TestHarness
             SiteExtensionManager = new RemoteSiteExtensionManager(site.ServiceUrl + "api", credentials);
             ZipDeploymentManager = new RemotePushDeploymentManager(site.ServiceUrl + "api/zipdeploy", credentials);
             WarDeploymentManager = new RemotePushDeploymentManager(site.ServiceUrl + "api/wardeploy", credentials);
+            OneDeployManager = new RemotePushDeploymentManager(site.ServiceUrl + "api/publish", credentials);
 
             var repositoryInfo = RepositoryManager.GetRepositoryInfo().Result;
             GitUrl = repositoryInfo.GitUrl.OriginalString;
@@ -193,6 +194,12 @@ namespace Kudu.TestHarness
         }
 
         public RemotePushDeploymentManager WarDeploymentManager
+        {
+            get;
+            private set;
+        }
+
+        public RemotePushDeploymentManager OneDeployManager
         {
             get;
             private set;


### PR DESCRIPTION
- Adds a new /api/publish API for Java deployment scenarios
- /api/publish primarily supports Java scenarios currently, but can be easily extended for additional scenarios
- Overview of new changes
  - OneDeploy reuses bulk of the code from PushDeploymentController and DeploymentManager
  - OneDeployBuilder is a new OneDeploy specific site builder, OneDeployFetch is a OneDeploy specific Fetch handler
  - WatchedFileEnabled/RestartAllowed are additional knobs introduced in DeploymentInfoBase.cs for OneDeploy specific functionality
  - The implementation inspects the WEBSITE_STACK environment variable for certain scenarios. This variable is injected by the App Service runtime
  - OneDeploy uses the new restart API (in other words, it does not rely on touching any file for triggering a recycle)
- Summary of changes to existing code:
  - A bunch of variables were renamed for readability purposes
  - ZipDeploymentInfo is now ArtifactDeploymentInfo (generalized) and is now used by OneDeploy for non-zip artifacts as well
  - Helper functions from ZipDeploymentTests.cs are moved to DeploymentHelperTests.cs/TestFile.cs so that OneDeployTests can use the same helpers
- Subsequent commit will make enhancements to the way OneDeploy handles lib, startup files, etc to improve the defaults