### PR TITLE
OneDeploy v2

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -138,12 +138,5 @@ namespace Kudu
         public const string AppOfflineKuduContent = "Created by kudu";
 
         public const string OneDeploy = "OneDeploy";
-        public const string StackEnvVarName = "WEBSITE_STACK";
-
-        // Stacks supported by OneDeploy 
-        public const string Tomcat = "TOMCAT";
-        public const string JavaSE = "JAVA";
-        public const string JBossEap = "JBOSSEAP";
-
     }
 }

--- a/Kudu.Contracts/Deployment/ArtifactType.cs
+++ b/Kudu.Contracts/Deployment/ArtifactType.cs
@@ -8,13 +8,14 @@ namespace Kudu.Contracts.Deployment
 {
     public enum ArtifactType
     {
-        Invalid,
+        Unknown,
         War,
         Jar,
         Ear,
         Lib,
         Static,
         Startup,
+        Script,
         Zip,
     }
 }

--- a/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
+++ b/Kudu.Contracts/Deployment/DeploymentInfoBase.cs
@@ -2,6 +2,7 @@
 using Kudu.Core.SourceControl;
 using Kudu.Contracts.Tracing;
 using System.Threading.Tasks;
+using Kudu.Contracts.Deployment;
 
 namespace Kudu.Core.Deployment
 {
@@ -16,6 +17,7 @@ namespace Kudu.Core.Deployment
             DoFullBuildByDefault = true;
             WatchedFileEnabled = true;
             RestartAllowed = true;
+            ArtifactType = ArtifactType.Unknown;
         }
 
         public RepositoryType RepositoryType { get; set; }
@@ -33,14 +35,23 @@ namespace Kudu.Core.Deployment
         public bool AllowDeploymentWhileScmDisabled { get; set; }
 
         // Optional.
+        // By default, TargetSubDirectoryRelativePath specifies the directory to deploy to relative to /home/site/wwwroot.
+        // This property can be used to change the root from wwwroot to something else.
+        public string TargetRootPath { get; set; }
+
+        // Optional.
         // Path of the directory to be deployed to. The path should be relative to the wwwroot directory.
         // Example: "webapps/ROOT"
-        public string TargetDirectoryPath { get; set; }
+        public string TargetSubDirectoryRelativePath { get; set; }
 
         // Optional.
         // Specifies the name of the deployed artifact.
-        // Example: When deploying startup files, OneDeploy will set this to startup.bat (or startup.sh)
+        // Example: When deploying startup files, OneDeploy will set this to startup.cmd (or startup.sh)
         public string TargetFileName { get; set; }
+
+        // Optional.
+        // Type of artifact being deployed.
+        public ArtifactType ArtifactType { get; set; }
 
         // Optional.
         // Path of the file that is watched for changes by the web server.

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -804,17 +804,22 @@ namespace Kudu.Core.Deployment
 
         private static string GetOutputPath(DeploymentInfoBase deploymentInfo, IEnvironment environment, IDeploymentSettingsManager perDeploymentSettings)
         {
-            string targetDirectoryPath = perDeploymentSettings.GetTargetPath();
+            string targetSubDirectoryRelativePath = perDeploymentSettings.GetTargetPath();
 
-            if (String.IsNullOrWhiteSpace(targetDirectoryPath))
+            if (String.IsNullOrWhiteSpace(targetSubDirectoryRelativePath))
             {
-                targetDirectoryPath = deploymentInfo?.TargetDirectoryPath;
+                targetSubDirectoryRelativePath = deploymentInfo?.TargetSubDirectoryRelativePath;
             }
 
-            if (!String.IsNullOrWhiteSpace(targetDirectoryPath))
+            if (deploymentInfo?.Deployer == Constants.OneDeploy)
             {
-                targetDirectoryPath = targetDirectoryPath.Trim('\\', '/');
-                return Path.GetFullPath(Path.Combine(environment.WebRootPath, targetDirectoryPath));
+                return string.IsNullOrWhiteSpace(deploymentInfo.TargetRootPath) ? environment.WebRootPath : deploymentInfo.TargetRootPath;
+            }
+
+            if (!String.IsNullOrWhiteSpace(targetSubDirectoryRelativePath))
+            {
+                targetSubDirectoryRelativePath = targetSubDirectoryRelativePath.Trim('\\', '/');
+                return Path.GetFullPath(Path.Combine(environment.WebRootPath, targetSubDirectoryRelativePath));
             }
 
             return environment.WebRootPath;

--- a/Kudu.Core/Deployment/Generator/OneDeployBuilder.cs
+++ b/Kudu.Core/Deployment/Generator/OneDeployBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -46,10 +47,22 @@ namespace Kudu.Core.Deployment.Generator
             {
                 context.Logger.Log($"Clean deploying to {context.OutputPath}");
 
-                // We do not want to use the manifest for OneDeploy. Set manifest paths to null.
+                // We do not want to use the manifest for OneDeploy. Use an empty manifest file.
                 // This way we don't interfere with manifest based deployments.
-                context.PreviousManifestFilePath = context.NextManifestFilePath = string.Empty;
-                base.Build(context);
+                string tempManifestPath = null;
+                try
+                {
+                    tempManifestPath = Path.GetTempFileName();
+                    context.PreviousManifestFilePath = context.NextManifestFilePath = tempManifestPath;
+                    base.Build(context);
+                }
+                finally
+                {
+                    if (!string.IsNullOrWhiteSpace(tempManifestPath))
+                    {
+                        FileSystemHelpers.DeleteFileSafe(tempManifestPath);
+                    }
+                }
             }
             else
             {

--- a/Kudu.FunctionalTests/App.config
+++ b/Kudu.FunctionalTests/App.config
@@ -3,6 +3,10 @@
     <appSettings>
         <!-- Uncomment out this line to reuse the same site for all functional tests, which runs much faster -->
         <add key="SiteReusedForAllTests" value="TestRunnerSite" />
+        <!-- Set this to true to run the tests against Linux Kudu instead of Windows Kudu -->
+        <add key="RunningAgainstLinuxKudu" value="false" />
+        <!-- Kudu URL to use for running the tests. This URL needs to have a trailing slash, example: http://localhost:8181/ -->
+        <add key="CustomKuduUrl" value="" />
         <!-- Update to change the maximum number of sites created on failure in reuse site mode -->
         <add key="MaxSiteNameIndex" value="1" />
         <!-- whether to retry on failure -->

--- a/Kudu.FunctionalTests/ZipDeploymentTests.cs
+++ b/Kudu.FunctionalTests/ZipDeploymentTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Kudu.Client.Deployment;
 using Kudu.Contracts.Settings;
 using Kudu.Core.Deployment;
+using Kudu.Core.Helpers;
 using Kudu.TestHarness;
 using Kudu.TestHarness.Xunit;
 using Newtonsoft.Json;
@@ -20,8 +21,6 @@ namespace Kudu.FunctionalTests
     [KuduXunitTestClass]
     public class ZipDeploymentTests
     {
-        public const string ZipDeployer = "ZipDeploy";
-
         [Fact]
         public Task TestSimpleZipDeployment()
         {
@@ -131,7 +130,7 @@ namespace Kudu.FunctionalTests
                 do
                 {
                     result = await appManager.DeploymentManager.GetResultAsync("latest");
-                    Assert.Equal(ZipDeployer, result.Deployer);
+                    Assert.Equal(GetZipDeployer(), result.Deployer);
                     await Task.Delay(TimeSpan.FromSeconds(2));
                 } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
 
@@ -174,7 +173,7 @@ namespace Kudu.FunctionalTests
                 do
                 {
                     result = await appManager.DeploymentManager.GetResultAsync("latest");
-                    Assert.Equal(ZipDeployer, result.Deployer);
+                    Assert.Equal(GetZipDeployer(), result.Deployer);
                     await Task.Delay(TimeSpan.FromSeconds(2));
                 } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
 
@@ -201,7 +200,7 @@ namespace Kudu.FunctionalTests
                 do
                 {
                     result = await appManager.DeploymentManager.GetResultAsync("latest");
-                    Assert.Equal(ZipDeployer, result.Deployer);
+                    Assert.Equal(GetZipDeployer(), result.Deployer);
                     await Task.Delay(TimeSpan.FromSeconds(2));
                 } while (!new[] { DeployStatus.Failed, DeployStatus.Success }.Contains(result.Status));
 
@@ -439,7 +438,7 @@ namespace Kudu.FunctionalTests
             var deployment = await appManager.DeploymentManager.GetResultAsync("latest");
 
             Assert.Equal(DeployStatus.Success, deployment.Status);
-            Assert.Equal(ZipDeployer, deployment.Deployer);
+            Assert.Equal(GetZipDeployer(), deployment.Deployer);
 
             var entries = await appManager.VfsWebRootManager.ListAsync(null);
             var deployedFilenames = entries.Select(e => e.Name);
@@ -505,6 +504,11 @@ namespace Kudu.FunctionalTests
                     metadata,
                     queryParams);
             }
+        }
+
+        private static string GetZipDeployer()
+        {
+            return KuduUtils.RunningAgainstLinuxKudu ? "Push-Deployer" : "ZipDeploy";
         }
 
         private static string simplePackageJsonWithDependencyContent = @"{

--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -1,0 +1,94 @@
+﻿using Kudu.Contracts.Deployment;
+using Kudu.Core;
+using Kudu.Core.Deployment;
+using Kudu.Core.Helpers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Kudu.Services.Deployment
+{
+    static class OneDeployHelper
+    {
+        // Stacks supported by OneDeploy 
+        public const string Tomcat = "TOMCAT";
+        public const string JavaSE = "JAVA";
+        public const string JBossEap = "JBOSSEAP";
+
+        private const string StackEnvVarName = "WEBSITE_STACK";
+
+        // All paths are relative to HOME directory
+        private const string ScriptsDirectoryRelativePath = "site/scripts";
+        private const string LibsDirectoryRelativePath = "site/libs";
+
+        public static bool IsLegacyWarPathValid(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            var segments = path.Split('/');
+
+            return segments.Length == 2 && path.StartsWith("webapps/", StringComparison.Ordinal) & !string.IsNullOrWhiteSpace(segments[1]);
+        }
+
+        public static bool EnsureValidStack(string expectedStack, bool ignoreStack, out string error)
+        {
+            var websiteStack = GetWebsiteStack();
+
+            if (ignoreStack || string.Equals(websiteStack, expectedStack, StringComparison.OrdinalIgnoreCase))
+            {
+                error = null;
+                return true;
+            }
+
+            error = $"WAR files cannot be deployed to stack='{websiteStack}'. Expected stack='{expectedStack}'";
+            return false;
+        }
+
+        public static bool EnsureValidPath(ArtifactType artifactType, string path, out string error)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                error = $"Path must be defined for type='{artifactType}'";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        public static string GetWebsiteStack()
+        {
+            return System.Environment.GetEnvironmentVariable(StackEnvVarName);
+        }
+
+        public static string GetLibsDirectoryAbsolutePath(IEnvironment environment)
+        {
+            return Path.Combine(environment.RootPath, LibsDirectoryRelativePath);
+        }
+
+        public static string GetScriptsDirectoryAbsolutePath(IEnvironment environment)
+        {
+            return Path.Combine(environment.RootPath, ScriptsDirectoryRelativePath);
+        }
+
+        public static string GetStartupFileName()
+        {
+            return OSDetector.IsOnWindows() ? "startup.cmd" : "startup.sh";
+        }
+
+        public static void SetTargetSubDirectoyAndFileNameFromPath(DeploymentInfoBase deploymentInfo, string relativeFilePath)
+        {
+            // Extract directory path and file name from relativeFilePath
+            // Example: path=a/b/c.jar => TargetDirectoryName=a/b and TargetFileName=c.jar
+            // Example: path=c.jar => TargetDirectoryName=null and TargetFileName=c.jar
+            // Example: path=/c.jar => TargetDirectoryName="" and TargetFileName=c.jar
+            // Example: path=null => TargetDirectoryName=null and TargetFileName=null
+            deploymentInfo.TargetFileName = Path.GetFileName(relativeFilePath);
+            deploymentInfo.TargetSubDirectoryRelativePath = Path.GetDirectoryName(relativeFilePath);
+        }
+    }
+}

--- a/Kudu.Services/Kudu.Services.csproj
+++ b/Kudu.Services/Kudu.Services.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Commands\CommandsNativeMethods.cs" />
     <Compile Include="Commands\PersistentCommandController.cs" />
     <Compile Include="Deployment\DeploymentController.cs" />
+    <Compile Include="Deployment\OneDeployHelper.cs" />
     <Compile Include="Deployment\PushDeploymentController.cs" />
     <Compile Include="Diagnostics\HttpRequestExtensions.cs" />
     <Compile Include="Diagnostics\LinuxProcessController.cs" />

--- a/Kudu.TestHarness/KuduUtils.cs
+++ b/Kudu.TestHarness/KuduUtils.cs
@@ -94,6 +94,22 @@ namespace Kudu.TestHarness
                 return GetBooleanTestSetting("StopAfterFirstTestFailure");
             }
         }
+        
+        public static string CustomKuduUrl
+        {
+            get
+            {
+                return GetTestSetting("CustomKuduUrl");
+            }
+        }
+
+        public static bool RunningAgainstLinuxKudu
+        {
+            get
+            {
+                return GetBooleanTestSetting("RunningAgainstLinuxKudu");
+            }
+        }
 
         public static bool DisableRetry
         {

--- a/Kudu.TestHarness/SitePool.cs
+++ b/Kudu.TestHarness/SitePool.cs
@@ -65,23 +65,33 @@ namespace Kudu.TestHarness
             if (site != null)
             {
                 TestTracer.Trace("{0} Site already exists at {1}. Reusing site", operationName, site.SiteUrl);
+
+                RunAgainstCustomKuduUrlIfRequired(site);
+
                 var appManager = new ApplicationManager(siteManager, site, applicationName)
                 {
                     SitePoolIndex = siteIndex
                 };
 
-                // In site reuse mode, clean out the existing site so we start clean
-                // Enumrate all w3wp processes and make sure to kill any process with an open handle to klr.host.dll
-                foreach (var process in (await appManager.ProcessManager.GetProcessesAsync()).Where(p => p.Name.Equals("w3wp", StringComparison.OrdinalIgnoreCase)))
+                if (!KuduUtils.RunningAgainstLinuxKudu)
                 {
-                    var extendedProcess = await appManager.ProcessManager.GetProcessAsync(process.Id);
-                    if (extendedProcess.OpenFileHandles.Any(h => h.IndexOf("dnx.host.dll", StringComparison.OrdinalIgnoreCase) != -1))
+                    // In site reuse mode, clean out the existing site so we start clean
+                    // Enumrate all w3wp processes and make sure to kill any process with an open handle to klr.host.dll
+                    foreach (var process in (await appManager.ProcessManager.GetProcessesAsync()).Where(p => p.Name.Equals("w3wp", StringComparison.OrdinalIgnoreCase)))
                     {
-                        await appManager.ProcessManager.KillProcessAsync(extendedProcess.Id, throwOnError:false);
+                        var extendedProcess = await appManager.ProcessManager.GetProcessAsync(process.Id);
+                        if (extendedProcess.OpenFileHandles.Any(h => h.IndexOf("dnx.host.dll", StringComparison.OrdinalIgnoreCase) != -1))
+                        {
+                            await appManager.ProcessManager.KillProcessAsync(extendedProcess.Id, throwOnError: false);
+                        }
                     }
                 }
 
                 await appManager.RepositoryManager.Delete(deleteWebRoot: true, ignoreErrors: true);
+
+                // Nuke directories of interest to start the tests with a clean slate
+                appManager.VfsManager.Delete("site/libs", recursive: true);
+                appManager.VfsManager.Delete("site/scripts", recursive: true);
 
                 // Make sure we start with the correct default file as some tests expect it
                 WriteIndexHtml(appManager);
@@ -115,6 +125,8 @@ namespace Kudu.TestHarness
                     }
 
                     site = siteManager.CreateSiteAsync(applicationName).Result;
+
+                    RunAgainstCustomKuduUrlIfRequired(site);
                 }
 
                 TestTracer.Trace("{0} Created new site at {1}", operationName, site.SiteUrl);
@@ -125,6 +137,13 @@ namespace Kudu.TestHarness
             }
         }
 
+        private static void RunAgainstCustomKuduUrlIfRequired(Site site)
+        {
+            if (!string.IsNullOrWhiteSpace(KuduUtils.CustomKuduUrl))
+            {
+                site.ServiceUrls = new List<string> { KuduUtils.CustomKuduUrl };
+            }
+        }
 
         private static ISiteManager GetSiteManager(IKuduContext context)
         {


### PR DESCRIPTION
- Makes changes to a few query parameters (clean, path, ignorestack, etc)
- Adds more OneDeploy tests
- App.config adds two new settings to be able to test against a custom Kudu URL and / or Linux Kudu
- No behavior change to scenarios other than OneDeploy