### PR TITLE
Update ProfileManager.cs

### DIFF
--- a/Kudu.Services/Diagnostics/ProfileManager.cs
+++ b/Kudu.Services/Diagnostics/ProfileManager.cs
@@ -139,7 +139,7 @@ namespace Kudu.Services.Performance
             {
                 if (Int32.TryParse(iisProfilingTimeoutInSeconds, out timeout))
                 {
-                    if (timeout < _profilingTimeout.TotalSeconds)
+                    if (timeout <= _profilingTimeout.TotalSeconds)
                     {
                         iisProfilingTimeout = TimeSpan.FromSeconds(timeout);
                     }


### PR DESCRIPTION
Allow iisProfilingTimeout to be set to max 15 minute when elected in app settings.

ref: https://docs.microsoft.com/en-us/answers/questions/85959/index.html, https://azure.github.io/AppService/2018/06/06/App-Service-Diagnostics-Profiling-an-ASP.NET-Web-App-on-Azure-App-Service.html#:~:text=It%20is%20possible%20to%20increase%20the%20default%20profiling%20duration%20by,to%20the%2060%20second%20value