### PR TITLE
Hiding KeyVault secrets on Environment page

### DIFF
--- a/Kudu.Core/Helpers/KeyVaultReferenceHelper.cs
+++ b/Kudu.Core/Helpers/KeyVaultReferenceHelper.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Kudu.Core.Helpers
+{
+    public static class KeyVaultReferenceHelper
+    {
+        private const string AppSettingPrefix = "APPSETTING_";
+        private const string KeyVaultReferenceInfoEnvVar = "WEBSITE_KEYVAULT_REFERENCES";
+
+        /// Example dictionary:
+        ///     {
+        ///         "secret1":
+        ///             {
+        ///                 { "rawReference", "@Microsoft.KeyVault(SecretUri=)" },
+        ///                 { "status", "ValueNotFound" }
+        ///             }
+        ///     }
+        /// </summary>
+        private static Dictionary<string, Dictionary<string, string>> KeyVaultReferencesInformation = GetKeyVaultReferencesInformation();
+
+        public static int NumKeyVaultReferences
+        {
+            get
+            {
+                return KeyVaultReferencesInformation.Count();
+            }
+        }
+
+        /// <summary>
+        /// Simple filter to hide secrets from KeyVault references.
+        /// </summary>
+        /// <param name="environmentVariables">All variables for the site</param>
+        /// <param name="hideKeyVaultSecrets">Whether to hide KeyVault secrets</param>
+        /// <returns>Filtered environment variables</returns>
+        public static IDictionary<object, object> KeyVaultReferencesFilter(IDictionary variables, bool hideKeyVaultSecrets)
+        {
+            IDictionary<object, object> filteredEnvironmentVariables = new Dictionary<object, object>();
+            foreach (var entry in variables.Keys)
+            {
+                filteredEnvironmentVariables.Add(entry, HideKeyVaultSecret(entry, variables[entry], hideKeyVaultSecrets));
+            }
+            return filteredEnvironmentVariables;
+        }
+
+        /// <summary>
+        /// Deserializes KeyVault References information in the form of a Dictionary<string, Dictionary<string, string>>
+        /// </summary>
+        /// <param name="serializedInformationBlob">Serialized dictionary containing KeyVault reference information</param>
+        public static Dictionary<string, Dictionary<string, string>> GetKeyVaultReferencesInformation()
+        {
+            try
+            {
+                var serializedInformationBlob = System.Environment.GetEnvironmentVariable(KeyVaultReferenceInfoEnvVar);
+                if (serializedInformationBlob != null)
+                {
+                    var result = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(serializedInformationBlob);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            return new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Hides a KeyVault secret if enabled, or just returns the original value if disabled
+        /// </summary>
+        /// <param name="key">Environment variable key</param>
+        /// <param name="value">Environment variable original value</param>
+        /// <param name="hideValue">Whether to hide</param>
+        /// <returns>Hidden value (or original)</returns>
+        public static object HideKeyVaultSecret(object key, object value, bool hideValue)
+        {
+            var keyString = (string) key;
+            if (hideValue && KeyVaultReferencesInformation.ContainsKey(keyString))
+            {
+                try
+                {
+                    return "[Hidden - " + KeyVaultReferencesInformation[keyString]["status"] + ": " + KeyVaultReferencesInformation[keyString]["rawReference"] + "]";
+                }
+                catch (Exception)
+                {
+                    return "[Hidden KeyVault secret]";
+                }
+            }
+
+            return value;
+        }
+    }
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Functions\FunctionManager.cs" />
     <Compile Include="Helpers\EnvironmentHelper.cs" />
     <Compile Include="Helpers\DeploymentCompletedInfo.cs" />
+    <Compile Include="Helpers\KeyVaultReferenceHelper.cs" />
     <Compile Include="Helpers\OSDetector.cs" />
     <Compile Include="Helpers\PermissionHelper.cs" />
     <Compile Include="Helpers\PostDeploymentHelper.cs" />

--- a/Kudu.Services.Web/Env.cshtml
+++ b/Kudu.Services.Web/Env.cshtml
@@ -9,6 +9,17 @@
 
 <div class="container">
     <h3>Index</h3>
+    @{ 
+        bool isHidden = String.IsNullOrEmpty(Request.Params["hideSecrets"]) || ("true").Equals(Request.Params["hideSecrets"]); // Hide by default
+    }
+    @if (Kudu.Core.Helpers.KeyVaultReferenceHelper.NumKeyVaultReferences > 0)
+    {
+        <div class="checkbox span5">
+            <label class="checkbox" style="padding:0px">
+                @Html.CheckBox("hideKeyVaultSecrets", isHidden, new { id = "hideKeyVaultSecrets", style = "padding:0px", onchange = "keyVaultCheckbox()" }) Hide Values of KeyVault References
+            </label>
+        </div>
+    }
     <ul>
         <li><a href="#sysInfo">System Info</a></li>
         <li><a href="#appSettings">App Settings</a></li>
@@ -48,12 +59,28 @@
     </ul>
 
     <h3 id="appSettings">AppSettings</h3>
+    @{
+        var appSettingsInEnvironment = Kudu.Core.Infrastructure.SettingsProcessor.Instance.AppSettings;
+        var appSettingVariablesDict = Kudu.Core.Helpers.KeyVaultReferenceHelper.KeyVaultReferencesFilter(appSettingsInEnvironment, isHidden);
+    }
     <ul class="fixed-width">
         @foreach (string name in ConfigurationManager.AppSettings)
          {
             <li>
                 @name = @ConfigurationManager.AppSettings[name]
             </li>
+         }
+
+
+        @foreach (KeyValuePair<object, object> kv in appSettingVariablesDict)
+         {
+
+            if (kv.Value != null)
+            {
+                <li>@kv.Key = @kv.Value</li>
+
+            }
+
          }
     </ul>
 
@@ -72,8 +99,12 @@
     </ul>
 
     <h3 id="envVariables">Environment variables</h3>
+    @{
+        IDictionary environmentVariables = Environment.GetEnvironmentVariables();
+        var environmentVariablesDict = Kudu.Core.Helpers.KeyVaultReferenceHelper.KeyVaultReferencesFilter(environmentVariables, isHidden);
+    }
     <ul class="fixed-width">
-        @foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables().OfType<DictionaryEntry>().OrderBy(e => e.Key))
+        @foreach (KeyValuePair<object, object> entry in environmentVariablesDict.OfType<KeyValuePair<object, object>>().OrderBy(e => e.Key))
          {
             <li>@entry.Key = @entry.Value</li>
          }
@@ -103,3 +134,23 @@
          }
     </ul>
 </div>
+
+<script type="text/javascript">
+    // Flip whether to hide KeyVault secrets based on current request; Reload page with new parameter
+    function keyVaultCheckbox() {
+        var isHidden = '@isHidden' == 'True';
+        var flipHidden = (!isHidden).toString();
+        var paramName = "hideSecrets";
+
+        // Replace hideSecrets param in URL
+        var str = location.search;
+        if (new RegExp("[&?]" + paramName + "([=&].+)?$").test(str)) {
+            str = str.replace(new RegExp("(?:[&?])" + paramName + "[^&]*", "g"), "")
+        }
+        str += "&";
+        str += paramName + "=" + flipHidden;
+        str = "?" + str.slice(1);
+
+        location.assign(location.origin + location.pathname + str + location.hash);
+    }
+</script>

--- a/Kudu.Services.Web/ProcessExplorer/Default.cshtml
+++ b/Kudu.Services.Web/ProcessExplorer/Default.cshtml
@@ -10,6 +10,14 @@
     <link rel="stylesheet" href="~/content/Styles/jquery-ui-1.10.0.custom.css" type="text/css" />
     <link href="/Content/Styles/font-awesome.css" rel="stylesheet" />
 }
+<script>
+    @{
+        bool isHidden = String.IsNullOrEmpty(Request.Params["hideSecrets"]) || ("true").Equals(Request.Params["hideSecrets"]); // Hide by default
+    }
+    // Whether secrets are hidden. Used when processing environment variables in ProcessExplorer.js
+    var secretsHidden = '@isHidden' == 'True';
+</script>
+
 <div id="main" class="container">
     <div id="generalModal" title="Basic dialog">
         <p class="content">This is the default dialog which is useful for displaying information. The dialog window can be moved, resized and closed with the 'x' icon.</p>


### PR DESCRIPTION
- Key Vault secrets are now hidden by default on the Environments page and Process Explorer 'Environment Variables' tab. 
- An optional URI query parameter on the Environment and Process Explorer toggles hiding key vault secrets (hideSecrets=true or hideSecrets=false)
  - e.g. scm.net/Env?hideSecrets=false

[KuduLite PR](https://github.com/Azure-App-Service/KuduLite/pull/155)

Examples:
![image](https://user-images.githubusercontent.com/23196850/99716797-6634e600-2a5d-11eb-8b42-30c021de074a.png)
![image](https://user-images.githubusercontent.com/23196850/99717007-a5fbcd80-2a5d-11eb-99d8-b52b9e30f76c.png)
