### PR TITLE
Set the dump type (full) when requesting a memory dump from the properties tab

### DIFF
--- a/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
+++ b/Kudu.Services.Web/Content/Scripts/ProcessExplorer.js
@@ -515,8 +515,8 @@ var Process = (function () {
             });
         }));
 
-        buttonDiv.appendChild(Utilities.getButton("ui-button-info", div.id + "-dumb", "Download memory dump", function () {
-            Utilities.downloadURL(_this._json.minidump);
+        buttonDiv.appendChild(Utilities.getButton("ui-button-info", div.id + "-dump", "Download memory dump", function () {
+            Utilities.downloadURL(_this._json.minidump + "?dumpType=2");
         }));
 
         div.appendChild(buttonDiv);


### PR DESCRIPTION
The "Download memory dump" button in the process properties tab doesn't currently set the dump type, which means ```Kudu.Services.Performance.MiniDump()``` will default to 0 (```MiniDumpNormal```). This does not match with the behavior from the process context menu and the produced memory dump can't be properly opened by debuggers.
The pull request sets the type to 2 (```MiniDumpWithFullMemory```).

