### PR TITLE
Fix synctriggers for functions

### DIFF
--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -87,6 +87,8 @@ namespace Kudu
 
         public const string RestartApiPath = "/api/app/restart";
         public const string UpdateDeployStatusPath = "/api/app/updatedeploystatus";
+        public const string SetTriggersApiPath = "/operations/settriggers";
+        public const string FunctionsSyncTriggersApiPath = "/admin/host/synctriggers";
 
         public const string SiteExtensionProvisioningStateCreated = "Created";
         public const string SiteExtensionProvisioningStateAccepted = "Accepted";

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -284,6 +284,13 @@ namespace Kudu.Core.Deployment
                         await PostDeploymentHelper.UpdateSiteVersion(zipDeploymentInfo, _environment, tracer);
                     }
                 }
+
+                if (statusFile.Status == DeployStatus.Success
+                    && ScmHostingConfigurations.FunctionsSyncTriggersDelaySeconds > 0)
+                {
+                    await PostDeploymentHelper.SyncTriggersIfFunctionsSite(_environment.RequestId, new PostDeploymentTraceListener(tracer),
+                        deploymentInfo?.SyncFunctionsTriggersPath, tracePath: _environment.TracePath);
+                }
             }
         }
 
@@ -770,7 +777,11 @@ namespace Kudu.Core.Deployment
 
                         await RestartMainSiteIfNeeded(tracer, logger, deploymentInfo);
 
-                        await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, new PostDeploymentTraceListener(tracer, logger), deploymentInfo?.SyncFunctionsTriggersPath);
+                        if (ScmHostingConfigurations.FunctionsSyncTriggersDelaySeconds == 0)
+                        {
+                            await PostDeploymentHelper.SyncTriggersIfFunctionsSite(_environment.RequestId, new PostDeploymentTraceListener(tracer, logger),
+                                deploymentInfo?.SyncFunctionsTriggersPath, tracePath: _environment.TracePath);
+                        }
 
                         TouchWatchedFileIfNeeded(_settings, deploymentInfo, context);
 

--- a/Kudu.Core/Functions/FunctionManager.cs
+++ b/Kudu.Core/Functions/FunctionManager.cs
@@ -33,7 +33,7 @@ namespace Kudu.Core.Functions
             tracer = tracer ?? _traceFactory.GetTracer();
             using (tracer.Step("FunctionManager.SyncTriggers"))
             {
-                await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, new PostDeploymentTraceListener(tracer));
+                await PostDeploymentHelper.SyncTriggersIfFunctionsSite(_environment.RequestId, new PostDeploymentTraceListener(tracer), tracePath: _environment.TracePath);
             }
         }
 

--- a/Kudu.Core/Infrastructure/DeploymentLockFile.cs
+++ b/Kudu.Core/Infrastructure/DeploymentLockFile.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Abstractions;
 using Kudu.Contracts.SourceControl;
 using Kudu.Core.Helpers;
+using Kudu.Core.Settings;
 using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 
@@ -14,6 +15,8 @@ namespace Kudu.Core.Infrastructure
     public class DeploymentLockFile : LockFile
     {
         private string siteRoot = "";
+        private bool shutdownDelayed = false;
+        private readonly ITraceFactory _traceFactory;
 
         public DeploymentLockFile(string path, ITraceFactory traceFactory)
             : base(path, traceFactory)
@@ -24,6 +27,8 @@ namespace Kudu.Core.Infrastructure
                     siteRoot = PathUtilityFactory.Instance.ResolveLocalSitePath();
                 }
             });
+
+            _traceFactory = traceFactory;
         }
 
         // This is set when IRepositoryFactory is created in Ninject.
@@ -35,27 +40,33 @@ namespace Kudu.Core.Infrastructure
 
         protected override void OnLockAcquired()
         {
-
-            OperationManager.SafeExecute(() => {
-                // Create Sentinel file for DWAS to check
-                // DWAS will check for presence of this file incase a an app setting based recycle needs to be performed in middle of deployment
-                // If this is present, DWAS will postpone the recycle so that deployment goes through first
-                if (!String.IsNullOrEmpty(siteRoot))
-                {
-                    FileSystemHelpers.CreateDirectory(Path.Combine(siteRoot, @"ShutdownSentinel"));
-                    string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
-
-                    if (!FileSystemHelpers.FileExists(sentinelPath))
+            if (ScmHostingConfigurations.FunctionsSyncTriggersDelayBackground)
+            {
+                shutdownDelayed = ShutdownDelaySemaphore.GetInstance().Acquire(_traceFactory.GetTracer());
+            }
+            else
+            {
+                OperationManager.SafeExecute(() => {
+                    // Create Sentinel file for DWAS to check
+                    // DWAS will check for presence of this file incase a an app setting based recycle needs to be performed in middle of deployment
+                    // If this is present, DWAS will postpone the recycle so that deployment goes through first
+                    if (!String.IsNullOrEmpty(siteRoot))
                     {
-                        var file = FileSystemHelpers.CreateFile(sentinelPath);
-                        file.Close();
-                    }
+                        FileSystemHelpers.CreateDirectory(Path.Combine(siteRoot, @"ShutdownSentinel"));
+                        string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
 
-                    // DWAS checks if write time of this file is in the future then only postpones the recycle
-                    FileInfoBase sentinelFileInfo = FileSystemHelpers.FileInfoFromFileName(sentinelPath);
-                    sentinelFileInfo.LastWriteTimeUtc = DateTime.UtcNow.AddMinutes(20);
-                }
-            });
+                        if (!FileSystemHelpers.FileExists(sentinelPath))
+                        {
+                            var file = FileSystemHelpers.CreateFile(sentinelPath);
+                            file.Close();
+                        }
+
+                        // DWAS checks if write time of this file is in the future then only postpones the recycle
+                        FileInfoBase sentinelFileInfo = FileSystemHelpers.FileInfoFromFileName(sentinelPath);
+                        sentinelFileInfo.LastWriteTimeUtc = DateTime.UtcNow.AddMinutes(20);
+                    }
+                });
+            }
 
             IRepositoryFactory repositoryFactory = RepositoryFactory;
             if (repositoryFactory != null)
@@ -73,18 +84,25 @@ namespace Kudu.Core.Infrastructure
         {
             base.OnLockRelease();
 
-            OperationManager.SafeExecute(() => {
-                // Delete the Sentinel file to signal DWAS that deployment is complete
-                if (!String.IsNullOrEmpty(siteRoot))
-                {
-                    string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
-
-                    if (FileSystemHelpers.FileExists(sentinelPath))
+            if (ScmHostingConfigurations.FunctionsSyncTriggersDelayBackground && shutdownDelayed)
+            {
+                ShutdownDelaySemaphore.GetInstance().Release(_traceFactory.GetTracer());
+            }
+            else
+            {
+                OperationManager.SafeExecute(() => {
+                    // Delete the Sentinel file to signal DWAS that deployment is complete
+                    if (!String.IsNullOrEmpty(siteRoot))
                     {
-                        FileSystemHelpers.DeleteFile(sentinelPath);
+                        string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
+
+                        if (FileSystemHelpers.FileExists(sentinelPath))
+                        {
+                            FileSystemHelpers.DeleteFile(sentinelPath);
+                        }
                     }
-                }
-            });
+                });
+            }
         }
     }
 }

--- a/Kudu.Core/Infrastructure/ShutdownDelaySemaphore.cs
+++ b/Kudu.Core/Infrastructure/ShutdownDelaySemaphore.cs
@@ -1,0 +1,135 @@
+﻿using Kudu.Contracts.Tracing;
+using Kudu.Core.Helpers;
+using Kudu.Core.Tracing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Threading;
+
+namespace Kudu.Core.Infrastructure
+{
+    internal class ShutdownDelaySemaphore
+    {
+        private const int InitialAndMaxCount = 8;
+
+        private static ShutdownDelaySemaphore _instance;
+
+        private readonly SemaphoreSlim _shutdownSemaphore = new SemaphoreSlim(InitialAndMaxCount, InitialAndMaxCount);
+        private readonly object _lock = new object();
+
+        private ShutdownDelaySemaphore() { }
+
+        public static ShutdownDelaySemaphore GetInstance()
+        {
+            if (_instance == null)
+            {
+                _instance = new ShutdownDelaySemaphore();
+            }
+
+            return _instance;
+        }
+
+        public bool Acquire(ITracer tracer)
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    // No timeout makes this call instant. No waiting for acquistion
+                    bool acquired = _shutdownSemaphore.Wait(millisecondsTimeout: 0);
+
+                    if (!acquired)
+                    {
+                        tracer.Trace("Could not acquire shutdown semaphore", new Dictionary<string, string>
+                        {
+                            { "SemaphoreCount", _shutdownSemaphore.CurrentCount.ToString() }
+                        });
+
+                        return false;
+                    }
+
+                    tracer.Trace("Acquired shutdown semaphore", new Dictionary<string, string>
+                    {
+                        { "SemaphoreCount", _shutdownSemaphore.CurrentCount.ToString() }
+                    });
+
+                    OperationManager.SafeExecute(() => {
+                        if (Environment.IsAzureEnvironment() && OSDetector.IsOnWindows())
+                        {
+                            string siteRoot = PathUtilityFactory.Instance.ResolveLocalSitePath();
+
+                            // Create Sentinel file for DWAS to check
+                            // DWAS will check for presence of this file incase a an app setting based recycle needs to be performed in middle of deployment
+                            // If this is present, DWAS will postpone the recycle so that deployment goes through first
+                            if (!string.IsNullOrEmpty(siteRoot))
+                            {
+                                FileSystemHelpers.CreateDirectory(Path.Combine(siteRoot, @"ShutdownSentinel"));
+                                string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
+
+                                if (!FileSystemHelpers.FileExists(sentinelPath))
+                                {
+                                    tracer.Trace("Creating shutdown sentinel file", new Dictionary<string, string>
+                                    {
+                                        { "SemaphoreCount", _shutdownSemaphore.CurrentCount.ToString() }
+                                    });
+                                    var file = FileSystemHelpers.CreateFile(sentinelPath);
+                                    file.Close();
+                                }
+
+                                tracer.Trace("Updating shutdown sentinel last write time", new Dictionary<string, string>
+                                {
+                                    { "SemaphoreCount", _shutdownSemaphore.CurrentCount.ToString() }
+                                });
+                                // DWAS checks if write time of this file is in the future then only postpones the recycle
+                                FileInfoBase sentinelFileInfo = FileSystemHelpers.FileInfoFromFileName(sentinelPath);
+                                sentinelFileInfo.LastWriteTimeUtc = DateTime.UtcNow.AddMinutes(20);
+                            }
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    tracer.TraceError(ex);
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        public void Release(ITracer tracer)
+        {
+            lock (_lock)
+            {
+                _shutdownSemaphore.Release();
+                tracer.Trace("Released shut down semaphore", new Dictionary<string, string>
+                {
+                    { "SemaphoreCount", _shutdownSemaphore.CurrentCount.ToString() }
+                });
+
+                if (_shutdownSemaphore.CurrentCount == InitialAndMaxCount)
+                {
+                    OperationManager.SafeExecute(() => {
+                        string siteRoot = PathUtilityFactory.Instance.ResolveLocalSitePath();
+
+                        // Delete the Sentinel file to signal DWAS that deployment is complete
+                        if (!string.IsNullOrEmpty(siteRoot))
+                        {
+                            string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
+
+                            if (FileSystemHelpers.FileExists(sentinelPath))
+                            {
+                                tracer.Trace("Deleting shutdown sentinel file", new Dictionary<string, string>
+                                {
+                                    { "SemaphoreCount", _shutdownSemaphore.CurrentCount.ToString() }
+                                });
+                                FileSystemHelpers.DeleteFile(sentinelPath);
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -281,6 +281,7 @@
     <Compile Include="Infrastructure\PathUtils\PathWindowsUtility.cs" />
     <Compile Include="Infrastructure\ServerConfiguration.cs" />
     <Compile Include="Infrastructure\SettingsProcessor.cs" />
+    <Compile Include="Infrastructure\ShutdownDelaySemaphore.cs" />
     <Compile Include="Infrastructure\ZipArchiveExtensions.cs" />
     <Compile Include="Jobs\AggregateContinuousJobsManager.cs" />
     <Compile Include="Jobs\AggregateJobsManagerBase.cs" />

--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -64,6 +64,33 @@ namespace Kudu.Core.Settings
             get { return GetValue("GetLatestDeploymentOptimized", "1") != "0"; }
         }
 
+        // default = 0, meaning same behavior as today
+        // 60, meaning 60s delay + only call after sitepackage update + empty trigger
+        public static int FunctionsSyncTriggersDelaySeconds
+        {
+            get
+            {
+                if (int.TryParse(GetValue("FunctionsSyncTriggersDelaySeconds"), out int secs)
+                    && secs >= 0)
+                {
+                    return secs;
+                }
+
+                return 0;
+            }
+        }
+
+        // If FunctionsSyncTriggersDelaySeconds = 0, this is a no-op
+        // default = 0, blocking for FunctionsSyncTriggersDelaySeconds
+        // 1, in the background
+        public static bool FunctionsSyncTriggersDelayBackground
+        {
+            get
+            {
+                return GetValue("FunctionsSyncTriggersDelayBackground", "0") == "1" && FunctionsSyncTriggersDelaySeconds > 0;
+            }
+        }
+
         public static bool DeploymentStatusCompleteFileEnabled
         {
             get { return GetValue("DeploymentStatusCompleteFileEnabled", "1") != "0"; }

--- a/Kudu.Services/Functions/FunctionController.cs
+++ b/Kudu.Services/Functions/FunctionController.cs
@@ -188,7 +188,7 @@ namespace Kudu.Services.Functions
             var tracer = _traceFactory.GetTracer();
             using (tracer.Step("FunctionController.SyncTriggers"))
             {
-                await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, new PostDeploymentTraceListener(tracer));
+                await PostDeploymentHelper.SyncTriggersIfFunctionsSite(_environment.RequestId, new PostDeploymentTraceListener(tracer), tracePath: _environment.TracePath);
 
                 // Return a dummy body to make it valid in ARM template action evaluation
                 return Request.CreateResponse(HttpStatusCode.OK, new { status = "success" });
@@ -262,7 +262,7 @@ namespace Kudu.Services.Functions
                 {
                     try
                     {
-                        await PostDeploymentHelper.SyncFunctionsTriggers(_environment.RequestId, new PostDeploymentTraceListener(bgTracer));
+                        await PostDeploymentHelper.SyncTriggersIfFunctionsSite(_environment.RequestId, new PostDeploymentTraceListener(bgTracer), tracePath: _environment.TracePath);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
This commit added code to make sure that synctriggers is always called
after a function app has finished deploying. Additionally, this change
also adds an empty settriggers call that is required by the front end to
notify the zip cache that changes were made.

Fixes https://github.com/projectkudu/kudu/issues/3238