### PR TITLE
Add sentinel file to delay kudu process recycle on app setting change

### DIFF
--- a/Kudu.Core.Test/LockFileTests.cs
+++ b/Kudu.Core.Test/LockFileTests.cs
@@ -115,6 +115,53 @@ namespace Kudu.Core.Test
             repository.Verify(r => r.ClearLock(), Times.Once);
         }
 
+        [Fact]
+        public void DeploymentLockSentinelTest()
+        {
+            // Mock
+            System.Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", "Instance1");
+            var path = @"x:\temp1";
+            var pathSentinel = "C:\\local\\ShutdownSentinel\\Sentinel.txt";
+            var lockFileName = Path.Combine(path, "deployment1.lock");
+            var fileSystem = new Mock<IFileSystem>();
+            var file = new Mock<FileBase>();
+            var fileInfoBase = new Mock<IFileInfoFactory>();
+            var directory = new Mock<DirectoryBase>();
+            var repository = new Mock<IRepository>();
+            var repositoryFactory = new Mock<IRepositoryFactory>();
+            var lockFile = new DeploymentLockFile(lockFileName, Mock.Of<ITraceFactory>(f => f.GetTracer() == Mock.Of<ITracer>()));
+
+            // Setup
+            fileSystem.SetupGet(f => f.Directory)
+                      .Returns(directory.Object);
+            directory.Setup(d => d.Exists(path))
+                     .Returns(true);
+            fileSystem.SetupGet(f => f.File)
+                      .Returns(file.Object);
+            file.Setup(f => f.Open(lockFileName, FileMode.Create, FileAccess.Write, FileShare.Read))
+                .Returns(Mock.Of<Stream>());
+            file.Setup(f => f.Create(pathSentinel)).Returns(Mock.Of<Stream>());
+            fileInfoBase.Setup(f => f.FromFileName(pathSentinel)).Returns(Mock.Of<FileInfoBase>());
+            fileSystem.SetupGet(f => f.FileInfo).Returns(fileInfoBase.Object);
+
+            repositoryFactory.Setup(f => f.GetRepository())
+                             .Returns(repository.Object);
+            FileSystemHelpers.Instance = fileSystem.Object;
+            lockFile.RepositoryFactory = repositoryFactory.Object;
+
+            // Test
+            var locked = lockFile.Lock("operationName");
+            file.Setup(f => f.Exists(pathSentinel)).Returns(true);
+
+            Assert.True(locked, "lock should be successful!");
+            Assert.True(FileSystemHelpers.FileExists(pathSentinel), "Sentinel file should be present");
+
+            repository.Verify(r => r.ClearLock(), Times.Once);
+
+            // Reset IsAzureEnvironment env variable
+            System.Environment.SetEnvironmentVariable("WEBSITE_INSTANCE_ID", null);
+        }
+
         private LockFile MockLockFile(string path, ITraceFactory traceFactory = null, IFileSystem fileSystem = null)
         {
             traceFactory = traceFactory ?? NullTracerFactory.Instance;

--- a/Kudu.Core/Infrastructure/DeploymentLockFile.cs
+++ b/Kudu.Core/Infrastructure/DeploymentLockFile.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.IO.Abstractions;
 using Kudu.Contracts.SourceControl;
+using Kudu.Core.Helpers;
 using Kudu.Core.SourceControl;
 using Kudu.Core.Tracing;
 
@@ -11,9 +13,17 @@ namespace Kudu.Core.Infrastructure
     /// </summary>
     public class DeploymentLockFile : LockFile
     {
+        private string siteRoot = "";
+
         public DeploymentLockFile(string path, ITraceFactory traceFactory)
             : base(path, traceFactory)
         {
+            OperationManager.SafeExecute(() => {
+                if (Environment.IsAzureEnvironment() && OSDetector.IsOnWindows())
+                {
+                    siteRoot = PathUtilityFactory.Instance.ResolveLocalSitePath();
+                }
+            });
         }
 
         // This is set when IRepositoryFactory is created in Ninject.
@@ -25,6 +35,28 @@ namespace Kudu.Core.Infrastructure
 
         protected override void OnLockAcquired()
         {
+
+            OperationManager.SafeExecute(() => {
+                // Create Sentinel file for DWAS to check
+                // DWAS will check for presence of this file incase a an app setting based recycle needs to be performed in middle of deployment
+                // If this is present, DWAS will postpone the recycle so that deployment goes through first
+                if (!String.IsNullOrEmpty(siteRoot))
+                {
+                    FileSystemHelpers.CreateDirectory(Path.Combine(siteRoot, @"ShutdownSentinel"));
+                    string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
+
+                    if (!FileSystemHelpers.FileExists(sentinelPath))
+                    {
+                        var file = FileSystemHelpers.CreateFile(sentinelPath);
+                        file.Close();
+                    }
+
+                    // DWAS checks if write time of this file is in the future then only postpones the recycle
+                    FileInfoBase sentinelFileInfo = FileSystemHelpers.FileInfoFromFileName(sentinelPath);
+                    sentinelFileInfo.LastWriteTimeUtc = DateTime.UtcNow.AddMinutes(20);
+                }
+            });
+
             IRepositoryFactory repositoryFactory = RepositoryFactory;
             if (repositoryFactory != null)
             {
@@ -35,6 +67,24 @@ namespace Kudu.Core.Infrastructure
                     repository.ClearLock();
                 }
             }
+        }
+
+        protected override void OnLockRelease()
+        {
+            base.OnLockRelease();
+
+            OperationManager.SafeExecute(() => {
+                // Delete the Sentinel file to signal DWAS that deployment is complete
+                if (!String.IsNullOrEmpty(siteRoot))
+                {
+                    string sentinelPath = Path.Combine(siteRoot, @"ShutdownSentinel\Sentinel.txt");
+
+                    if (FileSystemHelpers.FileExists(sentinelPath))
+                    {
+                        FileSystemHelpers.DeleteFile(sentinelPath);
+                    }
+                }
+            });
         }
     }
 }

--- a/Kudu.Core/Infrastructure/PathUtils/PathLinuxUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathLinuxUtility.cs
@@ -70,5 +70,10 @@ namespace Kudu.Core.Infrastructure
             }
             return path;
         }
+
+        internal override string ResolveLocalSitePath()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Kudu.Core/Infrastructure/PathUtils/PathUtilityBase.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathUtilityBase.cs
@@ -57,6 +57,10 @@ namespace Kudu.Core.Infrastructure
 
         internal abstract string ResolveMSBuildPath();
 
+        // This corresponds to the directory which contains the VirtualDirectory0
+        // Eg. D:\DWASFiles\Sites\<SiteName>
+        internal abstract string ResolveLocalSitePath();
+
         internal virtual string ResolveMSBuild15Dir()
         {
             return null;

--- a/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
+++ b/Kudu.Core/Infrastructure/PathUtils/PathWindowsUtility.cs
@@ -73,6 +73,11 @@ namespace Kudu.Core.Infrastructure
             return Path.Combine(gitPath, "bin", "bash.exe");
         }
 
+        internal override string ResolveLocalSitePath()
+        {
+            return System.Environment.ExpandEnvironmentVariables("%SystemDrive%\\local");
+        }
+
         internal override string ResolveNpmJsPath()
         {
             string programFiles = SystemEnvironment.GetFolderPath(SystemEnvironment.SpecialFolder.ProgramFilesX86);


### PR DESCRIPTION
The sentinel file will be created when the deployment lock is acquired and deleted when it is released marking the start and end of deployment.