### PR TITLE
Adds streaming support for zipDeploy

### DIFF
--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -110,6 +110,12 @@ namespace Kudu.Core.Settings
             get { return GetValue("UseMSBuild167ForDotnet31", "0") == "1"; }
         }
 
+        public static bool UseHttpCompletionOptionResponseHeadersRead
+        {
+            // this is enabled by default
+            get { return GetValue("UseHttpCompletionOptionResponseHeadersRead", "1") != "0"; }
+        }
+
         public static IPAddress ILBVip
         {
             get { return IPAddress.TryParse(GetValue(SettingsKeys.ILBVip), out var address) ? address : null; }

--- a/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
+++ b/Kudu.FunctionalTests/Kudu.FunctionalTests.csproj
@@ -18,9 +18,18 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.4.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=5.10.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.5.10.3\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.17.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.17.2\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -49,10 +58,19 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Activation" />
     <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Kudu.FunctionalTests/packages.config
+++ b/Kudu.FunctionalTests/packages.config
@@ -1,13 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.4.1" targetFramework="net46" />
+  <package id="FluentAssertions" version="5.10.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.9.8" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.17.2" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="System.IO.Abstractions" version="1.4.0.74" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />

--- a/Kudu.Services/ByteRanges/HttpRequestMessageExtensions.cs
+++ b/Kudu.Services/ByteRanges/HttpRequestMessageExtensions.cs
@@ -41,10 +41,10 @@ namespace Kudu.Services.ByteRanges
             return rangeNotSatisfiableResponse;
         }
 
-        public static async Task<int> CopyToAsync(this HttpContent content, string filePath, ITracer tracer)
+        public static async Task<long> CopyToAsync(this HttpContent content, string filePath, ITracer tracer)
         {
             var nextTraceTime = DateTime.UtcNow.AddSeconds(30);
-            var total = 0;
+            long total = 0;
             var buffer = new byte[ScmHostingConfigurations.StreamCopyBufferSize];
             using (var src = await content.ReadAsStreamAsync())
             using (var dst = FileSystemHelpers.CreateFile(filePath))

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -571,7 +571,7 @@ namespace Kudu.Services.Deployment
                 // If this was a request with a Zip URL in the JSON, we first need to get the zip content and write it to the site.
                 if (!string.IsNullOrEmpty(zipDeploymentInfo.RemoteURL))
                 {
-                    await WriteSitePackageZip(zipDeploymentInfo, tracer, await DeploymentHelper.GetArtifactContentFromURL(zipDeploymentInfo, tracer));
+                    await WriteSitePackageZip(zipDeploymentInfo, tracer, await DeploymentHelper.GetArtifactContentFromURLAsync(zipDeploymentInfo, tracer));
                 }
                 // If this is a Run-From-Zip deployment, then we need to extract function.json
                 // from the zip file into path zipDeploymentInfo.SyncFunctionsTriggersPath
@@ -661,7 +661,7 @@ namespace Kudu.Services.Deployment
             {
                 using (tracer.Step("Saving request content to {0}", artifactFileStagingPath))
                 {
-                    var content = await DeploymentHelper.GetArtifactContentFromURL(artifactDeploymentInfo, tracer);
+                    var content = await DeploymentHelper.GetArtifactContentFromURLAsync(artifactDeploymentInfo, tracer);
                     var copyTask = content.CopyToAsync(artifactFileStagingPath, tracer);
 
                     // Deletes all files and directories except for artifactFileStagingPath and artifactDirectoryStagingPath
@@ -689,7 +689,7 @@ namespace Kudu.Services.Deployment
 
         private async Task<string> DeployZipLocally(ArtifactDeploymentInfo zipDeploymentInfo, ITracer tracer)
         {
-            var content = await DeploymentHelper.GetArtifactContentFromURL(zipDeploymentInfo, tracer);
+            var content = await DeploymentHelper.GetArtifactContentFromURLAsync(zipDeploymentInfo, tracer);
             var zipFileName = Path.ChangeExtension(Path.GetRandomFileName(), "zip");
             var zipFilePath = Path.Combine(_environment.ZipTempPath, zipFileName);
 

--- a/Kudu.Services/Zip/ZipController.cs
+++ b/Kudu.Services/Zip/ZipController.cs
@@ -99,7 +99,7 @@ namespace Kudu.Services.Zip
                     : Tracer.Step("Extracting content from {0} to {1}", StringUtils.ObfuscatePath(packageUri.AbsoluteUri), targetPath))
                 {
                     var content = packageUri == null ? Request.Content
-                        : await DeploymentHelper.GetArtifactContentFromURL(new ArtifactDeploymentInfo(null, null) { RemoteURL = packageUri.AbsoluteUri }, Tracer);
+                        : await DeploymentHelper.GetArtifactContentFromURLAsync(new ArtifactDeploymentInfo(null, null) { RemoteURL = packageUri.AbsoluteUri }, Tracer);
                     using (var stream = await content.ReadAsStreamAsync())
                     {
                         // The unzipping is done over the existing folder, without first removing existing files.


### PR DESCRIPTION
This PR fixes streaming for ZipDeploy by using `HttpCompletionOption.ResponseHeadersRead` on HttpClient's `GetAsync`.
from https://www.stevejgordon.co.uk/using-httpcompletionoption-responseheadersread-to-improve-httpclient-performance-dotnet.

> The main benefit is for performance. When using this option, we avoid the intermediate MemoryStream buffer, instead of getting the content directly from the stream exposed on the Socket. This avoids unnecessary allocations which is a goal in highly optimised situations.

This is what we are currently observing since we are not doing Streaming properly, we read the entire file when we do `EnsureSuccessStatusCode` and it reflects in the following ways:

| Size | Error |
|------|-------|
|Small      | No error.      |
|0.5 gb| Task Cancelled Error (HttpClient exceeded 100 sec timeout)|
|Less than max buffer size of 2147483647     | System.OutOfMemory Exception (Instance doesn't have enough memory)      |
|More than max buffer size of 2147483647           |     Cannot write more bytes to the buffer than the configured maximum buffer size: 2147483647  |

This PR fixes all three cases.
