### PR TITLE
Deploy static files to any directory under /home

### DIFF
--- a/Kudu.FunctionalTests/OneDeployTests.cs
+++ b/Kudu.FunctionalTests/OneDeployTests.cs
@@ -97,68 +97,6 @@ namespace Kudu.FunctionalTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public Task TestLibDeployment(bool isAsync)
-        {
-            return ApplicationManager.RunAsync("TestLibDeployment", async appManager =>
-            {
-                var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
-
-                // Default deployment - incremental
-                {
-                    await DeployNonZippedArtifact(appManager, "lib", "library1.jar", isAsync, null, "site/libs/library1.jar");
-                    await DeployNonZippedArtifact(appManager, "lib", "library2.jar", isAsync, null, "site/libs/library2.jar");
-                    await DeployNonZippedArtifact(appManager, "lib", "dir1/dir2/library3.jar", isAsync, null, "site/libs/dir1/dir2/library3.jar");
-                    await DeployNonZippedArtifact(appManager, "lib", "dir1/dir2/library4.jar", isAsync, null, "site/libs/dir1/dir2/library4.jar");
-
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "library1.jar", "library2.jar", "dir1" }, "site/libs");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library3.jar", "library4.jar" }, "site/libs/dir1/dir2");
-                }
-
-                // Clean deployment
-                {
-                    await DeployNonZippedArtifact(appManager, "lib", "dir/library.jar", isAsync, true, "site/libs/dir/library.jar");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir" }, "site/libs");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library.jar" }, "site/libs/dir");
-
-                    await DeployNonZippedArtifact(appManager, "lib", "library.jar", isAsync, true, "site/libs/library.jar");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library.jar" }, "site/libs");
-                }
-            });
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public Task TestScriptDeployment(bool isAsync)
-        {
-            return ApplicationManager.RunAsync("TestScriptDeployment", async appManager =>
-            {
-                var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
-
-                // Default deployment - incremental
-                {
-                    await DeployNonZippedArtifact(appManager, "script", "script1.txt", isAsync, null, "site/scripts/script1.txt");
-                    await DeployNonZippedArtifact(appManager, "script", "dir1/script2.txt", isAsync, null, "site/scripts/dir1/script2.txt");
-
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "dir1", "script1.txt" }, "site/scripts");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "script2.txt" }, "site/scripts/dir1");
-                }
-
-                // Clean deployment
-                {
-                    await DeployNonZippedArtifact(appManager, "script", "dir/script2.txt", isAsync, true, "site/scripts/dir/script2.txt");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir" }, "site/scripts");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "script2.txt" }, "site/scripts/dir");
-
-                    await DeployNonZippedArtifact(appManager, "script", "script2.txt", isAsync, true, "site/scripts/script2.txt");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "script2.txt" }, "site/scripts");
-                }
-            });
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
         public Task TestStaticFileDeployment(bool isAsync)
         {
             return ApplicationManager.RunAsync("TestStaticFileDeployment", async appManager =>
@@ -166,48 +104,15 @@ namespace Kudu.FunctionalTests
                 var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
 
                 // Default deployment - incremental
+                // Not testing clean deployments as clean=true is no longer support with type=static
                 {
-                    await DeployNonZippedArtifact(appManager, "static", "a.txt", isAsync, false, "site/wwwroot/a.txt");
-                    await DeployNonZippedArtifact(appManager, "static", "b.txt", isAsync, false, "site/wwwroot/b.txt");
-                    await DeployNonZippedArtifact(appManager, "static", "dir1/dir1a.txt", isAsync, false, "site/wwwroot/dir1/dir1a.txt");
-                    await DeployNonZippedArtifact(appManager, "static", "dir1/dir1b.txt", isAsync, false, "site/wwwroot/dir1/dir1b.txt");
+                    await DeployNonZippedArtifact(appManager, "static", "/home/site/wwwroot/a.txt", isAsync, false, "site/wwwroot/a.txt");
+                    await DeployNonZippedArtifact(appManager, "static", "/home/site/wwwroot/b.txt", isAsync, false, "site/wwwroot/b.txt");
+                    await DeployNonZippedArtifact(appManager, "static", "/home/site/wwwroot/dir1/dir1a.txt", isAsync, false, "site/wwwroot/dir1/dir1a.txt");
+                    await DeployNonZippedArtifact(appManager, "static", "/home/site/wwwroot/dir1/dir1b.txt", isAsync, false, "site/wwwroot/dir1/dir1b.txt");
 
                     await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "webapps", "a.txt", "b.txt", "dir1", "hostingstart.html" }, "site/wwwroot");
                     await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir1a.txt", "dir1b.txt" }, "site/wwwroot/dir1");
-                }
-
-                // Clean deployment
-                {
-                    await DeployNonZippedArtifact(appManager, "static", "dir2/dir2a.txt", isAsync, true, "site/wwwroot/dir2/dir2a.txt");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir2" }, "site/wwwroot");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir2a.txt" }, "site/wwwroot/dir2");
-
-                    await DeployNonZippedArtifact(appManager, "static", "c.txt", isAsync, true, "site/wwwroot/c.txt");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "c.txt",  }, "site/wwwroot");
-                }
-            });
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public Task TestStartupFileDeployment(bool isAsync)
-        {
-            return ApplicationManager.RunAsync("TestStartupFileDeployment", async appManager =>
-            {
-                var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
-                var startupFileName = KuduUtils.RunningAgainstLinuxKudu ? "startup.sh" : "startup.cmd";
-
-                // Default deployment mode - overwrite previous startup file
-                {
-                    await DeployNonZippedArtifact(appManager, "startup", "invalid/path/to/test/that/it/is/ignored", isAsync, true, $"site/scripts/{startupFileName}");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { startupFileName }, "site/scripts");
-                }
-
-                // Clean deployment
-                {
-                    await DeployNonZippedArtifact(appManager, "startup", "invalid/path/to/test/that/it/is/ignored", isAsync, true, $"site/scripts/{startupFileName}");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { startupFileName }, "site/scripts");
                 }
             });
         }
@@ -292,36 +197,6 @@ namespace Kudu.FunctionalTests
                     await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "war", "/home/site/wwwroot/webapps2/app", isAsync: false, isClean: false, expectedSuccess: false);
                     await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "war", "/home/site/wwwroot/", isAsync: false, isClean: false, expectedSuccess: false);
                 }
-
-                // lib - absolute paths
-                {
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "lib", "/home/site/libs/file.jar", isAsync: false, isClean: false, expectedSuccess: true);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "lib", "/home/site/libs/file.jar/", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "lib", "/home/site/libs/", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "lib", "/home/site/libs", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "lib", "/home/site/libsfile.jar", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "lib", "/home/site/lib2/file.jar", isAsync: false, isClean: false, expectedSuccess: false);
-                }
-
-                // script - absolute paths
-                {
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "script", "/home/site/scripts/file.bat", isAsync: false, isClean: false, expectedSuccess: true);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "script", "/home/site/scripts/file.bat/", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "script", "/home/site/scripts/", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "script", "/home/site/scripts", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "script", "/home/site/scriptsfile.bat", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "script", "/home/site/scripts2/file.bat", isAsync: false, isClean: false, expectedSuccess: false);
-                }
-
-                // Static - absolute paths
-                {
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "static", "/home/site/wwwroot/file.bat", isAsync: false, isClean: false, expectedSuccess: true);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "static", "/home/site/wwwroot/file.bat/", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "static", "/home/site/wwwroot/", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "static", "/home/site/wwwroot", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "static", "/home/site/wwwrootfile.bat", isAsync: false, isClean: false, expectedSuccess: false);
-                    await DeployZippedArtifact(appManager, appManager.OneDeployManager, files, "static", "/home/site/wwwroot2/file.bat", isAsync: false, isClean: false, expectedSuccess: false);
-                }
             });
         }
 
@@ -372,7 +247,7 @@ namespace Kudu.FunctionalTests
             return ApplicationManager.RunAsync("TestURLDeployment", async appManager =>
             {
                 var client = appManager.OneDeployManager.Client;
-                var requestUri = isArmRequest ? $"{client.BaseAddress}" : $"{client.BaseAddress}?type=static&restart=false&path=NOTICE.txt&async={isAsync}";
+                var requestUri = isArmRequest ? $"{client.BaseAddress}" : $"{client.BaseAddress}?type=static&restart=false&path=/home/site/wwwroot/NOTICE.txt&async={isAsync}";
                 using (var request = new HttpRequestMessage(HttpMethod.Put, requestUri))
                 {
                     var packageUri = "https://github.com/projectkudu/kudu/blob/master/NOTICE.txt?raw=true";
@@ -386,7 +261,7 @@ namespace Kudu.FunctionalTests
                                 packageUri = packageUri,
                                 type = "static",
                                 restart = false,
-                                path = "NOTICE.txt",
+                                path = "/home/site/wwwroot/NOTICE.txt",
                                 async = isAsync,
                                 ignorestack = "true",
                             }

--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -20,9 +20,8 @@ namespace Kudu.Services.Deployment
         private const string StackEnvVarName = "WEBSITE_STACK";
 
         // All paths are relative to HOME directory
-        public const string WwwrootDirectoryRelativePath = "site/wwwroot";
-        public const string ScriptsDirectoryRelativePath = "site/scripts";
-        public const string LibsDirectoryRelativePath = "site/libs";
+        public const string WwwrootDirectoryRelativePath = "site/wwwroot/";
+        public const string ScriptsDirectoryRelativePath = "site/scripts/";
 
         public static bool IsLegacyWarPathValid(string path)
         {
@@ -53,7 +52,7 @@ namespace Kudu.Services.Deployment
             return false;
         }
 
-        public static bool EnsureValidPath(ArtifactType artifactType, string designatedDirectoryRelativePath, ref string path, out string error)
+        public static bool EnsureValidPath(ArtifactType artifactType, ref string path, out string error, string designatedDirectoryRelativePath = "")
         {
             if (string.IsNullOrWhiteSpace(path))
             {
@@ -71,7 +70,7 @@ namespace Kudu.Services.Deployment
             // If specified path is absolute, make sure it points to the designated directory for the artifact type
             if (path.StartsWith("/", StringComparison.Ordinal))
             {
-                string designatedRootAbsolutePath = $"/home/{designatedDirectoryRelativePath}/";
+                string designatedRootAbsolutePath = $"/home/{designatedDirectoryRelativePath}";
 
                 if (!path.StartsWith($"{designatedRootAbsolutePath}", StringComparison.Ordinal))
                 {

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -256,7 +256,7 @@ namespace Kudu.Services.Deployment
                             // For legacy war deployments, the only path allowed is webapps/<directory-name>
                             //
 
-                            if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.WwwrootDirectoryRelativePath, ref path, out error))
+                            if (!OneDeployHelper.EnsureValidPath(artifactType, ref path, out error, OneDeployHelper.WwwrootDirectoryRelativePath))
                             {
                                 return StatusCode400(error);
                             }
@@ -301,38 +301,22 @@ namespace Kudu.Services.Deployment
                         deploymentInfo.TargetFileName = "app.ear";
                         break;
 
-                    case ArtifactType.Lib:
-                        if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.LibsDirectoryRelativePath, ref path, out error))
-                        {
-                            return StatusCode400(error);
-                        }
-
-                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.LibsDirectoryRelativePath);
-                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
-                        break;
-
                     case ArtifactType.Startup:
                         deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.ScriptsDirectoryRelativePath);
                         OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, OneDeployHelper.GetStartupFileName());
                         break;
 
-                    case ArtifactType.Script:
-                        if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.ScriptsDirectoryRelativePath, ref path, out error))
-                        {
-                            return StatusCode400(error);
-                        }
-
-                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.ScriptsDirectoryRelativePath);
-                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
-
-                        break;
-
                     case ArtifactType.Static:
-                        if (!OneDeployHelper.EnsureValidPath(artifactType, OneDeployHelper.WwwrootDirectoryRelativePath, ref path, out error))
+                        if (!OneDeployHelper.EnsureValidPath(artifactType, ref path, out error))
                         {
                             return StatusCode400(error);
                         }
+                        if (deploymentInfo.CleanupTargetDirectory)
+                        {
+                            return StatusCode400("Clean deployments cannot be performed for type=static");
+                        }
 
+                        deploymentInfo.TargetRootPath = _environment.RootPath;
                         OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
 
                         break;


### PR DESCRIPTION
Static files now can be deployed to any directory under /home. Static files cannot be deployed with type=clean to protect user from wiping the entire /home directory. Removing type=lib and type=script as they both just function the same way type=static does. 