### PR TITLE
Adding clean parameter to ZipDeploy endpoint

### DIFF
--- a/Kudu.Core.Test/Deployment/PushDeploymentControllerFacts.cs
+++ b/Kudu.Core.Test/Deployment/PushDeploymentControllerFacts.cs
@@ -79,12 +79,12 @@ namespace Kudu.Core.Test.Deployment
             };
 
             // Act
-            var response = await controller.ZipPushDeploy();
+            var response = await controller.ZipPushDeploy(clean: true);
 
             // Assert
             deploymentManager
                 .Verify(m => m.FetchDeploy(It.Is<ArtifactDeploymentInfo>(di =>
-                    !string.IsNullOrEmpty(di.ArtifactFileName) && !string.IsNullOrEmpty(di.SyncFunctionsTriggersPath)),
+                    !string.IsNullOrEmpty(di.ArtifactFileName) && !string.IsNullOrEmpty(di.SyncFunctionsTriggersPath) && di.CleanupTargetDirectory == true),
                     It.IsAny<bool>(),
                     It.IsAny<Uri>(),
                     It.IsAny<string>()

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -64,7 +64,8 @@ namespace Kudu.Services.Deployment
             [FromUri] string authorEmail = null,
             [FromUri] string deployer = Constants.ZipDeploy,
             [FromUri] string message = DefaultMessage,
-            [FromUri] bool trackDeploymentProgress = false)
+            [FromUri] bool trackDeploymentProgress = false,
+            [FromUri] bool? clean = null)
         {
             using (_tracer.Step("ZipPushDeploy"))
             {
@@ -84,7 +85,8 @@ namespace Kudu.Services.Deployment
                     DoFullBuildByDefault = false,
                     Author = author,
                     AuthorEmail = authorEmail,
-                    Message = message
+                    Message = message,
+                    CleanupTargetDirectory = clean.GetValueOrDefault(false)
                 };
 
                 string remotebuild = _settings.GetValue(SettingsKeys.DoBuildDuringDeployment);

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -97,8 +97,9 @@ namespace Kudu.Services.Deployment
                 if (_settings.RunFromLocalZip())
                 {
                     SetRunFromZipDeploymentInfo(deploymentInfo);
-                    }                }
-                deploymentInfo.DeploymentPath = GetZipDeployPathInfo();
+                }
+                deploymentInfo.DeploymentPath = GetZipDeployPathInfo(clean);
+
                 return await PushDeployAsync(deploymentInfo, isAsync);
             }
         }
@@ -850,7 +851,7 @@ namespace Kudu.Services.Deployment
             return correlationId;
         }
 
-        private string GetZipDeployPathInfo()
+        private string GetZipDeployPathInfo(bool clean)
         {
             string pathmsg;
             string remotebuild = _settings.GetValue(SettingsKeys.DoBuildDuringDeployment);
@@ -869,13 +870,14 @@ namespace Kudu.Services.Deployment
             }
             else
             {
+                var cleanTargetDirectory = clean ? "Clean Target" : string.Empty;
                 if (StringUtils.IsTrueLike(remotebuild))
                 {
-                    pathmsg = string.Concat(isfunction, "ZipDeploy. Extract zip. Remote build.");
+                    pathmsg = string.Concat(isfunction, $"ZipDeploy. Extract zip. Remote build. {cleanTargetDirectory}");
                 }
                 else
                 {
-                    pathmsg = string.Concat(isfunction, "ZipDeploy. Extract zip.");
+                    pathmsg = string.Concat(isfunction, $"ZipDeploy. Extract zip. {cleanTargetDirectory}");
                 }
             }
             _tracer.Trace("{0}", pathmsg);

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -65,7 +65,7 @@ namespace Kudu.Services.Deployment
             [FromUri] string deployer = Constants.ZipDeploy,
             [FromUri] string message = DefaultMessage,
             [FromUri] bool trackDeploymentProgress = false,
-            [FromUri] bool? clean = null)
+            [FromUri] bool clean = false)
         {
             using (_tracer.Step("ZipPushDeploy"))
             {
@@ -86,32 +86,33 @@ namespace Kudu.Services.Deployment
                     Author = author,
                     AuthorEmail = authorEmail,
                     Message = message,
-                    CleanupTargetDirectory = clean.GetValueOrDefault(false)
+                    CleanupTargetDirectory = clean
                 };
 
                 string remotebuild = _settings.GetValue(SettingsKeys.DoBuildDuringDeployment);
+                var cleanTargetDirectory = clean ? "Clean Target" : string.Empty;
                 if (_settings.RunFromLocalZip())
                 {
                     SetRunFromZipDeploymentInfo(deploymentInfo);
 
                     if (StringUtils.IsTrueLike(remotebuild))
                     {
-                        deploymentInfo.DeploymentPath = "ZipDeploy. Run from package. Ignore remote build.";
+                        deploymentInfo.DeploymentPath = $"ZipDeploy. Run from package. Ignore remote build. {cleanTargetDirectory}";
                     }
                     else
                     { 
-                        deploymentInfo.DeploymentPath = "ZipDeploy. Run from package."; 
+                        deploymentInfo.DeploymentPath = $"ZipDeploy. Run from package. {cleanTargetDirectory}"; 
                     }
                 }
                 else
                 {
                     if (StringUtils.IsTrueLike(remotebuild))
                     {
-                        deploymentInfo.DeploymentPath = "ZipDeploy. Extract zip. Remote build.";
+                        deploymentInfo.DeploymentPath = $"ZipDeploy. Extract zip. Remote build. {cleanTargetDirectory}";
                     }
                     else
                     {
-                        deploymentInfo.DeploymentPath = "ZipDeploy. Extract zip.";
+                        deploymentInfo.DeploymentPath = $"ZipDeploy. Extract zip. {cleanTargetDirectory}";
                     }
                 }
                 _tracer.Trace(deploymentInfo.DeploymentPath);


### PR DESCRIPTION
Adding clean parameter in ZipDeploy 

When clean=true
- The deployment ignores Previous Manifest file. 
- Cleans up the wwwroot file before copying new files in the folder. 