### PR TITLE
Adding clean parameter to ZipDeploy endpoint 

### DIFF
--- a/Kudu.Core.Test/Deployment/PushDeploymentControllerFacts.cs
+++ b/Kudu.Core.Test/Deployment/PushDeploymentControllerFacts.cs
@@ -79,12 +79,12 @@ namespace Kudu.Core.Test.Deployment
             };
 
             // Act
-            var response = await controller.ZipPushDeploy();
+            var response = await controller.ZipPushDeploy(clean: true);
 
             // Assert
             deploymentManager
                 .Verify(m => m.FetchDeploy(It.Is<ArtifactDeploymentInfo>(di =>
-                    !string.IsNullOrEmpty(di.ArtifactFileName) && !string.IsNullOrEmpty(di.SyncFunctionsTriggersPath)),
+                    !string.IsNullOrEmpty(di.ArtifactFileName) && !string.IsNullOrEmpty(di.SyncFunctionsTriggersPath) && di.CleanupTargetDirectory == true),
                     It.IsAny<bool>(),
                     It.IsAny<Uri>(),
                     It.IsAny<string>()


### PR DESCRIPTION
Adding clean parameter in ZipDeploy 

When clean=true
- The deployment ignores Previous Manifest file. 
- Cleans up the wwwroot file before copying new files in the folder. 