### PR TITLE
Add lib and script types back to OneDeploy

### DIFF
--- a/Kudu.FunctionalTests/OneDeployTests.cs
+++ b/Kudu.FunctionalTests/OneDeployTests.cs
@@ -97,6 +97,68 @@ namespace Kudu.FunctionalTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public Task TestLibDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestLibDeployment", async appManager =>
+            {
+                var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
+
+                // Default deployment - incremental
+                {
+                    await DeployNonZippedArtifact(appManager, "lib", "library1.jar", isAsync, null, "site/libs/library1.jar");
+                    await DeployNonZippedArtifact(appManager, "lib", "library2.jar", isAsync, null, "site/libs/library2.jar");
+                    await DeployNonZippedArtifact(appManager, "lib", "dir1/dir2/library3.jar", isAsync, null, "site/libs/dir1/dir2/library3.jar");
+                    await DeployNonZippedArtifact(appManager, "lib", "dir1/dir2/library4.jar", isAsync, null, "site/libs/dir1/dir2/library4.jar");
+
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "library1.jar", "library2.jar", "dir1" }, "site/libs");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library3.jar", "library4.jar" }, "site/libs/dir1/dir2");
+                }
+
+                // Clean deployment
+                {
+                    await DeployNonZippedArtifact(appManager, "lib", "dir/library.jar", isAsync, true, "site/libs/dir/library.jar");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir" }, "site/libs");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library.jar" }, "site/libs/dir");
+
+                    await DeployNonZippedArtifact(appManager, "lib", "library.jar", isAsync, true, "site/libs/library.jar");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "library.jar" }, "site/libs");
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public Task TestScriptDeployment(bool isAsync)
+        {
+            return ApplicationManager.RunAsync("TestScriptDeployment", async appManager =>
+            {
+                var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
+
+                // Default deployment - incremental
+                {
+                    await DeployNonZippedArtifact(appManager, "script", "script1.txt", isAsync, null, "site/scripts/script1.txt");
+                    await DeployNonZippedArtifact(appManager, "script", "dir1/script2.txt", isAsync, null, "site/scripts/dir1/script2.txt");
+
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "dir1", "script1.txt" }, "site/scripts");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "script2.txt" }, "site/scripts/dir1");
+                }
+
+                // Clean deployment
+                {
+                    await DeployNonZippedArtifact(appManager, "script", "dir/script2.txt", isAsync, true, "site/scripts/dir/script2.txt");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "dir" }, "site/scripts");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "script2.txt" }, "site/scripts/dir");
+
+                    await DeployNonZippedArtifact(appManager, "script", "script2.txt", isAsync, true, "site/scripts/script2.txt");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { "script2.txt" }, "site/scripts");
+                }
+            });
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public Task TestStaticFileDeployment(bool isAsync)
         {
             return ApplicationManager.RunAsync("TestStaticFileDeployment", async appManager =>

--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -22,6 +22,7 @@ namespace Kudu.Services.Deployment
         // All paths are relative to HOME directory
         public const string WwwrootDirectoryRelativePath = "site/wwwroot/";
         public const string ScriptsDirectoryRelativePath = "site/scripts/";
+        public const string LibsDirectoryRelativePath = "site/libs/";
 
         public static bool IsLegacyWarPathValid(string path)
         {

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -303,9 +303,30 @@ namespace Kudu.Services.Deployment
                         deploymentInfo.TargetFileName = "app.ear";
                         break;
 
+                    case ArtifactType.Lib:
+                        if (!OneDeployHelper.EnsureValidPath(artifactType, ref path, out error, OneDeployHelper.LibsDirectoryRelativePath))
+                        {
+                            return StatusCode400(error);
+                        }
+
+                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.LibsDirectoryRelativePath);
+                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
+                        break;
+
                     case ArtifactType.Startup:
                         deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.ScriptsDirectoryRelativePath);
                         OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, OneDeployHelper.GetStartupFileName());
+                        break;
+
+                    case ArtifactType.Script:
+                        if (!OneDeployHelper.EnsureValidPath(artifactType, ref path, out error, OneDeployHelper.ScriptsDirectoryRelativePath))
+                        {
+                            return StatusCode400(error);
+                        }
+
+                        deploymentInfo.TargetRootPath = OneDeployHelper.GetAbsolutePath(_environment, OneDeployHelper.ScriptsDirectoryRelativePath);
+                        OneDeployHelper.SetTargetSubDirectoyAndFileNameFromRelativePath(deploymentInfo, path);
+
                         break;
 
                     case ArtifactType.Static:


### PR DESCRIPTION
Add type=lib and type=script back to OneDeploy to keep consistency with KuduLite