### PR TITLE
add tracing for CopyDirectoryRecursive

### DIFF
--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -139,6 +139,12 @@ namespace Kudu.Core.Settings
             get { return GetValue("UseLatestMSBuild16InsteadOfMSBuild15", "0") == "1"; }
         }
 
+        public static bool DataCopyingTelemetryEnabled
+        {
+            // this is disabled by default
+            get { return GetValue("DataCopyingTelemetryEnabled", "0") != "0"; }
+        }
+
         public static string GetValue(string key, string defaultValue = null)
         {
             var env = System.Environment.GetEnvironmentVariable($"SCM_{key}");


### PR DESCRIPTION
Adds tracing to Kusto for number of directories created, files copied, and bytes copied during recursive directory copying. Ultimately, we would like to change the copying process so it doesn't naively copy every single file to the temp directory - it will only copy the modified/added files (essentially the diff in directories.) This data will give us insight into the amount of data being written.