### PR TITLE
Backup stream for deployment retry and check disk space in validation

### DIFF
--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -116,6 +116,12 @@ namespace Kudu.Core.Settings
             get { return GetValue("UseHttpCompletionOptionResponseHeadersRead", "1") != "0"; }
         }
 
+        public static int DeploymentBackupMemoryKBytes
+        {
+            // this is disabled by default
+            get { return int.TryParse(GetValue("DeploymentBackupMemoryKBytes", "0"), out int value) ? value : 0; }
+        }
+
         public static IPAddress ILBVip
         {
             get { return IPAddress.TryParse(GetValue(SettingsKeys.ILBVip), out var address) ? address : null; }

--- a/Kudu.Services/ByteRanges/HttpRequestMessageExtensions.cs
+++ b/Kudu.Services/ByteRanges/HttpRequestMessageExtensions.cs
@@ -72,23 +72,72 @@ namespace Kudu.Services.ByteRanges
             return total;
         }
 
-        public static async Task<long> CopyToAsync(this HttpContent content, string filePath, ITracer tracer, bool leaveOpen = false)
+        public static async Task<long> CopyToAsync(this HttpContent content, string filePath, ITracer tracer, MemoryStream backupStream)
         {
             var nextTraceTime = DateTime.UtcNow.AddSeconds(30);
             long total = 0;
             var buffer = new byte[ScmHostingConfigurations.StreamCopyBufferSize];
-            var src = await content.ReadAsStreamAsync();
-            try
+            using (var src = await content.ReadAsStreamAsync())
+            using (var dst = FileSystemHelpers.CreateFile(filePath))
             {
-                if (src.CanSeek)
+                while (true)
                 {
-                    src.Seek(0, SeekOrigin.Begin);
+                    int read = await src.ReadAsync(buffer, 0, buffer.Length);
+                    if (read <= 0)
+                    {
+                        tracer.Trace("Total {0:n0} bytes written to {1}", total, filePath);
+                        break;
+                    }
+                    else if (DateTime.UtcNow > nextTraceTime)
+                    {
+                        tracer.Trace("Writing {0:n0} bytes to {1}", total, filePath);
+                        nextTraceTime = DateTime.UtcNow.AddSeconds(30);
+                    }
+
+                    await dst.WriteAsync(buffer, 0, read);
+                    total += read;
                 }
-                using (var dst = FileSystemHelpers.CreateFile(filePath))
+
+                //backupStream is for copy retry
+                try
                 {
+                    if (src.CanSeek)
+                    {
+                        src.Seek(0, SeekOrigin.Begin);
+                        long limit = ScmHostingConfigurations.DeploymentBackupMemoryKBytes;
+                        tracer.Trace("DeploymentBackupMemoryKBytes: {0} KB", limit);
+                        if (total < (limit * 1_024))
+                        {
+                            tracer.Trace("backupStream start");
+                            await src.CopyToAsync(backupStream);
+                            backupStream.Seek(0, SeekOrigin.Begin);
+                            tracer.Trace("backupStream successful");
+                        }                        
+                    }                    
+                }
+                catch (Exception ex)
+                {
+                    tracer.Trace("backupStream failed: {0}", ex.Message);
+                }                
+            }
+
+            return total;
+        }
+
+        public static async Task<long> CopyFromBackupAsync(this HttpContent content, string filePath, ITracer tracer, MemoryStream backupStream)
+        {
+            tracer.Trace("Starting CopyFromBackupAsync");
+            var nextTraceTime = DateTime.UtcNow.AddSeconds(30);
+            long total = 0;
+            var buffer = new byte[ScmHostingConfigurations.StreamCopyBufferSize];
+            using (var dst = FileSystemHelpers.CreateFile(filePath))
+            {
+                if (backupStream != null)
+                {
+                    backupStream.Seek(0, SeekOrigin.Begin);
                     while (true)
                     {
-                        int read = await src.ReadAsync(buffer, 0, buffer.Length);
+                        int read = await backupStream.ReadAsync(buffer, 0, buffer.Length);
                         if (read <= 0)
                         {
                             tracer.Trace("Total {0:n0} bytes written to {1}", total, filePath);
@@ -103,17 +152,10 @@ namespace Kudu.Services.ByteRanges
                         await dst.WriteAsync(buffer, 0, read);
                         total += read;
                     }
-                }
+                }                
+            }
 
-                return total;
-            }
-            finally
-            {
-                if (!leaveOpen)
-                {
-                    src.Dispose();
-                }
-            }
+            return total;
         }
     }
 }


### PR DESCRIPTION
1. Storing backup MemoryStream to copy zip again. This is needed for async deployments.
2. Checking local disk space in validation API. 

Use this link to compare all changes together (this PR + my last merged PR): 
https://github.com/projectkudu/kudu/compare/ed6e9c4..3fe359d