### PR TITLE
Properly populate ARM return object

### DIFF
--- a/Kudu.Contracts/Deployment/IFetchDeploymentManager.cs
+++ b/Kudu.Contracts/Deployment/IFetchDeploymentManager.cs
@@ -10,5 +10,7 @@ namespace Kudu.Core.Deployment
             bool asyncRequested,
             Uri requestUri,
             string targetBranch);
+
+        DeployResult GetDeployResult();
     }
 }

--- a/Kudu.Core/Deployment/DeploymentManager.cs
+++ b/Kudu.Core/Deployment/DeploymentManager.cs
@@ -604,7 +604,7 @@ namespace Kudu.Core.Deployment
             }
         }
 
-        private DeployResult GetResult(string id, string activeDeploymentId, bool isDeploying)
+        public DeployResult GetResult(string id, string activeDeploymentId, bool isDeploying)
         {
             var file = VerifyDeployment(id, isDeploying);
 

--- a/Kudu.Core/Deployment/FetchDeploymentManager.cs
+++ b/Kudu.Core/Deployment/FetchDeploymentManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Kudu.Contracts.Infrastructure;
@@ -327,6 +328,11 @@ namespace Kudu.Core.Deployment
             }
 
             return true;
+        }
+
+        public DeployResult GetDeployResult()
+        {
+            return _deploymentManager.GetResults().First();
         }
 
         // key goal is to create background tracer that is independent of request.


### PR DESCRIPTION
Ensure ARM requests to OneDeploy are returned with properly populated DeployResult object and Deployment ID.