### PR TITLE
Honor app setting artifact names in OneDeploy

### DIFF
--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace Kudu.Services.Deployment
 {
@@ -18,6 +17,8 @@ namespace Kudu.Services.Deployment
         public const string JBossEap = "JBOSSEAP";
 
         private const string StackEnvVarName = "WEBSITE_STACK";
+        private const string JarNameAppSetting = "WEBSITE_JAVA_JAR_FILE_NAME";
+        private const string WarNameAppSetting = "WEBSITE_JAVA_WAR_FILE_NAME";
 
         // All paths are relative to HOME directory
         public const string WwwrootDirectoryRelativePath = "site/wwwroot";
@@ -132,6 +133,36 @@ namespace Kudu.Services.Deployment
 
             error = null;
             return true;
+        }
+
+        public static string GetArtifactNameFromAppSetting(ArtifactType artifactType)
+        {
+            // App Settings are read from EnvVars with the prefix APPSETTING_
+            //string appSettingsPrefix = "APPSETTING_";
+            string appSettingArtifactName = null;
+            switch (artifactType)
+            {
+                case ArtifactType.War:
+                    appSettingArtifactName = System.Environment.GetEnvironmentVariable(WarNameAppSetting);
+                    if(String.IsNullOrEmpty(appSettingArtifactName))
+                    {
+                        // Default of app.war if WEBSITE_JAVA_WAR_FILE_NAME is not defined by user
+                        return "app.war";
+                    }
+
+                    break;
+                case ArtifactType.Jar:
+                    appSettingArtifactName = System.Environment.GetEnvironmentVariable(JarNameAppSetting);
+                    if (String.IsNullOrEmpty(appSettingArtifactName))
+                    {
+                        // Default of app.war if WEBSITE_JAVA_JAR_FILE_NAME is not defined by user
+                        return "app.jar";
+                    }
+
+                    break;
+            }
+
+            return appSettingArtifactName;
         }
 
         public static string GetWebsiteStack()

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -248,10 +248,14 @@ namespace Kudu.Services.Deployment
                 string error;
                 bool deployToRoot;
 
+                // The name of WAR and JAR files can be defined with the WEBSITE_JAVA_WAR_FILE_NAME and
+                // WEBSITE_JAVA_JAR_FILE_NAME app settings respectively
+                string appSettingArtifactName = OneDeployHelper.GetArtifactNameFromAppSetting(artifactType);
+
                 switch (artifactType)
                 {
                     case ArtifactType.War:
-                        if (!OneDeployHelper.EnsureValidStack(artifactType, new List<string> { OneDeployHelper.Tomcat, OneDeployHelper.JBossEap }, ignoreStack, out error))
+                        if (!OneDeployHelper.EnsureValidStack(artifactType, new List<string> { OneDeployHelper.Tomcat, OneDeployHelper.JBossEap, OneDeployHelper.JavaSE }, ignoreStack, out error))
                         {
                             return StatusCode400(error);
                         }
@@ -285,7 +289,7 @@ namespace Kudu.Services.Deployment
                         else
                         {
                             // For type=war, if no path is specified, the target file is app.war
-                            deploymentInfo.TargetFileName = "app.war";
+                            deploymentInfo.TargetFileName = OneDeployHelper.GetArtifactNameFromAppSetting(artifactType);
                         }
 
                         break;
@@ -296,7 +300,7 @@ namespace Kudu.Services.Deployment
                             return StatusCode400(error);
                         }
 
-                        deploymentInfo.TargetFileName = "app.jar";
+                        deploymentInfo.TargetFileName = OneDeployHelper.GetArtifactNameFromAppSetting(artifactType);
                         break;
 
                     case ArtifactType.Ear:
@@ -360,6 +364,7 @@ namespace Kudu.Services.Deployment
                         {
                             SetRunFromZipDeploymentInfo(deploymentInfo);
                         }
+
                         else
                         {
                             deploymentInfo.TargetSubDirectoryRelativePath = path;


### PR DESCRIPTION
If the `WEBSITE_JAVA_JAR_FILE_NAME` app setting is defined, type=jar deployments will use the file name specified in `WEBSITE_JAVA_JAR_FILE_NAME`. Otherwise OneDeploy will default to app.jar

If the `WEBSITE_JAVA_WAR_FILE_NAME` app setting is defined, type=war deployments will use the file name specified in `WEBSITE_JAVA_WAR_FILE_NAME`. Otherwise OneDeploy will default to app.war

War files can now be deployed to JavaSE site