### PR TITLE
Support non-root context in OneDeploy

### DIFF
--- a/Kudu.FunctionalTests/OneDeployTests.cs
+++ b/Kudu.FunctionalTests/OneDeployTests.cs
@@ -33,7 +33,9 @@ namespace Kudu.FunctionalTests
                 // Default deployment mode - overwrite app.war
                 {
                     await DeployNonZippedArtifact(appManager, "war", null, isAsync, null, "site/wwwroot/app.war");
-                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "webapps", "hostingstart.html", "app.war" }, "site/wwwroot");
+                    await DeployNonZippedArtifact(appManager, "war", "test.war", isAsync, null, "site/wwwroot/test.war");
+                    await DeployNonZippedArtifact(appManager, "war", "/home/site/wwwroot/nonroot.war", isAsync, null, "site/wwwroot/nonroot.war");
+                    await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, new string[] { initialFileName, "webapps", "hostingstart.html", "app.war", "test.war", "nonroot.war"}, "site/wwwroot");
                 }
 
                 // Clean deployment

--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Kudu.Services.Deployment
 {
@@ -117,6 +118,7 @@ namespace Kudu.Services.Deployment
                 if (path.StartsWith(keyWord))
                 {
                     path = path.Substring(keyWord.Length);
+
                     // If absolute path points to wwwroot set path relative to wwwroot
                     if (path.StartsWith(WwwrootDirectoryRelativePath, StringComparison.OrdinalIgnoreCase))
                     {
@@ -132,6 +134,27 @@ namespace Kudu.Services.Deployment
 
             error = null;
             return true;
+        }
+
+        public static string CustomWarName(string path)
+        {
+            string designatedRootAbsolutePath = $"/home/{WwwrootDirectoryRelativePath}/";
+
+            // Only matches files names (i.e app.war, anyname.war)
+            // Will not match relative paths (webapps/app.war, webapps/ROOT)
+            string warPattern = @"^[\w-]+\.war$";
+
+            if (Regex.IsMatch(path, warPattern))
+            {
+                return path;
+            }
+
+            else if (path.Contains(designatedRootAbsolutePath) && Regex.IsMatch(path.Substring(designatedRootAbsolutePath.Length + 1), warPattern))
+            {
+                return path.Substring(designatedRootAbsolutePath.Length + 1);
+            }
+
+            return null;
         }
 
         public static string GetWebsiteStack()


### PR DESCRIPTION
ROOT
`az webapp deploy --resource-group ${resourceGroup} --name ${webAppName} --src-path  **/*.war --type war`
`az webapp deploy --resource-group ${resourceGroup} --name ${webAppName} --target-path "C:\site\wwwroot\root.war" --src-path  **/*.war --type war`
`az webapp deploy --resource-group ${resourceGroup} --name ${webAppName} --target-path "C:\site\wwwroot\app.war" --src-path  **/*.war --type war`

NON-ROOT
`az webapp deploy --resource-group ${resourceGroup} --name ${webAppName} --target-path "C:\site\wwwroot\cpt.war" --src-path  **/*.war --type war`
`az webapp deploy --resource-group ${resourceGroup} --name ${webAppName} --target-path "cpt.war" --src-path  **/*.war --type war`
