### PR TITLE
Fix issue delete site extension by name

### DIFF
--- a/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManager.cs
@@ -703,13 +703,13 @@ namespace Kudu.Core.SiteExtensions
         {
             ITracer tracer = _traceFactory.GetTracer();
 
-            string installationDirectory = GetInstallationDirectory(id);
-
             SiteExtensionInfo info = await GetLocalExtension(id, checkLatest: false);
 
-            if (info == null || !FileSystemHelpers.DirectoryExists(info.LocalPath))
+            string installationDirectory = GetInstallationDirectory(info.Id);
+
+            if (info == null || !FileSystemHelpers.DirectoryExists(info.LocalPath) || installationDirectory == null)
             {
-                tracer.TraceError("Site extension {0} not found.", id);
+                tracer.TraceError("Site extension {0} not found during uninstall.", id);
                 throw new DirectoryNotFoundException(installationDirectory);
             }
 

--- a/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
+++ b/Kudu.Core/SiteExtensions/SiteExtensionManagerV2.cs
@@ -610,13 +610,13 @@ namespace Kudu.Core.SiteExtensions
         {
             ITracer tracer = _traceFactory.GetTracer();
 
-            string installationDirectory = GetInstallationDirectory(id);
-
             SiteExtensionInfo info = await GetLocalExtension(id, checkLatest: false);
 
-            if (info == null || !FileSystemHelpers.DirectoryExists(info.LocalPath))
+            string installationDirectory = GetInstallationDirectory(info.Id);
+
+            if (info == null || !FileSystemHelpers.DirectoryExists(info.LocalPath) || installationDirectory == null)
             {
-                tracer.TraceError("Site extension {0} not found.", id);
+                tracer.TraceError("Site extension {0} not found during uninstall.", id);
                 throw new DirectoryNotFoundException(String.Format(CultureInfo.CurrentCulture, Resources.Error_SiteExtensionNotFound, id, installationDirectory));
             }
 


### PR DESCRIPTION
When cx run the [Delete Site Extension API](https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/delete-site-extension ) by providing the site extension name as `siteExtensionId`, there could be chance that for some thrid-parties site extension their name and id are different, which cause the [Delete Site Extension API](https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/delete-site-extension ) to fail. 
Update the code logics so that customer can run [Delete Site Extension API](https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/delete-site-extension) by providing site extension name or site extension id as value of `siteExtensionId`. 

Update for both v1 and v2. 

Tested private build of both happy and sad path, works as expect. 