### PR TITLE
Add reset to OneDeploy

### DIFF
--- a/Kudu.Client/Deployment/RemotePushDeploymentManager.cs
+++ b/Kudu.Client/Deployment/RemotePushDeploymentManager.cs
@@ -60,7 +60,11 @@ namespace Kudu.Client.Deployment
                 }
 
                 request.Method = HttpMethod.Post;
-                request.Content = new StreamContent(zipFile);
+                if (zipFile != null)
+                {
+                    request.Content = new StreamContent(zipFile);
+                }
+
                 return await Client.SendAsync(request);
             }
         }


### PR DESCRIPTION
## Overview 
Adding a new feature to OneDeploy that will allow users to revert their Java applications to the default parking page if a previous deployment put the app into a bad state. This will be much quicker than recreating the webapp or manually deleting all files.

## Usage 
`curl -X POST -k -u [username] "https://[site-name].scm.azurewebsites.net/api/publish?reset=true"`