### PR TITLE
Add safe directory config to `.gitconfig` on startup

### DIFF
--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -145,6 +145,12 @@ namespace Kudu.Core.Settings
             get { return GetValue("DataCopyingTelemetryEnabled", "0") != "0"; }
         }
 
+        public static bool EnsureGitSafeDirectoryEnabled
+        {
+            // this is disabled by default
+            get { return GetValue("EnsureGitSafeDirectoryEnabled", "0") == "1"; }
+        }
+
         // SiteTokenIssuingMode
         // 0: (default) add both x-ms-site-restricted-token and x-ms-site-token
         // 1: add x-ms-site-restricted-token only


### PR DESCRIPTION
The latest windows-git throws this error:
`fatal: detected dubious ownership in repository at xyz/abc`

We need to run ` git config --global --add safe.directory *` to suppress this error

Instead of running command using git.exe, we can edit the `.gitconfig` file to append this section
```
[safe]
    directory = "*"
```
Also, to prevent this step on every start, we can keep a marker file to know the status of config