### PR TITLE
Fix OneDeploy --clean option for type zip

### DIFF
--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -375,7 +375,7 @@ namespace Kudu.Services.Deployment
                         }
                         else
                         {
-                            deploymentInfo.TargetSubDirectoryRelativePath = path;
+                            deploymentInfo.TargetRootPath = path;
                             // Deployments for type=zip default to clean=true
                             deploymentInfo.CleanupTargetDirectory = clean.GetValueOrDefault(true);
                         }


### PR DESCRIPTION
Fixing issue where --clean option would not work for type=zip. 