### PR TITLE
Fix TestZipDeployment

### DIFF
--- a/Kudu.FunctionalTests/OneDeployTests.cs
+++ b/Kudu.FunctionalTests/OneDeployTests.cs
@@ -224,7 +224,7 @@ namespace Kudu.FunctionalTests
                     await DeploymentTestHelper.AssertSuccessfulDeploymentByFilenames(appManager, expectedFiles1.ToArray(), "site/wwwroot");
                 }
 
-                // Custom path
+                // Custom path - clean
                 {
                     var initialFileName = DeploymentTestHelper.DeployRandomFilesEverywhere(appManager);
 

--- a/Kudu.Services/Deployment/OneDeployHelper.cs
+++ b/Kudu.Services/Deployment/OneDeployHelper.cs
@@ -94,6 +94,31 @@ namespace Kudu.Services.Deployment
             return true;
         }
 
+        public static bool IsDeployToRoot(ref string path)
+        {
+            string[] rootPathKeyWords = { "home/", "%home%/", "$home/", "/home/", "/%home%/", "/$home/" };
+            // Path is absolute iif it begins with one of the rootPathKeyWords
+            foreach (string keyWord in rootPathKeyWords)
+            {
+                if (path.StartsWith(keyWord))
+                {
+                    path = path.Substring(keyWord.Length);
+
+                    // If absolute path points to wwwroot set path relative to wwwroot
+                    if (path.StartsWith(WwwrootDirectoryRelativePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        path = path.Substring(WwwrootDirectoryRelativePath.Length);
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                    break;
+                }
+            }
+            return false;
+        }
+
         public static bool EnsureValidStaticPath(ref string path, out string error, out bool deployToRoot)
         {
             string[] rootPathKeyWords = { "home/", "%home%/", "$home/", "/home/", "/%home%/", "/$home/" };
@@ -112,25 +137,7 @@ namespace Kudu.Services.Deployment
                 return false;
             }
 
-            // Path is absolute iif it begins with one of the rootPathKeyWords
-            foreach (string keyWord in rootPathKeyWords)
-            {
-                if (path.StartsWith(keyWord))
-                {
-                    path = path.Substring(keyWord.Length);
-
-                    // If absolute path points to wwwroot set path relative to wwwroot
-                    if (path.StartsWith(WwwrootDirectoryRelativePath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        path = path.Substring(WwwrootDirectoryRelativePath.Length);
-                    }
-                    else
-                    {
-                        deployToRoot = true;
-                    }
-                    break;
-                }
-            }
+            deployToRoot = IsDeployToRoot(ref path);
 
             error = null;
             return true;

--- a/Kudu.Services/Deployment/PushDeploymentController.cs
+++ b/Kudu.Services/Deployment/PushDeploymentController.cs
@@ -372,13 +372,28 @@ namespace Kudu.Services.Deployment
                         if (_settings.RunFromLocalZip())
                         {
                             SetRunFromZipDeploymentInfo(deploymentInfo);
+                            break;
                         }
-                        else
+
+                        if (!string.IsNullOrEmpty(path))
                         {
-                            deploymentInfo.TargetRootPath = path;
-                            // Deployments for type=zip default to clean=true
-                            deploymentInfo.CleanupTargetDirectory = clean.GetValueOrDefault(true);
+                            deployToRoot = OneDeployHelper.IsDeployToRoot(ref path);
+                            if (deployToRoot)
+                            {
+                                if (deploymentInfo.CleanupTargetDirectory)
+                                {
+                                    return StatusCode400("Clean deployments cannot be performed outside of wwwroot");
+                                }
+
+                                deploymentInfo.TargetRootPath = _environment.RootPath;
+                            }
+
+                            deploymentInfo.TargetSubDirectoryRelativePath = path;
                         }
+
+                        //deploymentInfo.TargetRootPath = path;
+                        // Deployments for type=zip default to clean=true
+                        deploymentInfo.CleanupTargetDirectory = clean.GetValueOrDefault(true);
 
                         break;
 


### PR DESCRIPTION
Previous PR did not account for clean zip deployments with paths multiple levels deep relative to wwwroot. For example, performing a clean zip deployment to wwwroot/a/b/ would fail. Refactored logic to account for this. 

All tests passing now:
![image](https://github.com/projectkudu/kudu/assets/38927254/87075065-1c9a-4cab-a389-ec33f80cbc47)
