### PR TITLE
Enable EnsureGitSafeDirectoryEnabled flag by default

### DIFF
--- a/Kudu.Core/Settings/ScmHostingConfigurations.cs
+++ b/Kudu.Core/Settings/ScmHostingConfigurations.cs
@@ -147,8 +147,8 @@ namespace Kudu.Core.Settings
 
         public static bool EnsureGitSafeDirectoryEnabled
         {
-            // this is disabled by default
-            get { return GetValue("EnsureGitSafeDirectoryEnabled", "0") == "1"; }
+            // this is enabled by default
+            get { return GetValue("EnsureGitSafeDirectoryEnabled", "1") != "0"; }
         }
 
         // SiteTokenIssuingMode


### PR DESCRIPTION
Enabling EnsureGitSafeDirectoryEnabled ScmHostingConfig flag by default
Required for this fix: https://github.com/projectkudu/kudu/pull/3465