### PR TITLE
Refactor logic for zip and static clean deployments 

### DIFF
--- a/Kudu.FunctionalTests/DeploymentTestHelper.cs
+++ b/Kudu.FunctionalTests/DeploymentTestHelper.cs
@@ -114,6 +114,8 @@ namespace Kudu.FunctionalTests
             appManager.VfsManager.WriteAllText($"site/wwwroot/webapps/{testFile.Filename}", testFile.Content);
             appManager.VfsManager.WriteAllText($"site/wwwroot/webapps/ROOT/{testFile.Filename}", testFile.Content);
             appManager.VfsManager.WriteAllText($"site/wwwroot/webapps/ROOT2/{testFile.Filename}", testFile.Content);
+            appManager.VfsManager.WriteAllText($"site/test/{testFile.Filename}", testFile.Content);
+            appManager.VfsManager.WriteAllText($"site/test/test2/{testFile.Filename}", testFile.Content);
 
             return testFile.Content;
         }


### PR DESCRIPTION
Refactoring logic to simplify the code behind clean deployments. This change will also enable a couple of scenarios that were previously not allowed.

![image](https://github.com/projectkudu/kudu/assets/38927254/6f1100db-531b-473b-a1be-d748cc299b90)
