### PR TITLE
Maximum length of Query String increased to 8192

### DIFF
--- a/Kudu.Services.Web/Web.config
+++ b/Kudu.Services.Web/Web.config
@@ -71,7 +71,7 @@
   <system.webServer>
     <security>
       <requestFiltering allowDoubleEscaping="true">
-        <requestLimits maxAllowedContentLength="4294967295" />
+        <requestLimits maxAllowedContentLength="4294967295" maxQueryString="8192" />
         <fileExtensions allowUnlisted="true">
           <remove fileExtension=".asa" />
           <remove fileExtension=".asax" />


### PR DESCRIPTION
@suwatch  When deploying from GitHub using `azure/webapps-deploy@v3`, if the commit message is long and contains multibyte strings, it will get stuck in the query string length limit and cause an error, so Kudu will relax the limit to handle this.

Since this problem does not occur with the Linux App Service, but only with the Windows App Service, the idea is to adapt to the Linux behavior.

https://github.com/Azure/webapps-deploy/issues/336